### PR TITLE
Expander with 2 Pins

### DIFF
--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -597,15 +597,17 @@ The default attenuation level is 11 dB.
 
 The expander module allows communication with another microcontroller connected via [serial](#serial-interface).
 
-| Constructor                                 | Description                        | Arguments               |
-| ------------------------------------------- | ---------------------------------- | ----------------------- |
-| `expander = Expander(serial, boot, enable)` | Serial module and boot/enable pins | Serial module, 2x `int` |
+| Constructor                                   | Description                        | Arguments               |
+| --------------------------------------------- | ---------------------------------- | ----------------------- |
+| `expander = Expander(serial[, boot, enable])` | Serial module and boot/enable pins | Serial module, 2x `int` |
 
 | Methods                 | Description                                      | Arguments |
 | ----------------------- | ------------------------------------------------ | --------- |
 | `expander.run(command)` | Run any `command` on the other microcontroller   | `string`  |
 | `expander.disconnect()` | Disconnect serial connection and pins            |           |
 | `expander.flash()`      | Flash other microcontroller with own binary data |           |
+
+The `flash()` method requires the `boot` and `enable` pins to be defined.
 
 The `disconnect()` method might be useful to access the other microcontroller on UART0 via USB while still being physically connected to the main microcontroller.
 

--- a/main/modules/expander.cpp
+++ b/main/modules/expander.cpp
@@ -13,7 +13,7 @@ Expander::Expander(const std::string name,
                    MessageHandler message_handler)
     : Module(expander, name), serial(serial), boot_pin(boot_pin), enable_pin(enable_pin), message_handler(message_handler) {
     serial->enable_line_detection();
-    if (boot_pin != GPIO_NUM_MAX && enable_pin != GPIO_NUM_MAX) {
+    if (boot_pin != GPIO_NUM_NC && enable_pin != GPIO_NUM_NC) {
         gpio_reset_pin(boot_pin);
         gpio_reset_pin(enable_pin);
         gpio_set_direction(boot_pin, GPIO_MODE_OUTPUT);
@@ -63,7 +63,7 @@ void Expander::call(const std::string method_name, const std::vector<ConstExpres
     } else if (method_name == "disconnect") {
         Module::expect(arguments, 0);
         this->serial->deinstall();
-        if (this->boot_pin != GPIO_NUM_MAX && this->enable_pin != GPIO_NUM_MAX) {
+        if (this->boot_pin != GPIO_NUM_NC && this->enable_pin != GPIO_NUM_NC) {
             gpio_reset_pin(this->boot_pin);
             gpio_reset_pin(this->enable_pin);
             gpio_set_direction(this->boot_pin, GPIO_MODE_INPUT);
@@ -73,7 +73,7 @@ void Expander::call(const std::string method_name, const std::vector<ConstExpres
         }
     } else if (method_name == "flash") {
         Module::expect(arguments, 0);
-        if (this->boot_pin == GPIO_NUM_MAX || this->enable_pin == GPIO_NUM_MAX) {
+        if (this->boot_pin == GPIO_NUM_NC || this->enable_pin == GPIO_NUM_NC) {
             throw std::runtime_error("expander \"" + this->name + "\" does not support flashing, pins not set");
         }
         Storage::clear_nvs();

--- a/main/modules/module.cpp
+++ b/main/modules/module.cpp
@@ -64,15 +64,18 @@ Module_ptr Module::create(const std::string type,
     if (type == "Core") {
         throw std::runtime_error("creating another core module is forbidden");
     } else if (type == "Expander") {
-        Module::expect(arguments, 3, identifier, integer, integer);
+        if (arguments.size() < 1 || arguments.size() > 3) {
+            throw std::runtime_error("unexpected number of arguments");
+        }
+        Module::expect(arguments, -1, identifier, integer, integer);
         std::string serial_name = arguments[0]->evaluate_identifier();
         Module_ptr module = Global::get_module(serial_name);
         if (module->type != serial) {
             throw std::runtime_error("module \"" + serial_name + "\" is no serial connection");
         }
         const ConstSerial_ptr serial = std::static_pointer_cast<const Serial>(module);
-        const gpio_num_t boot_pin = (gpio_num_t)arguments[1]->evaluate_integer();
-        const gpio_num_t enable_pin = (gpio_num_t)arguments[2]->evaluate_integer();
+        const gpio_num_t boot_pin = arguments.size() > 1 ? (gpio_num_t)arguments[1]->evaluate_integer() : GPIO_NUM_MAX;
+        const gpio_num_t enable_pin = arguments.size() > 2 ? (gpio_num_t)arguments[2]->evaluate_integer() : GPIO_NUM_MAX;
         return std::make_shared<Expander>(name, serial, boot_pin, enable_pin, message_handler);
     } else if (type == "Bluetooth") {
         Module::expect(arguments, 1, string);

--- a/main/modules/module.cpp
+++ b/main/modules/module.cpp
@@ -74,8 +74,8 @@ Module_ptr Module::create(const std::string type,
             throw std::runtime_error("module \"" + serial_name + "\" is no serial connection");
         }
         const ConstSerial_ptr serial = std::static_pointer_cast<const Serial>(module);
-        const gpio_num_t boot_pin = arguments.size() > 1 ? (gpio_num_t)arguments[1]->evaluate_integer() : GPIO_NUM_MAX;
-        const gpio_num_t enable_pin = arguments.size() > 2 ? (gpio_num_t)arguments[2]->evaluate_integer() : GPIO_NUM_MAX;
+        const gpio_num_t boot_pin = arguments.size() > 1 ? (gpio_num_t)arguments[1]->evaluate_integer() : GPIO_NUM_NC;
+        const gpio_num_t enable_pin = arguments.size() > 2 ? (gpio_num_t)arguments[2]->evaluate_integer() : GPIO_NUM_NC;
         return std::make_shared<Expander>(name, serial, boot_pin, enable_pin, message_handler);
     } else if (type == "Bluetooth") {
         Module::expect(arguments, 1, string);

--- a/main/modules/module.cpp
+++ b/main/modules/module.cpp
@@ -64,7 +64,7 @@ Module_ptr Module::create(const std::string type,
     if (type == "Core") {
         throw std::runtime_error("creating another core module is forbidden");
     } else if (type == "Expander") {
-        if (arguments.size() < 1 || arguments.size() > 3) {
+        if (arguments.size() != 1 && arguments.size() != 3) {
             throw std::runtime_error("unexpected number of arguments");
         }
         Module::expect(arguments, -1, identifier, integer, integer);


### PR DESCRIPTION
I've changed the expander, so I can run without a boot and enable pin set. You can't use `expander.flash()` anymore, but the rest of the functionality is the same.

---

Feature request: #54