### PR TITLE
Update PWM output frequency to 2000 Hz

### DIFF
--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -113,7 +113,7 @@ The PWM output module is associated with a digital output pin that is connected 
 | Properties         | Description                              | Data type |
 | ------------------ | ---------------------------------------- | --------- |
 | `output.duty`      | Duty cycle (8 bit: 0..256, default: 128) | `int`     |
-| `output.frequency` | Frequency (Hz, default: 1000)            | `int`     |
+| `output.frequency` | Frequency (Hz, default: 2000)            | `int`     |
 
 | Methods        | Description             | Arguments |
 | -------------- | ----------------------- | --------- |

--- a/main/modules/pwm_output.cpp
+++ b/main/modules/pwm_output.cpp
@@ -8,7 +8,7 @@ PwmOutput::PwmOutput(const std::string name,
     : Module(pwm_output, name), pin(pin), ledc_timer(ledc_timer), ledc_channel(ledc_channel) {
     gpio_reset_pin(pin);
 
-    this->properties["frequency"] = std::make_shared<IntegerVariable>(1000);
+    this->properties["frequency"] = std::make_shared<IntegerVariable>(2000);
     this->properties["duty"] = std::make_shared<IntegerVariable>(128);
 
     ledc_timer_config_t timer_config = {


### PR DESCRIPTION
When testing on the Fieldfriend we noticed some flickering in the PWM on lower duty cycles. When increasing the Frequency this does not happen anymore.