### PR TITLE
Forward property values from proxy module to expander

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -39,7 +39,7 @@ extern "C" {
 void app_main();
 }
 
-void process_lizard(const char *line, bool trigger_keep_alive = true);
+void process_lizard(const char *line, bool trigger_keep_alive = true, bool from_expander = false);
 
 std::string identifier_to_string(const struct owl_ref ref) {
     const struct parsed_identifier identifier = parsed_identifier_get(ref);
@@ -179,7 +179,7 @@ std::vector<Action_ptr> compile_actions(const struct owl_ref ref) {
     return actions;
 }
 
-void process_tree(owl_tree *const tree) {
+void process_tree(owl_tree *const tree, bool from_expander) {
     const struct parsed_statements statements = owl_tree_get_parsed_statements(tree);
     for (struct owl_ref r = statements.statement; !r.empty; r = owl_next(r)) {
         const struct parsed_statement statement = parsed_statement_get(r);
@@ -234,7 +234,7 @@ void process_tree(owl_tree *const tree) {
             const Module_ptr module = Global::get_module(module_name);
             const std::string property_name = identifier_to_string(property_assignment.property_name);
             const ConstExpression_ptr expression = compile_expression(property_assignment.expression);
-            module->write_property(property_name, expression);
+            module->write_property(property_name, expression, from_expander);
         } else if (!statement.variable_assignment.empty) {
             const struct parsed_variable_assignment variable_assignment = parsed_variable_assignment_get(statement.variable_assignment);
             const std::string variable_name = identifier_to_string(variable_assignment.variable_name);
@@ -285,7 +285,7 @@ void process_tree(owl_tree *const tree) {
     }
 }
 
-void process_lizard(const char *line, bool trigger_keep_alive) {
+void process_lizard(const char *line, bool trigger_keep_alive, bool from_expander) {
     if (trigger_keep_alive) {
         core_module->keep_alive();
     }
@@ -323,7 +323,7 @@ void process_lizard(const char *line, bool trigger_keep_alive) {
             owl_tree_print(tree.get());
             tic();
         }
-        process_tree(tree.get());
+        process_tree(tree.get(), from_expander);
         if (debug) {
             toc("Tree traversal");
         }

--- a/main/modules/bluetooth.cpp
+++ b/main/modules/bluetooth.cpp
@@ -6,7 +6,7 @@ Bluetooth::Bluetooth(const std::string name, const std::string device_name, Mess
     ZZ::BleCommand::init(device_name, [message_handler](const std::string_view &message) {
         try {
             std::string message_string(message.data(), message.length());
-            message_handler(message_string.c_str(), true);
+            message_handler(message_string.c_str(), true, false);
         } catch (const std::exception &e) {
             echo("error in bluetooth message handler: %s", e.what());
         }

--- a/main/modules/expander.cpp
+++ b/main/modules/expander.cpp
@@ -44,7 +44,7 @@ void Expander::step() {
         check(buffer, len);
         if (buffer[0] == '!' && buffer[1] == '!') {
             /* Don't trigger keep-alive from expander updates */
-            this->message_handler(&buffer[2], false);
+            this->message_handler(&buffer[2], false, true);
         } else {
             echo("%s: %s", this->name.c_str(), buffer);
         }

--- a/main/modules/module.cpp
+++ b/main/modules/module.cpp
@@ -342,7 +342,7 @@ Variable_ptr Module::get_property(const std::string property_name) const {
     return this->properties.at(property_name);
 }
 
-void Module::write_property(const std::string property_name, const ConstExpression_ptr expression) {
+void Module::write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) {
     this->get_property(property_name)->assign(expression);
 }
 

--- a/main/modules/module.h
+++ b/main/modules/module.h
@@ -35,7 +35,7 @@ enum ModuleType {
 class Module;
 using Module_ptr = std::shared_ptr<Module>;
 using ConstModule_ptr = std::shared_ptr<const Module>;
-using MessageHandler = void (*)(const char *line, bool trigger_keep_alive);
+using MessageHandler = void (*)(const char *line, bool trigger_keep_alive, bool from_expander);
 
 class Module {
 private:
@@ -61,6 +61,6 @@ public:
     void call_with_shadows(const std::string method_name, const std::vector<ConstExpression_ptr> arguments);
     virtual std::string get_output() const;
     Variable_ptr get_property(const std::string property_name) const;
-    virtual void write_property(const std::string property_name, const ConstExpression_ptr expression);
+    virtual void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander = false);
     virtual void handle_can_msg(const uint32_t id, const int count, const uint8_t *const data);
 };

--- a/main/modules/proxy.cpp
+++ b/main/modules/proxy.cpp
@@ -32,9 +32,15 @@ void Proxy::call(const std::string method_name, const std::vector<ConstExpressio
     this->expander->serial->write_checked_line(buffer, pos);
 }
 
-void Proxy::write_property(const std::string property_name, const ConstExpression_ptr expression) {
+void Proxy::write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) {
     if (!this->properties.count(property_name)) {
         this->properties[property_name] = std::make_shared<Variable>(expression->type);
+    }
+    if (!from_expander) {
+        static char buffer[256];
+        int pos = std::sprintf(buffer, "%s.%s = ", this->name.c_str(), property_name.c_str());
+        pos += expression->print_to_buffer(&buffer[pos]);
+        this->expander->serial->write_checked_line(buffer, pos);
     }
     Module::get_property(property_name)->assign(expression);
 }

--- a/main/modules/proxy.h
+++ b/main/modules/proxy.h
@@ -14,5 +14,5 @@ public:
           const Expander_ptr expander,
           const std::vector<ConstExpression_ptr> arguments);
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
-    void write_property(const std::string property_name, const ConstExpression_ptr expression) override;
+    void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;
 };


### PR DESCRIPTION
This PR allows _writing_ properties for modules that run on an expander. Until now these values haven't been forwarded, so the change was ineffective. Now they are sent to the expander over serial.

In order to avoid endless loops of back and forth, we have to consider whether a property value originates from the expander (then we don't need to send it back) or from another source like user or bluetooth (then we need to send it to the expander).