### PR TITLE
allow inputs to be inverted

### DIFF
--- a/main/modules/input.cpp
+++ b/main/modules/input.cpp
@@ -5,12 +5,15 @@
 Input::Input(const std::string name) : Module(input, name) {
     this->properties["level"] = std::make_shared<IntegerVariable>();
     this->properties["change"] = std::make_shared<IntegerVariable>();
+    this->properties["inverted"] = std::make_shared<BooleanVariable>();
+    this->properties["active"] = std::make_shared<BooleanVariable>();
 }
 
 void Input::step() {
     const int new_level = this->get_level();
     this->properties.at("change")->integer_value = new_level - this->properties.at("level")->integer_value;
     this->properties.at("level")->integer_value = new_level;
+    this->properties.at("active")->boolean_value = this->properties.at("inverted")->boolean_value ? !new_level : new_level;
     Module::step();
 }
 


### PR DESCRIPTION
Since most endstop switches are normally-closed the input value must be inverted. This PR expands the input class by an inverted and an active property.
Active is always true when the button is pressed while the level depends on whether it's normally-closed or normally-open (i.e inverted or not).


Tested with input pin low:
```
> button = Input(34)
I (29990) gpio: GPIO[34]| InputEn: 0| OutputEn: 0| OpenDrain: 0| Pullup: 1| Pulldown: 0| Intr:0 
> button.inverted
false
> button.level
0
> button.active
false
> button.inverted = true
> button.inverted
true
> button.level
0
> button.active
true
```

With input pin high:
```
> button = Input(34)
I (33190) gpio: GPIO[34]| InputEn: 0| OutputEn: 0| OpenDrain: 0| Pullup: 1| Pulldown: 0| Intr:0 
> button.inverted
false
> button.level
1
> button.active
true
> button.inverted = true
> button.inverted
true
> button.level
1
> button.active
false
```