### PR TITLE
Check relevant pins for p0.flash()

### DIFF
--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -691,7 +691,8 @@ The expander module allows communication with another microcontroller connected 
 | `expander.flash([force])` | Flash other microcontroller with own binary data | `bool`    |
 | `expander.restart()`      | Restart other microcontroller                    |           |
 
-The `flash()` method requires the `boot` and `enable` pins to be defined. The optional `force` argument skips the check for strapping pins.
+The `flash()` method requires the `boot` and `enable` pins to be defined.
+The optional `force` argument skips the default check whether certain strapping pins are set correctly.
 
 The `disconnect()` method might be useful to access the other microcontroller on UART0 via USB while still being physically connected to the main microcontroller.
 

--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -684,14 +684,14 @@ The expander module allows communication with another microcontroller connected 
 | --------------------------------------------- | ---------------------------------- | ----------------------- |
 | `expander = Expander(serial[, boot, enable])` | Serial module and boot/enable pins | Serial module, 2x `int` |
 
-| Methods                 | Description                                      | Arguments |
-| ----------------------- | ------------------------------------------------ | --------- |
-| `expander.run(command)` | Run any `command` on the other microcontroller   | `string`  |
-| `expander.disconnect()` | Disconnect serial connection and pins            |           |
-| `expander.flash()`      | Flash other microcontroller with own binary data |           |
-| `expander.restart()`    | Restart other microcontroller                    |           |
+| Methods                   | Description                                      | Arguments |
+| ------------------------- | ------------------------------------------------ | --------- |
+| `expander.run(command)`   | Run any `command` on the other microcontroller   | `string`  |
+| `expander.disconnect()`   | Disconnect serial connection and pins            |           |
+| `expander.flash([force])` | Flash other microcontroller with own binary data | `bool`    |
+| `expander.restart()`      | Restart other microcontroller                    |           |
 
-The `flash()` method requires the `boot` and `enable` pins to be defined.
+The `flash()` method requires the `boot` and `enable` pins to be defined. The optional `force` argument skips the check for strapping pins.
 
 The `disconnect()` method might be useful to access the other microcontroller on UART0 via USB while still being physically connected to the main microcontroller.
 

--- a/main/modules/expander.cpp
+++ b/main/modules/expander.cpp
@@ -166,6 +166,9 @@ void Expander::call(const std::string method_name, const std::vector<ConstExpres
         Module::expect(arguments, 0);
         deinstall();
     } else if (method_name == "flash") {
+        if (arguments.size() > 1) {
+            throw std::runtime_error("unexpected number of arguments");
+        }
         Module::expect(arguments, -1, boolean);
         bool force = arguments.size() > 0 ? arguments[0]->evaluate_boolean() : false;
         if (this->boot_pin == GPIO_NUM_NC || this->enable_pin == GPIO_NUM_NC) {

--- a/main/modules/expander.cpp
+++ b/main/modules/expander.cpp
@@ -177,6 +177,8 @@ void Expander::call(const std::string method_name, const std::vector<ConstExpres
             throw std::runtime_error("expander \"" + this->name + "\" does not support flashing, pins not set");
         }
         Storage::clear_nvs();
+        gpio_set_level(this->boot_pin, 0);
+        check_strapping_pins();
         this->serial->deinstall();
         bool success = ZZ::Replicator::flashReplica(this->serial->uart_num,
                                                     this->enable_pin,
@@ -194,5 +196,58 @@ void Expander::call(const std::string method_name, const std::vector<ConstExpres
         pos += write_arguments_to_buffer(arguments, &buffer[pos], sizeof(buffer) - pos);
         pos += csprintf(&buffer[pos], sizeof(buffer) - pos, ")");
         this->serial->write_checked_line(buffer, pos);
+    }
+}
+
+void Expander::check_strapping_pins() {
+    if (this->boot_pin == GPIO_NUM_NC || this->enable_pin == GPIO_NUM_NC) {
+        throw std::runtime_error("expander \"" + this->name + "\" does not support strapping pin check, pins not set");
+    }
+    this->serial->write_checked_line("core.get_pin_status(0)");
+    this->serial->write_checked_line("core.get_pin_status(2)");
+    this->serial->write_checked_line("core.get_pin_status(12)");
+
+    delay(100);
+
+    static char buffer[1024];
+    while (this->serial->has_buffered_lines()) {
+        int len = this->serial->read_line(buffer, sizeof(buffer));
+        check(buffer, len);
+        handle_pin_status(buffer);
+        this->last_message_millis = millis();
+        this->ping_pending = false;
+        echo("%s: %s", this->name.c_str(), buffer);
+    }
+}
+
+// We only need to check GPIO0, GPIO2 and GPIO12 states because they directly influence boot mode and flash voltage selection,
+// ensuring correct operation during boot and flashing. These are not directly controllable by the expander.
+void Expander::handle_pin_status(const char *buffer) {
+
+    if (strstr(buffer, "GPIO_Status[12]|") != nullptr) {
+        int level;
+        if (sscanf(buffer, "GPIO_Status[12]| Level: %d", &level) == 1) {
+            if (level != 0) {
+                echo("warning: GPIO12 state is HIGH, this can cause issues with flash voltage selection");
+            }
+        }
+    }
+
+    if (strstr(buffer, "GPIO_Status[0]|") != nullptr) {
+        int level;
+        if (sscanf(buffer, "GPIO_Status[0]| Level: %d", &level) == 1) {
+            if (level != 0) {
+                throw std::runtime_error("GPIO0 current state is HIGH - must be LOW for boot mode");
+            }
+        }
+    }
+
+    if (strstr(buffer, "GPIO_Status[2]|") != nullptr) {
+        int level;
+        if (sscanf(buffer, "GPIO_Status[2]| Level: %d", &level) == 1) {
+            if (level == 1) {
+                throw std::runtime_error("GPIO2 current state is HIGH - must be LOW or floating for flash mode");
+            }
+        }
     }
 }

--- a/main/modules/expander.h
+++ b/main/modules/expander.h
@@ -24,10 +24,9 @@ private:
     void check_boot_progress();
     void ping();
     void restart();
-    void handle_messages();
+    void handle_messages(bool check_for_strapping_pins = false);
     void setup_proxy(ProxyInformation &proxy);
-    void check_strapping_pins();
-    void handle_pin_status(const char *buffer);
+    void check_strapping_pins(const char *buffer);
 
 public:
     const ConstSerial_ptr serial;

--- a/main/modules/expander.h
+++ b/main/modules/expander.h
@@ -26,6 +26,8 @@ private:
     void restart();
     void handle_messages();
     void setup_proxy(ProxyInformation &proxy);
+    void check_strapping_pins();
+    void handle_pin_status(const char *buffer);
 
 public:
     const ConstSerial_ptr serial;

--- a/main/modules/expander.h
+++ b/main/modules/expander.h
@@ -21,6 +21,7 @@ private:
     unsigned long boot_start_time;
     std::vector<ProxyInformation> proxies;
 
+    void deinstall();
     void check_boot_progress();
     void ping();
     void restart();


### PR DESCRIPTION
This is for #75
----
Before flashing, the p0.flash() call will set the GPIO0 to the correct state and check GPIO2 and GPIO12 on the p0 for their states. 
GPIO0 and 2 are responsible for booting to the bootloader upon restart. 
GPIO12 on low sets the flash voltage to 3.3V. On high, which sets it to 1.8V, it can cause issues when flashing.

The strapping register itself does not need to be checked in that stage of flashing. Since the configuration after the restart would be the relevant one, but then the p0 would be in bootloader mode, which we would not have to check and could not check.