### PR TITLE
Implement new MotorAxis module

### DIFF
--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -428,6 +428,25 @@ When using multiple stepper motors, they can be set to different values to avoid
 
 The optional acceleration argument defaults to 0, which starts and stops pulsing immediately.
 
+## Motor Axis
+
+The motor axis module wraps a stepper motor and two limit switches.
+It prevents the motor from moving past the limits.
+But in contrast to a simple Lizard rule, it allows to actively move out of the limits when moving in the right direction.
+
+| Constructor                               | Description                    | Arguments |
+| ----------------------------------------- | ------------------------------ | --------- |
+| `axis = MotorAxis(motor, limit1, limit2)` | StepperMotor and Input modules | 3 modules |
+
+Currently the motor axis module has no properties.
+To get the current position or speed, access the StepperMotor module instead.
+
+| Methods                                           | Description              | Arguments  |
+| ------------------------------------------------- | ------------------------ | ---------- |
+| `motor.speed(speed[, acceleration])`              | Move with given `speed`  | 2x `float` |
+| `motor.position(position, speed[, acceleration])` | Move to given `position` | 3x `float` |
+| `motor.stop()`                                    | Stop                     |            |
+
 ## CanOpenMaster
 
 The CanOpenMaster module sends periodic SYNC messages to all CANopen nodes. At creation, no messages are sent until `sync_interval` is set to a value greater than 0.

--- a/main/modules/input.h
+++ b/main/modules/input.h
@@ -9,7 +9,6 @@ using Input_ptr = std::shared_ptr<Input>;
 
 class Input : public Module {
 private:
-    virtual bool get_level() const = 0;
     virtual void set_pull_mode(const gpio_pull_mode_t mode) const = 0;
 
 protected:
@@ -19,25 +18,26 @@ public:
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     std::string get_output() const override;
+    virtual bool get_level() const = 0;
 };
 
 class GpioInput : public Input {
 private:
     const gpio_num_t number;
-    bool get_level() const override;
     void set_pull_mode(const gpio_pull_mode_t mode) const override;
 
 public:
     GpioInput(const std::string name, const gpio_num_t number);
+    bool get_level() const override;
 };
 
 class McpInput : public Input {
 private:
     const Mcp23017_ptr mcp;
     const uint8_t number;
-    bool get_level() const override;
     void set_pull_mode(const gpio_pull_mode_t mode) const override;
 
 public:
     McpInput(const std::string name, const Mcp23017_ptr mcp, const uint8_t number);
+    bool get_level() const override;
 };

--- a/main/modules/input.h
+++ b/main/modules/input.h
@@ -4,6 +4,9 @@
 #include "mcp23017.h"
 #include "module.h"
 
+class Input;
+using Input_ptr = std::shared_ptr<Input>;
+
 class Input : public Module {
 private:
     virtual bool get_level() const = 0;

--- a/main/modules/module.cpp
+++ b/main/modules/module.cpp
@@ -13,6 +13,7 @@
 #include "input.h"
 #include "linear_motor.h"
 #include "mcp23017.h"
+#include "motor_axis.h"
 #include "odrive_motor.h"
 #include "odrive_wheels.h"
 #include "output.h"
@@ -46,7 +47,7 @@ template <typename M>
 static std::shared_ptr<M> get_module_paramter(const ConstExpression_ptr &arg, ModuleType type, const std::string &type_name) {
     const std::string name = arg->evaluate_identifier();
     Module_ptr module = Global::get_module(name);
-    if (module->type != type) {
+    if (module->type != type && module->type != proxy) {
         throw std::runtime_error("module \"" + name + "\" is no " + type_name);
     }
 
@@ -253,6 +254,12 @@ Module_ptr Module::create(const std::string type,
         ledc_timer_t ledc_timer = arguments.size() > 4 ? (ledc_timer_t)arguments[4]->evaluate_integer() : LEDC_TIMER_0;
         ledc_channel_t ledc_channel = arguments.size() > 5 ? (ledc_channel_t)arguments[5]->evaluate_integer() : LEDC_CHANNEL_0;
         return std::make_shared<StepperMotor>(name, step_pin, dir_pin, pcnt_unit, pcnt_channel, ledc_timer, ledc_channel);
+    } else if (type == "MotorAxis") {
+        Module::expect(arguments, 3, identifier, identifier, identifier);
+        const StepperMotor_ptr motor = get_module_paramter<StepperMotor>(arguments[0], stepper_motor, "stepper motor");
+        const Input_ptr input1 = get_module_paramter<Input>(arguments[1], input, "input");
+        const Input_ptr input2 = get_module_paramter<Input>(arguments[2], input, "input");
+        return std::make_shared<MotorAxis>(name, motor, input1, input2);
     } else if (type == "CanOpenMotor") {
         Module::expect(arguments, 2, identifier, integer);
         const Can_ptr can_module = get_module_paramter<Can>(arguments[0], can, "can connection");

--- a/main/modules/module.h
+++ b/main/modules/module.h
@@ -25,6 +25,7 @@ enum ModuleType {
     roboclaw_motor,
     roboclaw_wheels,
     stepper_motor,
+    motor_axis,
     canopen_motor,
     canopen_master,
     proxy,

--- a/main/modules/motor_axis.cpp
+++ b/main/modules/motor_axis.cpp
@@ -4,10 +4,34 @@ MotorAxis::MotorAxis(const std::string name, const StepperMotor_ptr motor, const
     : Module(motor_axis, name), motor(motor), input1(input1), input2(input2) {
 }
 
+void MotorAxis::step() {
+    if (this->motor->get_target_speed() < 0 && this->input1->get_level()) {
+        this->motor->stop();
+    } else if (this->motor->get_target_speed() > 0 && this->input2->get_level()) {
+        this->motor->stop();
+    }
+    Module::step();
+}
+
 void MotorAxis::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
-    if (method_name == "reference") {
+    if (method_name == "position") {
+        if (arguments.size() < 2 || arguments.size() > 3) {
+            throw std::runtime_error("unexpected number of arguments");
+        }
+        Module::expect(arguments, -1, numbery, numbery, numbery);
+        this->motor->position(arguments[0]->evaluate_number(),
+                              arguments[1]->evaluate_number(),
+                              arguments.size() > 2 ? std::abs(arguments[2]->evaluate_number()) : 0);
+    } else if (method_name == "speed") {
+        if (arguments.size() < 1 || arguments.size() > 2) {
+            throw std::runtime_error("unexpected number of arguments");
+        }
+        Module::expect(arguments, -1, numbery, numbery);
+        this->motor->speed(arguments[0]->evaluate_number(),
+                           arguments.size() > 1 ? std::abs(arguments[1]->evaluate_number()) : 0);
+    } else if (method_name == "stop") {
         Module::expect(arguments, 0);
-        // TODO
+        this->motor->stop();
     } else {
         Module::call(method_name, arguments);
     }

--- a/main/modules/motor_axis.cpp
+++ b/main/modules/motor_axis.cpp
@@ -5,7 +5,7 @@ MotorAxis::MotorAxis(const std::string name, const StepperMotor_ptr motor, const
     : Module(motor_axis, name), motor(motor), input1(input1), input2(input2) {
 }
 
-void MotorAxis::step() {
+void MotorAxis::check_inputs() const {
     try {
         if (this->motor->get_target_speed() < 0 && !this->input1->get_property("level")->integer_value) {
             this->motor->stop();
@@ -16,6 +16,10 @@ void MotorAxis::step() {
     } catch (std::runtime_error &e) {
         echo("error in MotorAxis::step(): %s", e.what());
     }
+}
+
+void MotorAxis::step() {
+    this->check_inputs();
     Module::step();
 }
 
@@ -28,6 +32,7 @@ void MotorAxis::call(const std::string method_name, const std::vector<ConstExpre
         this->motor->position(arguments[0]->evaluate_number(),
                               arguments[1]->evaluate_number(),
                               arguments.size() > 2 ? std::abs(arguments[2]->evaluate_number()) : 0);
+        this->check_inputs();
     } else if (method_name == "speed") {
         if (arguments.size() < 1 || arguments.size() > 2) {
             throw std::runtime_error("unexpected number of arguments");
@@ -35,6 +40,7 @@ void MotorAxis::call(const std::string method_name, const std::vector<ConstExpre
         Module::expect(arguments, -1, numbery, numbery);
         this->motor->speed(arguments[0]->evaluate_number(),
                            arguments.size() > 1 ? std::abs(arguments[1]->evaluate_number()) : 0);
+        this->check_inputs();
     } else if (method_name == "stop") {
         Module::expect(arguments, 0);
         this->motor->stop();

--- a/main/modules/motor_axis.cpp
+++ b/main/modules/motor_axis.cpp
@@ -1,14 +1,20 @@
 #include "motor_axis.h"
+#include "utils/uart.h"
 
 MotorAxis::MotorAxis(const std::string name, const StepperMotor_ptr motor, const Input_ptr input1, const Input_ptr input2)
     : Module(motor_axis, name), motor(motor), input1(input1), input2(input2) {
 }
 
 void MotorAxis::step() {
-    if (this->motor->get_target_speed() < 0 && this->input1->get_level()) {
-        this->motor->stop();
-    } else if (this->motor->get_target_speed() > 0 && this->input2->get_level()) {
-        this->motor->stop();
+    try {
+        if (this->motor->get_target_speed() < 0 && !this->input1->get_property("level")->integer_value) {
+            this->motor->stop();
+        }
+        if (this->motor->get_target_speed() > 0 && !this->input2->get_property("level")->integer_value) {
+            this->motor->stop();
+        }
+    } catch (std::runtime_error &e) {
+        echo("error in MotorAxis::step(): %s", e.what());
     }
     Module::step();
 }

--- a/main/modules/motor_axis.cpp
+++ b/main/modules/motor_axis.cpp
@@ -1,0 +1,14 @@
+#include "motor_axis.h"
+
+MotorAxis::MotorAxis(const std::string name, const StepperMotor_ptr motor, const Input_ptr input1, const Input_ptr input2)
+    : Module(motor_axis, name), motor(motor), input1(input1), input2(input2) {
+}
+
+void MotorAxis::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
+    if (method_name == "reference") {
+        Module::expect(arguments, 0);
+        // TODO
+    } else {
+        Module::call(method_name, arguments);
+    }
+}

--- a/main/modules/motor_axis.h
+++ b/main/modules/motor_axis.h
@@ -9,6 +9,8 @@ private:
     const Input_ptr input1;
     const Input_ptr input2;
 
+    void check_inputs() const;
+
 public:
     MotorAxis(const std::string name, const StepperMotor_ptr motor, const Input_ptr input1, const Input_ptr input2);
     void step() override;

--- a/main/modules/motor_axis.h
+++ b/main/modules/motor_axis.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "input.h"
+#include "stepper_motor.h"
+
+class MotorAxis : public Module {
+private:
+    const StepperMotor_ptr motor;
+    const Input_ptr input1;
+    const Input_ptr input2;
+
+public:
+    MotorAxis(const std::string name, const StepperMotor_ptr motor, const Input_ptr input1, const Input_ptr input2);
+    void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+};

--- a/main/modules/motor_axis.h
+++ b/main/modules/motor_axis.h
@@ -11,5 +11,6 @@ private:
 
 public:
     MotorAxis(const std::string name, const StepperMotor_ptr motor, const Input_ptr input1, const Input_ptr input2);
+    void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
 };

--- a/main/modules/stepper_motor.cpp
+++ b/main/modules/stepper_motor.cpp
@@ -16,7 +16,7 @@ StepperMotor::StepperMotor(const std::string name,
                            const pcnt_channel_t pcnt_channel,
                            const ledc_timer_t ledc_timer,
                            const ledc_channel_t ledc_channel)
-    : Module(output, name),
+    : Module(stepper_motor, name),
       step_pin(step_pin),
       dir_pin(dir_pin),
       pcnt_unit(pcnt_unit),

--- a/main/modules/stepper_motor.cpp
+++ b/main/modules/stepper_motor.cpp
@@ -163,23 +163,38 @@ void StepperMotor::call(const std::string method_name, const std::vector<ConstEx
             throw std::runtime_error("unexpected number of arguments");
         }
         Module::expect(arguments, -1, numbery, numbery, numbery);
-        this->target_position = arguments[0]->evaluate_number();
-        bool forward = this->target_position > this->properties.at("position")->integer_value;
-        this->target_speed = arguments[1]->evaluate_number() * (forward ? 1 : -1);
-        this->target_acceleration = arguments.size() > 2 ? std::abs(arguments[2]->evaluate_number()) : 0;
-        set_state(Positioning);
+        this->position(arguments[0]->evaluate_number(),
+                       arguments[1]->evaluate_number(),
+                       arguments.size() > 2 ? std::abs(arguments[2]->evaluate_number()) : 0);
     } else if (method_name == "speed") {
         if (arguments.size() < 1 || arguments.size() > 2) {
             throw std::runtime_error("unexpected number of arguments");
         }
         Module::expect(arguments, -1, numbery, numbery);
-        this->target_speed = arguments[0]->evaluate_number();
-        this->target_acceleration = arguments.size() > 1 ? std::abs(arguments[1]->evaluate_number()) : 0;
-        set_state(this->target_speed == 0 ? Idle : Speeding);
+        this->speed(arguments[0]->evaluate_number(),
+                    arguments.size() > 1 ? std::abs(arguments[1]->evaluate_number()) : 0);
     } else if (method_name == "stop") {
         Module::expect(arguments, 0);
-        set_state(Idle);
+        this->stop();
     } else {
         Module::call(method_name, arguments);
     }
+}
+
+void StepperMotor::position(const int32_t position, const int32_t speed, const uint32_t acceleration) {
+    this->target_position = position;
+    bool forward = this->target_position > this->properties.at("position")->integer_value;
+    this->target_speed = speed * (forward ? 1 : -1);
+    this->target_acceleration = acceleration;
+    set_state(Positioning);
+}
+
+void StepperMotor::speed(const int32_t speed, const uint32_t acceleration) {
+    this->target_speed = speed;
+    this->target_acceleration = acceleration;
+    set_state(this->target_speed == 0 ? Idle : Speeding);
+}
+
+void StepperMotor::stop() {
+    set_state(Idle);
 }

--- a/main/modules/stepper_motor.h
+++ b/main/modules/stepper_motor.h
@@ -44,4 +44,12 @@ public:
                  const ledc_channel_t ledc_channel);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void position(const int32_t position, const int32_t speed, const uint32_t acceleration);
+    void speed(const int32_t speed, const uint32_t acceleration);
+    void stop();
+
+    StepperState get_state() const { return this->state; }
+    int32_t get_target_position() const { return this->target_position; }
+    int32_t get_target_speed() const { return this->target_speed; }
+    uint32_t get_target_acceleration() const { return this->target_acceleration; }
 };

--- a/main/modules/stepper_motor.h
+++ b/main/modules/stepper_motor.h
@@ -11,6 +11,9 @@ enum StepperState {
     Positioning,
 };
 
+class StepperMotor;
+using StepperMotor_ptr = std::shared_ptr<StepperMotor>;
+
 class StepperMotor : public Module {
 private:
     const gpio_num_t step_pin;
@@ -29,7 +32,6 @@ private:
     uint32_t target_acceleration = 0;
 
     void read_position();
-    void set_frequency();
     void set_state(StepperState new_state);
 
 public:
@@ -42,5 +44,4 @@ public:
                  const ledc_channel_t ledc_channel);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
-    void stop();
 };


### PR DESCRIPTION
The main goal of this module is to quickly respond to switches and protect the hardware from damage - even if, for example, no RoSys is running, a different serial interface is being used, or a developer sends "manual" commands via the Lizard console.

Tasks:

- [x] control a `StepperMotor` via position/speed/stop commands
- [x] use `Input` switches to stop the motor if a switch becomes active
- [x] prevent the motor from moving in the wrong direction if switch is already active

Maybe later:

- [ ] allow using inverted switches
- [ ] support one or two switches
- [ ] `reference()` with reference switch: find reference switch with predetermined speed, send message to RoSys
- [ ] approach reference again more slowly?
- [ ] set the internal position to zero when referenced?
- [ ] handle the conversion between motor and output
