### PR TITLE
Odrive error handling

### DIFF
--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -280,8 +280,7 @@ The ODrive motor module controls a motor using an [ODrive motor controller](http
 | `motor.position(position)`     | Move to given `position` (m)                | `float`          |
 | `motor.limits(speed, current)` | Set speed (m/s) and current (A) limits      | `float`, `float` |
 | `motor.off()`                  | Turn motor off (idle state)                 |                  |
-| `motor.clear_errors`           | Clears all error statements                 |                  |
-| `motor.reset_motor`            | Resets the Motor and clears error statments |                  |
+| `motor.reset_motor_error()`    | Resets the Motor and clears error statments |                  |
 
 ## ODrive Wheels
 

--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -270,7 +270,7 @@ The ODrive motor module controls a motor using an [ODrive motor controller](http
 | `motor.m_per_tick`  | Meters per encoder tick | `float`   |
 | `motor.reversed`    | Reverse motor direction | `bool`    |
 | `motor.axis_error`  | Error code of the axis  | `int`     |
-| `motor.motor_error` | Motor in fault mode     | `bool`    |
+| `motor.motor_error` | Motor in fault mode     | `int`     |
 
 | Methods                        | Description                                 | Arguments        |
 | ------------------------------ | ------------------------------------------- | ---------------- |
@@ -280,7 +280,6 @@ The ODrive motor module controls a motor using an [ODrive motor controller](http
 | `motor.position(position)`     | Move to given `position` (m)                | `float`          |
 | `motor.limits(speed, current)` | Set speed (m/s) and current (A) limits      | `float`, `float` |
 | `motor.off()`                  | Turn motor off (idle state)                 |                  |
-| `motor.update_motor_error`     | Update the motor_error Propertie            |                  |
 | `motor.clear_errors`           | Clears all error statements                 |                  |
 | `motor.reset_motor`            | Resets the Motor and clears error statments |                  |
 

--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -265,14 +265,15 @@ The ODrive motor module controls a motor using an [ODrive motor controller](http
 | ---------------------------------- | ---------------------- | ----------------- |
 | `motor = ODriveMotor(can, can_id)` | CAN module and node ID | CAN module, `int` |
 
-| Properties          | Description             | Data type |
-| ------------------- | ----------------------- | --------- |
-| `motor.position`    | Motor position (meters) | `float`   |
-| `motor.tick_offset` | Encoder tick offset     | `float`   |
-| `motor.m_per_tick`  | Meters per encoder tick | `float`   |
-| `motor.reversed`    | Reverse motor direction | `bool`    |
-| `motor.axis_error`  | Error code of the axis  | `int`     |
-| `motor.motor_error` | Motor in fault mode     | `int`     |
+| Properties          | Description                 | Data type |
+| ------------------- | --------------------------- | --------- |
+| `motor.position`    | Motor position (meters)     | `float`   |
+| `motor.tick_offset` | Encoder tick offset         | `float`   |
+| `motor.m_per_tick`  | Meters per encoder tick     | `float`   |
+| `motor.reversed`    | Reverse motor direction     | `bool`    |
+| `motor.axis_error`  | Error code of the axis      | `int`     |
+| `motor.motor_error` | Motor in fault mode         | `int`     |
+| `motor.axis_state`  | the state of the motor axis | `int`     |
 
 | Methods                        | Description                                 | Arguments        |
 | ------------------------------ | ------------------------------------------- | ---------------- |
@@ -282,7 +283,7 @@ The ODrive motor module controls a motor using an [ODrive motor controller](http
 | `motor.position(position)`     | Move to given `position` (m)                | `float`          |
 | `motor.limits(speed, current)` | Set speed (m/s) and current (A) limits      | `float`, `float` |
 | `motor.off()`                  | Turn motor off (idle state)                 |                  |
-| `motor.reset_motor_error()`    | Resets the Motor and clears error statments |                  |
+| `motor.reset_motor()`          | Resets the Motor and clears error statments |                  |
 
 ## ODrive Wheels
 

--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -261,29 +261,31 @@ This module controls a linear actuator via two output pins (move in, move out) a
 
 The ODrive motor module controls a motor using an [ODrive motor controller](https://odriverobotics.com/).
 
-| Constructor                        | Description            | Arguments         |
-| ---------------------------------- | ---------------------- | ----------------- |
-| `motor = ODriveMotor(can, can_id)` | CAN module and node ID | CAN module, `int` |
+| Constructor                                   | Description                     | Arguments                |
+| --------------------------------------------- | ------------------------------- | ------------------------ |
+| `motor = ODriveMotor(can, can_id[, version])` | CAN module, node ID and version | CAN module, `int`, `int` |
 
-| Properties          | Description                 | Data type |
-| ------------------- | --------------------------- | --------- |
-| `motor.position`    | Motor position (meters)     | `float`   |
-| `motor.tick_offset` | Encoder tick offset         | `float`   |
-| `motor.m_per_tick`  | Meters per encoder tick     | `float`   |
-| `motor.reversed`    | Reverse motor direction     | `bool`    |
-| `motor.axis_error`  | Error code of the axis      | `int`     |
-| `motor.motor_error` | Motor in fault mode         | `int`     |
-| `motor.axis_state`  | the state of the motor axis | `int`     |
+The `version` parameter is an optional integer indicating the patch number of the ODrive firmware (4, 5 or 6; default: 4 for version "0.5.4"). Version 0.5.6 allows to read the motor error flag.
 
-| Methods                        | Description                                 | Arguments        |
-| ------------------------------ | ------------------------------------------- | ---------------- |
-| `motor.zero()`                 | Set current position as zero position       |                  |
-| `motor.power(torque)`          | Move with given `torque`                    | `float`          |
-| `motor.speed(speed)`           | Move with given `speed` (m/s)               | `float`          |
-| `motor.position(position)`     | Move to given `position` (m)                | `float`          |
-| `motor.limits(speed, current)` | Set speed (m/s) and current (A) limits      | `float`, `float` |
-| `motor.off()`                  | Turn motor off (idle state)                 |                  |
-| `motor.reset_motor()`          | Resets the Motor and clears error statments |                  |
+| Properties          | Description                               | Data type |
+| ------------------- | ----------------------------------------- | --------- |
+| `motor.position`    | Motor position (meters)                   | `float`   |
+| `motor.tick_offset` | Encoder tick offset                       | `float`   |
+| `motor.m_per_tick`  | Meters per encoder tick                   | `float`   |
+| `motor.reversed`    | Reverse motor direction                   | `bool`    |
+| `motor.axis_state`  | State of the motor axis                   | `int`     |
+| `motor.axis_error`  | Error code of the axis                    | `int`     |
+| `motor.motor_error` | Motor error flat (requires version 0.5.6) | `int`     |
+
+| Methods                        | Description                            | Arguments        |
+| ------------------------------ | -------------------------------------- | ---------------- |
+| `motor.zero()`                 | Set current position as zero position  |                  |
+| `motor.power(torque)`          | Move with given `torque`               | `float`          |
+| `motor.speed(speed)`           | Move with given `speed` (m/s)          | `float`          |
+| `motor.position(position)`     | Move to given `position` (m)           | `float`          |
+| `motor.limits(speed, current)` | Set speed (m/s) and current (A) limits | `float`, `float` |
+| `motor.off()`                  | Turn motor off (idle state)            |                  |
+| `motor.reset_motor()`          | Resets the motor and clears errors     |                  |
 
 ## ODrive Wheels
 

--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -269,15 +269,20 @@ The ODrive motor module controls a motor using an [ODrive motor controller](http
 | `motor.tick_offset` | Encoder tick offset     | `float`   |
 | `motor.m_per_tick`  | Meters per encoder tick | `float`   |
 | `motor.reversed`    | Reverse motor direction | `bool`    |
+| `motor.axis_error`  | Error code of the axis  | `int`     |
+| `motor.motor_error` | Motor in fault mode     | `bool`    |
 
-| Methods                        | Description                            | Arguments        |
-| ------------------------------ | -------------------------------------- | ---------------- |
-| `motor.zero()`                 | Set current position as zero position  |                  |
-| `motor.power(torque)`          | Move with given `torque`               | `float`          |
-| `motor.speed(speed)`           | Move with given `speed` (m/s)          | `float`          |
-| `motor.position(position)`     | Move to given `position` (m)           | `float`          |
-| `motor.limits(speed, current)` | Set speed (m/s) and current (A) limits | `float`, `float` |
-| `motor.off()`                  | Turn motor off (idle state)            |                  |
+| Methods                        | Description                                 | Arguments        |
+| ------------------------------ | ------------------------------------------- | ---------------- |
+| `motor.zero()`                 | Set current position as zero position       |                  |
+| `motor.power(torque)`          | Move with given `torque`                    | `float`          |
+| `motor.speed(speed)`           | Move with given `speed` (m/s)               | `float`          |
+| `motor.position(position)`     | Move to given `position` (m)                | `float`          |
+| `motor.limits(speed, current)` | Set speed (m/s) and current (A) limits      | `float`, `float` |
+| `motor.off()`                  | Turn motor off (idle state)                 |                  |
+| `motor.update_motor_error`     | Update the motor_error Propertie            |                  |
+| `motor.clear_errors`           | Clears all error statements                 |                  |
+| `motor.reset_motor`            | Resets the Motor and clears error statments |                  |
 
 ## ODrive Wheels
 

--- a/main/modules/module.cpp
+++ b/main/modules/module.cpp
@@ -166,15 +166,29 @@ Module_ptr Module::create(const std::string type,
             return std::make_shared<McpLinearMotor>(name, mcp, move_in, move_out, end_in, end_out);
         }
     } else if (type == "ODriveMotor") {
-        Module::expect(arguments, 2, identifier, integer);
-        std::string can_name = arguments[0]->evaluate_identifier();
-        Module_ptr module = Global::get_module(can_name);
-        if (module->type != can) {
-            throw std::runtime_error("module \"" + can_name + "\" is no can connection");
+        if (arguments.size() == 2) {
+            Module::expect(arguments, 2, identifier, integer);
+            std::string can_name = arguments[0]->evaluate_identifier();
+            Module_ptr module = Global::get_module(can_name);
+            if (module->type != can) {
+                throw std::runtime_error("module \"" + can_name + "\" is no can connection");
+            }
+            const Can_ptr can = std::static_pointer_cast<Can>(module);
+            uint32_t can_id = arguments[1]->evaluate_integer();
+            ODriveMotor_ptr odrive_motor = std::make_shared<ODriveMotor>(name, can, can_id, 4);
+        } else {
+            Module::expect(arguments, 3, identifier, integer, integer);
+            std::string can_name = arguments[0]->evaluate_identifier();
+            Module_ptr module = Global::get_module(can_name);
+            if (module->type != can) {
+                throw std::runtime_error("module \"" + can_name + "\" is no can connection");
+            }
+            const Can_ptr can = std::static_pointer_cast<Can>(module);
+            uint32_t can_id = arguments[1]->evaluate_integer();
+            int version = arguments[2]->evaluate_integer();
+            ODriveMotor_ptr odrive_motor = std::make_shared<ODriveMotor>(name, can, can_id, version);
         }
-        const Can_ptr can = std::static_pointer_cast<Can>(module);
-        uint32_t can_id = arguments[1]->evaluate_integer();
-        ODriveMotor_ptr odrive_motor = std::make_shared<ODriveMotor>(name, can, can_id);
+
         odrive_motor->subscribe_to_can();
         return odrive_motor;
     } else if (type == "ODriveWheels") {

--- a/main/modules/module.cpp
+++ b/main/modules/module.cpp
@@ -176,6 +176,8 @@ Module_ptr Module::create(const std::string type,
             const Can_ptr can = std::static_pointer_cast<Can>(module);
             uint32_t can_id = arguments[1]->evaluate_integer();
             ODriveMotor_ptr odrive_motor = std::make_shared<ODriveMotor>(name, can, can_id, 4);
+            odrive_motor->subscribe_to_can();
+            return odrive_motor;
         } else {
             Module::expect(arguments, 3, identifier, integer, integer);
             std::string can_name = arguments[0]->evaluate_identifier();
@@ -187,10 +189,10 @@ Module_ptr Module::create(const std::string type,
             uint32_t can_id = arguments[1]->evaluate_integer();
             int version = arguments[2]->evaluate_integer();
             ODriveMotor_ptr odrive_motor = std::make_shared<ODriveMotor>(name, can, can_id, version);
+            odrive_motor->subscribe_to_can();
+            return odrive_motor;
         }
 
-        odrive_motor->subscribe_to_can();
-        return odrive_motor;
     } else if (type == "ODriveWheels") {
         Module::expect(arguments, 2, identifier, identifier);
         std::string left_name = arguments[0]->evaluate_identifier();

--- a/main/modules/module.cpp
+++ b/main/modules/module.cpp
@@ -166,33 +166,21 @@ Module_ptr Module::create(const std::string type,
             return std::make_shared<McpLinearMotor>(name, mcp, move_in, move_out, end_in, end_out);
         }
     } else if (type == "ODriveMotor") {
-        if (arguments.size() == 2) {
-            Module::expect(arguments, 2, identifier, integer);
-            std::string can_name = arguments[0]->evaluate_identifier();
-            Module_ptr module = Global::get_module(can_name);
-            if (module->type != can) {
-                throw std::runtime_error("module \"" + can_name + "\" is no can connection");
-            }
-            const Can_ptr can = std::static_pointer_cast<Can>(module);
-            uint32_t can_id = arguments[1]->evaluate_integer();
-            ODriveMotor_ptr odrive_motor = std::make_shared<ODriveMotor>(name, can, can_id, 4);
-            odrive_motor->subscribe_to_can();
-            return odrive_motor;
-        } else {
-            Module::expect(arguments, 3, identifier, integer, integer);
-            std::string can_name = arguments[0]->evaluate_identifier();
-            Module_ptr module = Global::get_module(can_name);
-            if (module->type != can) {
-                throw std::runtime_error("module \"" + can_name + "\" is no can connection");
-            }
-            const Can_ptr can = std::static_pointer_cast<Can>(module);
-            uint32_t can_id = arguments[1]->evaluate_integer();
-            int version = arguments[2]->evaluate_integer();
-            ODriveMotor_ptr odrive_motor = std::make_shared<ODriveMotor>(name, can, can_id, version);
-            odrive_motor->subscribe_to_can();
-            return odrive_motor;
+        if (arguments.size() < 2 || arguments.size() > 3) {
+            throw std::runtime_error("unexpected number of arguments");
         }
-
+        Module::expect(arguments, -1, identifier, integer, integer);
+        std::string can_name = arguments[0]->evaluate_identifier();
+        Module_ptr module = Global::get_module(can_name);
+        if (module->type != can) {
+            throw std::runtime_error("module \"" + can_name + "\" is no can connection");
+        }
+        const Can_ptr can = std::static_pointer_cast<Can>(module);
+        uint32_t can_id = arguments[1]->evaluate_integer();
+        int version = arguments.size() > 2 ? arguments[2]->evaluate_integer() : 4;
+        ODriveMotor_ptr odrive_motor = std::make_shared<ODriveMotor>(name, can, can_id, version);
+        odrive_motor->subscribe_to_can();
+        return odrive_motor;
     } else if (type == "ODriveWheels") {
         Module::expect(arguments, 2, identifier, identifier);
         std::string left_name = arguments[0]->evaluate_identifier();

--- a/main/modules/odrive_motor.cpp
+++ b/main/modules/odrive_motor.cpp
@@ -31,7 +31,7 @@ ODriveMotor::ODriveMotor(const std::string name, const Can_ptr can, const uint32
     this->properties["tick_offset"] = std::make_shared<NumberVariable>();
     this->properties["m_per_tick"] = std::make_shared<NumberVariable>(1.0);
     this->properties["reversed"] = std::make_shared<BooleanVariable>();
-    this->properties["motor_error"] = std::make_shared<BooleanVariable>(false);
+    this->properties["motor_error"] = std::make_shared<IntegerVariable>(0);
     this->properties["axis_error"] = std::make_shared<IntegerVariable>();
 }
 
@@ -79,9 +79,6 @@ void ODriveMotor::call(const std::string method_name, const std::vector<ConstExp
     } else if (method_name == "off") {
         Module::expect(arguments, 0);
         this->off();
-    } else if (method_name == "update_motor_error") {
-        Module::expect(arguments, 0);
-        this->update_motor_error();
     } else if (method_name == "reset_motor") {
         Module::expect(arguments, 0);
         this->reset_motor();
@@ -135,11 +132,11 @@ void ODriveMotor::handle_can_msg(const uint32_t id, const int count, const uint8
         std::memcpy(&motor_error, data, 4);
         switch (motor_error) {
         case MOTOR_ERROR_NONE:
-            this->properties.at("motor_error")->boolean_value = false;
+            this->properties.at("motor_error")->integer_value = 0;
             break;
 
         default:
-            this->properties.at("motor_error")->boolean_value = true;
+            this->properties.at("motor_error")->integer_value = 1;
             break;
         }
     }
@@ -211,4 +208,9 @@ void ODriveMotor::reset_motor() {
 }
 double ODriveMotor::get_position() {
     return this->properties.at("position")->number_value;
+}
+
+void ODriveMotor::step() {
+    this->update_motor_error();
+    Module::step();
 }

--- a/main/modules/odrive_motor.cpp
+++ b/main/modules/odrive_motor.cpp
@@ -13,8 +13,8 @@ enum AXIS_ERROR {
     AXIS_ERROR_UNKNOWN_POSITION = 0x80000
 };
 
-ODriveMotor::ODriveMotor(const std::string name, const Can_ptr can, const uint32_t can_id) : Module(odrive_motor, name),
-                                                                                             can_id(can_id), can(can) {
+ODriveMotor::ODriveMotor(const std::string name, const Can_ptr can, const uint32_t can_id, const uint32_t version) : Module(odrive_motor, name),
+                                                                                                                     can_id(can_id), can(can), version(version) {
     this->properties["position"] = std::make_shared<NumberVariable>();
     this->properties["tick_offset"] = std::make_shared<NumberVariable>();
     this->properties["m_per_tick"] = std::make_shared<NumberVariable>(1.0);
@@ -83,11 +83,11 @@ void ODriveMotor::handle_can_msg(const uint32_t id, const int count, const uint8
         int axis_state;
         std::memcpy(&axis_state, data + 4, 1);
         this->axis_state = axis_state;
-
-        int messege_byte;
-        std::memcpy(&messege_byte, data + 5, 1);
-        this->properties.at("motor_error_flag")->integer_value = messege_byte & 0x01;
-
+        if (version == 6) {
+            int messege_byte;
+            std::memcpy(&messege_byte, data + 5, 1);
+            this->properties.at("motor_error_flag")->integer_value = messege_byte & 0x01;
+        }
         int axis_error;
         std::memcpy(&axis_error, data, 4);
         switch (axis_error) {

--- a/main/modules/odrive_motor.cpp
+++ b/main/modules/odrive_motor.cpp
@@ -2,15 +2,42 @@
 #include <cstring>
 #include <memory>
 
-ODriveMotor::ODriveMotor(const std::string name, const Can_ptr can, const uint32_t can_id)
-    : Module(odrive_motor, name), can_id(can_id), can(can) {
+enum AXIS_ERROR {
+    AXIS_ERROR_NONE = 0,
+    AXIS_ERROR_INVALID_STATE = 0x01,
+    AXIS_ERROR_WATCHDOG_TIMER_EXPIRED = 0x800,
+    AXIS_ERROR_MIN_ENDSTOP_PRESSED = 0x1000,
+    AXIS_ERROR_MAX_ENDSTOP_PRESSED = 0x2000,
+    AXIS_ERROR_ESTOP_REQUESTED = 0x4000,
+    AXIS_ERROR_OVER_TEMP = 0x40000,
+    AXIS_ERROR_UNKNOWN_POSITION = 0x80000
+};
+enum MOTOR_ERROR {
+    MOTOR_ERROR_NONE = 0,
+    MOTOR_ERROR_PHASE_RESISTANCE_OUT_OF_RANGE = 0x01,
+    MOTOR_ERROR_PHASE_INDUCTANCE_OUT_OF_RANGE = 0x02,
+    MOTOR_ERROR_DRV_FAULT = 0x08,
+    MOTOR_ERROR_CONTROL_DEADLINE_MISSED = 0x10,
+    MOTOR_ERROR_MODULATION_MAGNITUDE = 0x80,
+    MOTOR_ERROR_BRAKE_CURRENT_OUT_OF_RANGE = 0x400,
+    MOTOR_ERROR_CURRENT_LIMIT_VIALTION = 0x1000,
+    // TODO add more error coddes https://docs.odriverobotics.com/v/0.5.4/fibre_types/com_odriverobotics_ODrive.html?highlight=motor+error#ODrive.Motor.Error
+
+};
+
+ODriveMotor::ODriveMotor(const std::string name, const Can_ptr can, const uint32_t can_id) : Module(odrive_motor, name),
+                                                                                             can_id(can_id), can(can) {
     this->properties["position"] = std::make_shared<NumberVariable>();
     this->properties["tick_offset"] = std::make_shared<NumberVariable>();
     this->properties["m_per_tick"] = std::make_shared<NumberVariable>(1.0);
     this->properties["reversed"] = std::make_shared<BooleanVariable>();
+    this->properties["motor_error"] = std::make_shared<BooleanVariable>(false);
+    this->properties["axis_error"] = std::make_shared<IntegerVariable>();
 }
 
 void ODriveMotor::subscribe_to_can() {
+    this->can->subscribe(this->can_id + 0x001, std::static_pointer_cast<Module>(this->shared_from_this()));
+    this->can->subscribe(this->can_id + 0x003, std::static_pointer_cast<Module>(this->shared_from_this()));
     this->can->subscribe(this->can_id + 0x009, std::static_pointer_cast<Module>(this->shared_from_this()));
 }
 
@@ -52,6 +79,15 @@ void ODriveMotor::call(const std::string method_name, const std::vector<ConstExp
     } else if (method_name == "off") {
         Module::expect(arguments, 0);
         this->off();
+    } else if (method_name == "update_motor_error") {
+        Module::expect(arguments, 0);
+        this->update_motor_error();
+    } else if (method_name == "reset_motor") {
+        Module::expect(arguments, 0);
+        this->reset_motor();
+    } else if (method_name == "clear_errors") {
+        Module::expect(arguments, 0);
+        this->clear_errors();
     } else {
         Module::call(method_name, arguments);
     }
@@ -60,6 +96,53 @@ void ODriveMotor::call(const std::string method_name, const std::vector<ConstExp
 void ODriveMotor::handle_can_msg(const uint32_t id, const int count, const uint8_t *const data) {
     this->is_boot_complete = true;
     switch (id - this->can_id) {
+    case 0x001: {
+        int axis_state;
+        std::memcpy(&axis_state, data + 4, 2);
+        this->axis_state = axis_state;
+        int axis_error;
+        std::memcpy(&axis_error, data, 4);
+        switch (axis_error) {
+        case AXIS_ERROR_INVALID_STATE:
+            this->properties.at("axis_error")->integer_value = 1;
+            break;
+        case AXIS_ERROR_WATCHDOG_TIMER_EXPIRED:
+            this->properties.at("axis_error")->integer_value = 2;
+            break;
+        case AXIS_ERROR_MIN_ENDSTOP_PRESSED:
+            this->properties.at("axis_error")->integer_value = 3;
+            break;
+        case AXIS_ERROR_MAX_ENDSTOP_PRESSED:
+            this->properties.at("axis_error")->integer_value = 4;
+            break;
+        case AXIS_ERROR_ESTOP_REQUESTED:
+            this->properties.at("axis_error")->integer_value = 5;
+            break;
+        case AXIS_ERROR_OVER_TEMP:
+            this->properties.at("axis_error")->integer_value = 6;
+            break;
+        case AXIS_ERROR_UNKNOWN_POSITION:
+            this->properties.at("axis_error")->integer_value = 7;
+            break;
+        default:
+            this->properties.at("axis_error")->integer_value = axis_error;
+
+            break;
+        }
+        break;
+    case 0x003: {
+        int motor_error;
+        std::memcpy(&motor_error, data, 4);
+        switch (motor_error) {
+        case MOTOR_ERROR_NONE:
+            this->properties.at("motor_error")->boolean_value = false;
+            break;
+
+        default:
+            this->properties.at("motor_error")->boolean_value = true;
+            break;
+        }
+    }
     case 0x009: {
         float tick;
         std::memcpy(&tick, data, 4);
@@ -67,6 +150,7 @@ void ODriveMotor::handle_can_msg(const uint32_t id, const int count, const uint8
             (tick - this->properties.at("tick_offset")->number_value) *
             (this->properties.at("reversed")->boolean_value ? -1 : 1) *
             this->properties.at("m_per_tick")->number_value;
+    }
     }
     }
 }
@@ -112,7 +196,19 @@ void ODriveMotor::limits(const float speed, const float current) {
 void ODriveMotor::off() {
     this->set_mode(1); // AXIS_STATE_IDLE
 }
-
+void ODriveMotor::clear_errors() {
+    uint8_t empty_data[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    this->can->send(this->can_id + 0x018, empty_data, true);
+}
+void ODriveMotor::update_motor_error() {
+    uint8_t empty_data[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    this->can->send(this->can_id + 0x003, empty_data, true);
+}
+void ODriveMotor::reset_motor() {
+    this->clear_errors();
+    this->set_mode(8, 2, 1); // AXIS_STATE_CLOSED_LOOP_CONTROL, CONTROL_MODE_VELOCITY_CONTROL, INPUT_MODE_PASSTHROUGH
+    this->update_motor_error();
+}
 double ODriveMotor::get_position() {
     return this->properties.at("position")->number_value;
 }

--- a/main/modules/odrive_motor.cpp
+++ b/main/modules/odrive_motor.cpp
@@ -183,7 +183,3 @@ void ODriveMotor::reset_motor_error() {
 double ODriveMotor::get_position() {
     return this->properties.at("position")->number_value;
 }
-
-void ODriveMotor::step() {
-    Module::step();
-}

--- a/main/modules/odrive_motor.h
+++ b/main/modules/odrive_motor.h
@@ -29,8 +29,7 @@ public:
     void position(const float position);
     void limits(const float speed, const float current);
     void off();
-    void reset_motor();
-    void clear_errors();
+    void reset_motor_error();
     double get_position();
     void step() override;
 };

--- a/main/modules/odrive_motor.h
+++ b/main/modules/odrive_motor.h
@@ -17,6 +17,7 @@ private:
     uint8_t axis_input_mode = -1;
 
     void set_mode(const uint8_t state, const uint8_t control_mode = 0, const uint8_t input_mode = 0);
+    void update_motor_error();
 
 public:
     ODriveMotor(const std::string name, const Can_ptr can, const uint32_t can_id);
@@ -28,8 +29,8 @@ public:
     void position(const float position);
     void limits(const float speed, const float current);
     void off();
-    void update_motor_error();
     void reset_motor();
     void clear_errors();
     double get_position();
+    void step() override;
 };

--- a/main/modules/odrive_motor.h
+++ b/main/modules/odrive_motor.h
@@ -18,7 +18,6 @@ private:
     uint8_t axis_input_mode = -1;
 
     void set_mode(const uint8_t state, const uint8_t control_mode = 0, const uint8_t input_mode = 0);
-    void update_motor_error();
 
 public:
     ODriveMotor(const std::string name, const Can_ptr can, const uint32_t can_id, const uint32_t version);

--- a/main/modules/odrive_motor.h
+++ b/main/modules/odrive_motor.h
@@ -32,5 +32,4 @@ public:
     void off();
     void reset_motor_error();
     double get_position();
-    void step() override;
 };

--- a/main/modules/odrive_motor.h
+++ b/main/modules/odrive_motor.h
@@ -11,6 +11,7 @@ class ODriveMotor : public Module, public std::enable_shared_from_this<ODriveMot
 private:
     const uint32_t can_id;
     const Can_ptr can;
+    const uint32_t version;
     bool is_boot_complete = false;
     uint8_t axis_state = -1;
     uint8_t axis_control_mode = -1;
@@ -20,7 +21,7 @@ private:
     void update_motor_error();
 
 public:
-    ODriveMotor(const std::string name, const Can_ptr can, const uint32_t can_id);
+    ODriveMotor(const std::string name, const Can_ptr can, const uint32_t can_id, const uint32_t version);
     void subscribe_to_can();
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     void handle_can_msg(const uint32_t id, const int count, const uint8_t *const data) override;

--- a/main/modules/odrive_motor.h
+++ b/main/modules/odrive_motor.h
@@ -28,5 +28,8 @@ public:
     void position(const float position);
     void limits(const float speed, const float current);
     void off();
+    void update_motor_error();
+    void reset_motor();
+    void clear_errors();
     double get_position();
 };


### PR DESCRIPTION
Ad a function, where the Odrive module now supports the heartbeat message of the Motor axis. If the firmware version of the Odrive is `0.5.6` the hearbeat will return a `motor_error_flag`. The version can be given as a third variable(for example `m = ODriveMotor(can, 0x100,6)` , when caling the constructor of the OdriveMotor. When no version is given, version `0.5.4` will be used. This can be reset using the reset_motor() function. After this the motor will work again. this reset works for both firmware versions, but only `0.5.6`will give feedback.