### PR TITLE
Expander flash() working again.

### DIFF
--- a/main/utils/serial-replicator.cpp
+++ b/main/utils/serial-replicator.cpp
@@ -7,10 +7,12 @@
 #include <esp_err.h>
 #include <esp_flash_partitions.h>
 #include <esp_log.h>
+#include <esp_ota_ops.h>
 #include <esp_spi_flash.h>
 
 #include <esp32_port.h>
 #include <esp_loader.h>
+#include <esp_partition.h>
 
 namespace ZZ::Replicator {
 
@@ -107,7 +109,7 @@ public:
 
 /* parses the partition table to determine extents of image to flash.
  * based on github.com/espressif/esp-idf/blob/v4.4/components/spi_flash/partition.c#L164 */
-static auto getUsedFlashSize(uint32_t &usedSize) -> esp_err_t {
+static auto getUsedFlashSize(const esp_partition_t *partition, uint32_t &usedSize) -> esp_err_t {
     const void *ptr;
     spi_flash_mmap_handle_t handle;
     esp_err_t ec;
@@ -132,7 +134,10 @@ static auto getUsedFlashSize(uint32_t &usedSize) -> esp_err_t {
         ESP_LOGD(TAG, "Visiting partition: [%*.s] [%X/%X]", sizeof(partitionPtr->label),
                  partitionPtr->label, partitionPtr->pos.offset, partitionPtr->pos.size);
 
-        usedSize = partitionPtr->pos.offset + partitionPtr->pos.size;
+        if (partitionPtr->pos.offset == partition->address) {
+            usedSize = partitionPtr->pos.offset + partitionPtr->pos.size;
+            break;
+        }
     }
 
     return ESP_OK;
@@ -236,8 +241,14 @@ auto flashReplica(const uart_port_t uart_num,
         return false;
     }
 
+    const esp_partition_t *running_partition = esp_ota_get_running_partition();
+    if (running_partition == nullptr) {
+        ESP_LOGE(TAG, "Failed to find OTA partition");
+        return false;
+    }
+
     uint32_t usedSize;
-    esp_err_t ec{getUsedFlashSize(usedSize)};
+    esp_err_t ec{getUsedFlashSize(running_partition, usedSize)};
 
     HANDLE_ESP_ERROR(ec, "querying used flash size");
 

--- a/main/utils/serial-replicator.cpp
+++ b/main/utils/serial-replicator.cpp
@@ -128,6 +128,7 @@ static auto getUsedFlashSize(const esp_partition_t *partition, uint32_t &usedSiz
 
     auto partitionPtr{reinterpret_cast<const esp_partition_info_t *>(bytePtr)};
     usedSize = 0;
+    // todo kann ich NICHT DIE WERTE NEHMEN, DIE ICH DA AUCH PRNINTE?
 
     /* walk all partition entries */
     for (; partitionPtr->magic == ESP_PARTITION_MAGIC; ++partitionPtr) {
@@ -135,7 +136,7 @@ static auto getUsedFlashSize(const esp_partition_t *partition, uint32_t &usedSiz
                  partitionPtr->label, partitionPtr->pos.offset, partitionPtr->pos.size);
 
         if (partitionPtr->pos.offset == partition->address) {
-            usedSize = partitionPtr->pos.offset + partitionPtr->pos.size;
+            usedSize = partitionPtr->pos.size;
             break;
         }
     }
@@ -247,12 +248,18 @@ auto flashReplica(const uart_port_t uart_num,
         return false;
     }
 
+    ESP_LOGI(TAG, "Running partition: [%s] [%X/%X]", running_partition->label, running_partition->address, running_partition->size);
+
     uint32_t usedSize;
     esp_err_t ec{getUsedFlashSize(running_partition, usedSize)};
 
+    uint32_t usedSize_test;
+    // get used flash size from running partition
+    usedSize_test = running_partition->size;
+
     HANDLE_ESP_ERROR(ec, "querying used flash size");
 
-    if (!flash(usedSize, block_size)) {
+    if (!flash(usedSize_test, block_size)) {
         return false;
     }
 

--- a/main/utils/serial-replicator.cpp
+++ b/main/utils/serial-replicator.cpp
@@ -213,16 +213,12 @@ auto flashReplica(const uart_port_t uart_num,
 
     ESP_LOGI(TAG, "Running partition: [%s] adress: [%X] size: [%X]", running_partition->label, running_partition->address, running_partition->size);
 
-    uint32_t usedSize_test = 0;
-    // get used flash size from running partition
-    usedSize_test = running_partition->size;
-
-    if (usedSize_test == 0) {
+    if (running_partition->size == 0) {
         ESP_LOGE(TAG, "Failed to determine used flash size");
         return false;
     }
 
-    if (!flash(usedSize_test, block_size)) {
+    if (!flash(running_partition->size, block_size)) {
         return false;
     }
 


### PR DESCRIPTION
Updated the `expander.flash()` functionality to work with OTA.
Tested in all 4 possible active ota partition combinations.

---
Issue: #53 