### PR TITLE
Expander last_message_age property.

### DIFF
--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -653,6 +653,10 @@ The `disconnect()` method might be useful to access the other microcontroller on
 
 Note that the expander forwards all other method calls to the remote core module, e.g. `expander.info()`.
 
+| Properties         | Description                                             | Data type |
+| ------------------ | ------------------------------------------------------- | --------- |
+| `last_message_age` | Time since last message from other microcontroller (ms) | `int`     |
+
 ## Proxy
 
 -- _This module is mainly for internal use with the expander module._ --

--- a/main/modules/expander.cpp
+++ b/main/modules/expander.cpp
@@ -12,7 +12,6 @@ Expander::Expander(const std::string name,
                    const gpio_num_t enable_pin,
                    MessageHandler message_handler)
     : Module(expander, name), serial(serial), boot_pin(boot_pin), enable_pin(enable_pin), message_handler(message_handler) {
-    
     this->properties["last_message_age"] = std::make_shared<IntegerVariable>();
 
     serial->enable_line_detection();
@@ -48,16 +47,13 @@ void Expander::step() {
     while (this->serial->has_buffered_lines()) {
         int len = this->serial->read_line(buffer);
         check(buffer, len);
+        this->last_message_millis = millis();
         if (buffer[0] == '!' && buffer[1] == '!') {
-            /* Update expander last_message_millis */
-            this->last_message_millis = millis();
-            /* Don't trigger core keep-alive from expander updates */
-            this->message_handler(&buffer[2], false, true);
+            this->message_handler(&buffer[2], false, true); // Don't trigger core keep-alive from expander broadcasts
         } else {
             echo("%s: %s", this->name.c_str(), buffer);
         }
     }
-    /* Update last_message_age property */
     this->properties.at("last_message_age")->integer_value = millis_since(this->last_message_millis);
     Module::step();
 }

--- a/main/modules/expander.cpp
+++ b/main/modules/expander.cpp
@@ -12,6 +12,9 @@ Expander::Expander(const std::string name,
                    const gpio_num_t enable_pin,
                    MessageHandler message_handler)
     : Module(expander, name), serial(serial), boot_pin(boot_pin), enable_pin(enable_pin), message_handler(message_handler) {
+    
+    this->properties["last_message_age"] = std::make_shared<IntegerVariable>();
+
     serial->enable_line_detection();
     if (boot_pin != GPIO_NUM_NC && enable_pin != GPIO_NUM_NC) {
         gpio_reset_pin(boot_pin);
@@ -46,12 +49,16 @@ void Expander::step() {
         int len = this->serial->read_line(buffer);
         check(buffer, len);
         if (buffer[0] == '!' && buffer[1] == '!') {
-            /* Don't trigger keep-alive from expander updates */
+            /* Update expander last_message_millis */
+            this->last_message_millis = millis();
+            /* Don't trigger core keep-alive from expander updates */
             this->message_handler(&buffer[2], false, true);
         } else {
             echo("%s: %s", this->name.c_str(), buffer);
         }
     }
+    /* Update last_message_age property */
+    this->properties.at("last_message_age")->integer_value = millis_since(this->last_message_millis);
     Module::step();
 }
 

--- a/main/modules/expander.h
+++ b/main/modules/expander.h
@@ -8,6 +8,9 @@ class Expander;
 using Expander_ptr = std::shared_ptr<Expander>;
 
 class Expander : public Module {
+private:
+    unsigned long int last_message_millis = 0;
+
 public:
     const ConstSerial_ptr serial;
     const gpio_num_t boot_pin;


### PR DESCRIPTION
Hello,

This change enables one to write rules or higher level controls which are dependent on wether or not the expander actually transmits data.
This could be used for motor-movement based on sensor data from a sensor on an expander, where communication could fail or is highly time-critical.
