### PR TITLE
Expander improvements II

### DIFF
--- a/main/modules/core.cpp
+++ b/main/modules/core.cpp
@@ -163,6 +163,9 @@ void Core::call(const std::string method_name, const std::vector<ConstExpression
             echo("Not a strapping pin");
             break;
         }
+    } else if (method_name == "is_alive") {
+        Module::expect(arguments, 0);
+        echo("lizard is alive");
     } else {
         Module::call(method_name, arguments);
     }

--- a/main/modules/expander.h
+++ b/main/modules/expander.h
@@ -9,16 +9,12 @@ using Expander_ptr = std::shared_ptr<Expander>;
 
 class Expander : public Module {
 private:
-    unsigned long int last_message_millis = 0;
-
     enum BootState {
         BOOT_INIT,
         BOOT_WAITING,
         BOOT_RESTARTING,
         BOOT_READY
     };
-    BootState boot_state;
-    unsigned long boot_start_time;
 
     struct PendingProxy {
         std::string module_name;
@@ -26,10 +22,21 @@ private:
         std::vector<ConstExpression_ptr> arguments;
         bool is_setup = false;
     };
+
+    unsigned long int last_message_millis = 0;
+    bool heartbeat_request_pending = false;
+    unsigned long heartbeat_request_time = 0;
+    BootState boot_state;
+    unsigned long boot_start_time;
     std::vector<PendingProxy> pending_proxies;
+
+    static constexpr unsigned long HEARTBEAT_TIMEOUT_MS = 30000;         // 30 seconds
+    static constexpr unsigned long HEARTBEAT_RESPONSE_TIMEOUT_MS = 5000; // 5 seconds
 
     void handle_boot_process();
     void setup_proxy(const PendingProxy &proxy);
+    void handle_heartbeat();
+    void prepare_restart();
 
 public:
     const ConstSerial_ptr serial;

--- a/main/modules/expander.h
+++ b/main/modules/expander.h
@@ -13,6 +13,7 @@ private:
         BOOT_INIT,
         BOOT_WAITING,
         BOOT_RESTARTING,
+        BOOT_SETTING_UP_PROXIES,
         BOOT_READY
     };
 

--- a/main/modules/expander.h
+++ b/main/modules/expander.h
@@ -26,12 +26,11 @@ private:
 
     unsigned long int last_message_millis = 0;
     bool heartbeat_request_pending = false;
-    unsigned long heartbeat_request_time = 0;
     BootState boot_state;
     unsigned long boot_start_time;
     std::vector<PendingProxy> pending_proxies;
 
-    static constexpr unsigned long HEARTBEAT_TIMEOUT_MS = 30000;         // 30 seconds
+    static constexpr unsigned long HEARTBEAT_TIMEOUT_MS = 10000;         // 10 seconds
     static constexpr unsigned long HEARTBEAT_RESPONSE_TIMEOUT_MS = 5000; // 5 seconds
 
     void handle_boot_process();

--- a/main/modules/proxy.cpp
+++ b/main/modules/proxy.cpp
@@ -9,15 +9,8 @@ Proxy::Proxy(const std::string name,
              const Expander_ptr expander,
              const std::vector<ConstExpression_ptr> arguments)
     : Module(proxy, name), expander(expander) {
-    this->properties["is_ready"] = std::make_shared<BooleanVariable>(false);
+    this->properties["is_ready"] = expander->get_property("is_ready");
     expander->add_proxy(name, module_type, arguments);
-}
-
-void Proxy::step() {
-    // Update proxy's ready state based on expander's state
-    this->properties.at("is_ready")->boolean_value =
-        expander->get_property("is_ready")->boolean_value;
-    Module::step();
 }
 
 void Proxy::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {

--- a/main/modules/proxy.cpp
+++ b/main/modules/proxy.cpp
@@ -13,6 +13,13 @@ Proxy::Proxy(const std::string name,
     expander->add_proxy(name, module_type, arguments);
 }
 
+void Proxy::step() {
+    // Update proxy's ready state based on expander's state
+    this->properties.at("is_ready")->boolean_value =
+        expander->get_property("is_ready")->boolean_value;
+    Module::step();
+}
+
 void Proxy::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
     static char buffer[256];
     int pos = csprintf(buffer, sizeof(buffer), "%s.%s(", this->name.c_str(), method_name.c_str());
@@ -24,7 +31,6 @@ void Proxy::call(const std::string method_name, const std::vector<ConstExpressio
 void Proxy::write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) {
     if (!this->properties.count(property_name)) {
         this->properties[property_name] = std::make_shared<Variable>(expression->type);
-        this->properties.at("is_ready")->boolean_value = true;
     }
     if (!from_expander) {
         static char buffer[256];

--- a/main/modules/proxy.h
+++ b/main/modules/proxy.h
@@ -15,5 +15,4 @@ public:
           const std::vector<ConstExpression_ptr> arguments);
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;
-    void step() override;
 };

--- a/main/modules/proxy.h
+++ b/main/modules/proxy.h
@@ -15,4 +15,5 @@ public:
           const std::vector<ConstExpression_ptr> arguments);
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;
+    void step() override;
 };


### PR DESCRIPTION
This will handle the 2nd update from the #18.  With this change, the expander module will be able to detect a crash within the expander esp32. It will then unready itself until the expander esp32 is responding again.
Also, the handling of proxies is changed. Proxy initialization is tied to the expander module's state, and the proxy itself will update its ready flag based on the expander.

- [x] added heartbeat handling
- [x] possible to change is_ready on esp crash (expander & proxy)
- [x] change initialization of proxies (state)
- [x] Update is_ready of proxy with step
- [x] Testing everything