### PR TITLE
Property assignment fix

### DIFF
--- a/main/modules/analog.cpp
+++ b/main/modules/analog.cpp
@@ -6,12 +6,11 @@
 #include "freertos/task.h"
 #include "uart.h"
 
-const std::map<std::string, Variable_ptr> &Analog::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> Analog::get_defaults() {
+    return {
         {"raw", std::make_shared<IntegerVariable>()},
         {"voltage", std::make_shared<NumberVariable>()},
     };
-    return defaults;
 }
 
 Analog::Analog(const std::string name, uint8_t unit, uint8_t channel, float attenuation_level)

--- a/main/modules/analog.h
+++ b/main/modules/analog.h
@@ -17,5 +17,5 @@ private:
 public:
     Analog(const std::string name, uint8_t unit, uint8_t channel, float attenuation_level);
     void step() override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/bluetooth.cpp
+++ b/main/modules/bluetooth.cpp
@@ -1,9 +1,8 @@
 #include "bluetooth.h"
 #include "uart.h"
 
-const std::map<std::string, Variable_ptr> &Bluetooth::get_defaults() {
-    static std::map<std::string, Variable_ptr> defaults = {};
-    return defaults;
+const std::map<std::string, Variable_ptr> Bluetooth::get_defaults() {
+    return {};
 }
 
 Bluetooth::Bluetooth(const std::string name, const std::string device_name, MessageHandler message_handler)

--- a/main/modules/bluetooth.h
+++ b/main/modules/bluetooth.h
@@ -16,5 +16,5 @@ public:
     Bluetooth(const std::string name, const std::string device_name, MessageHandler message_handler);
 
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/can.cpp
+++ b/main/modules/can.cpp
@@ -4,8 +4,8 @@
 #include "driver/twai.h"
 #include <stdexcept>
 
-const std::map<std::string, Variable_ptr> &Can::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> Can::get_defaults() {
+    return {
         {"state", std::make_shared<StringVariable>()},
         {"tx_error_counter", std::make_shared<IntegerVariable>()},
         {"rx_error_counter", std::make_shared<IntegerVariable>()},
@@ -17,7 +17,6 @@ const std::map<std::string, Variable_ptr> &Can::get_defaults() {
         {"arb_lost_count", std::make_shared<IntegerVariable>()},
         {"bus_error_count", std::make_shared<IntegerVariable>()},
     };
-    return defaults;
 }
 
 Can::Can(const std::string name, const gpio_num_t rx_pin, const gpio_num_t tx_pin, const long baud_rate)

--- a/main/modules/can.h
+++ b/main/modules/can.h
@@ -15,7 +15,7 @@ public:
     Can(const std::string name, const gpio_num_t rx_pin, const gpio_num_t tx_pin, const long baud_rate);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
 
     bool receive();
     void send(const uint32_t id, const uint8_t data[8], const bool rtr = false, const uint8_t dlc = 8) const;

--- a/main/modules/canopen_master.cpp
+++ b/main/modules/canopen_master.cpp
@@ -1,10 +1,9 @@
 #include "canopen_master.h"
 
-const std::map<std::string, Variable_ptr> &CanOpenMaster::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> CanOpenMaster::get_defaults() {
+    return {
         {"sync_interval", std::make_shared<IntegerVariable>(0)},
     };
-    return defaults;
 }
 
 CanOpenMaster::CanOpenMaster(const std::string &name, const Can_ptr can)

--- a/main/modules/canopen_master.h
+++ b/main/modules/canopen_master.h
@@ -14,5 +14,5 @@ private:
 public:
     CanOpenMaster(const std::string &name, const Can_ptr can);
     void step() override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/canopen_motor.cpp
+++ b/main/modules/canopen_motor.cpp
@@ -47,8 +47,8 @@ static const std::string PROP_PV_IS_MOVING{"pv_is_moving"};
 static const std::string PROP_CTRL_ENA_OP{"ctrl_enable"};
 static const std::string PROP_CTRL_HALT{"ctrl_halt"};
 
-const std::map<std::string, Variable_ptr> &CanOpenMotor::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> CanOpenMotor::get_defaults() {
+    return {
         {PROP_INITIALIZED, std::make_shared<BooleanVariable>(false)},
         {PROP_PENDING_READS, std::make_shared<IntegerVariable>(0)},
         {PROP_PENDING_WRITES, std::make_shared<IntegerVariable>(0)},
@@ -68,7 +68,6 @@ const std::map<std::string, Variable_ptr> &CanOpenMotor::get_defaults() {
         {PROP_CTRL_ENA_OP, std::make_shared<BooleanVariable>(false)},
         {PROP_CTRL_HALT, std::make_shared<BooleanVariable>(true)},
     };
-    return defaults;
 }
 
 CanOpenMotor::CanOpenMotor(const std::string &name, Can_ptr can, int64_t node_id)

--- a/main/modules/canopen_motor.h
+++ b/main/modules/canopen_motor.h
@@ -58,7 +58,7 @@ public:
     void subscribe_to_can();
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     void handle_can_msg(const uint32_t id, const int count, const uint8_t *const data) override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
 
     void stop() override;
     double get_position() override;

--- a/main/modules/d1_motor.cpp
+++ b/main/modules/d1_motor.cpp
@@ -4,8 +4,8 @@
 #include "utils/timing.h"
 #include <cinttypes>
 
-const std::map<std::string, Variable_ptr> &D1Motor::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> D1Motor::get_defaults() {
+    return {
         {"switch_search_speed", std::make_shared<IntegerVariable>()},
         {"zero_search_speed", std::make_shared<IntegerVariable>()},
         {"homing_acceleration", std::make_shared<IntegerVariable>()},
@@ -17,7 +17,6 @@ const std::map<std::string, Variable_ptr> &D1Motor::get_defaults() {
         {"status_word", std::make_shared<IntegerVariable>(-1)},
         {"status_flags", std::make_shared<IntegerVariable>()},
     };
-    return defaults;
 }
 
 D1Motor::D1Motor(const std::string &name, Can_ptr can, int64_t node_id)

--- a/main/modules/d1_motor.h
+++ b/main/modules/d1_motor.h
@@ -26,7 +26,7 @@ public:
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     void step() override;
     void handle_can_msg(const uint32_t id, const int count, const uint8_t *const data) override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
     void setup();
     void home();
     void profile_position(const int32_t position);

--- a/main/modules/dunker_motor.cpp
+++ b/main/modules/dunker_motor.cpp
@@ -4,13 +4,12 @@
 #include "utils/timing.h"
 #include <cinttypes>
 
-const std::map<std::string, Variable_ptr> &DunkerMotor::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> DunkerMotor::get_defaults() {
+    return {
         {"speed", std::make_shared<NumberVariable>()},
         {"m_per_turn", std::make_shared<NumberVariable>(1.0)},
         {"reversed", std::make_shared<BooleanVariable>()},
     };
-    return defaults;
 }
 
 DunkerMotor::DunkerMotor(const std::string &name, Can_ptr can, int64_t node_id)

--- a/main/modules/dunker_motor.h
+++ b/main/modules/dunker_motor.h
@@ -25,7 +25,7 @@ public:
     void subscribe_to_can();
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     void handle_can_msg(const uint32_t id, const int count, const uint8_t *const data) override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
     void speed(const double speed);
     double get_speed();
 };

--- a/main/modules/dunker_wheels.cpp
+++ b/main/modules/dunker_wheels.cpp
@@ -1,13 +1,12 @@
 #include "dunker_wheels.h"
 #include <memory>
 
-const std::map<std::string, Variable_ptr> &DunkerWheels::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> DunkerWheels::get_defaults() {
+    return {
         {"width", std::make_shared<NumberVariable>(1.0)},
         {"linear_speed", std::make_shared<NumberVariable>()},
         {"angular_speed", std::make_shared<NumberVariable>()},
     };
-    return defaults;
 }
 
 DunkerWheels::DunkerWheels(const std::string name, const DunkerMotor_ptr left_motor, const DunkerMotor_ptr right_motor)

--- a/main/modules/dunker_wheels.h
+++ b/main/modules/dunker_wheels.h
@@ -12,5 +12,5 @@ public:
     DunkerWheels(const std::string name, const DunkerMotor_ptr left_motor, const DunkerMotor_ptr right_motor);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/expander.cpp
+++ b/main/modules/expander.cpp
@@ -9,14 +9,14 @@
 #include <cstring>
 #include <stdexcept>
 
-const std::map<std::string, Variable_ptr> &Expander::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> Expander::get_defaults() {
+    return {
         {"boot_timeout", std::make_shared<NumberVariable>(5.0)},
         {"ping_interval", std::make_shared<NumberVariable>(1.0)},
         {"ping_timeout", std::make_shared<NumberVariable>(2.0)},
         {"is_ready", std::make_shared<BooleanVariable>(false)},
-        {"last_message_age", std::make_shared<IntegerVariable>(0)}};
-    return defaults;
+        {"last_message_age", std::make_shared<IntegerVariable>(0)},
+    };
 }
 
 Expander::Expander(const std::string name,

--- a/main/modules/expander.h
+++ b/main/modules/expander.h
@@ -45,5 +45,5 @@ public:
     void add_proxy(const std::string module_name,
                    const std::string module_type,
                    const std::vector<ConstExpression_ptr> arguments);
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/imu.cpp
+++ b/main/modules/imu.cpp
@@ -4,8 +4,8 @@
 #define I2C_MASTER_TX_BUF_DISABLE 0
 #define I2C_MASTER_RX_BUF_DISABLE 0
 
-const std::map<std::string, Variable_ptr> &Imu::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> Imu::get_defaults() {
+    return {
         {"acc_x", std::make_shared<NumberVariable>()},
         {"acc_y", std::make_shared<NumberVariable>()},
         {"acc_z", std::make_shared<NumberVariable>()},
@@ -21,7 +21,6 @@ const std::map<std::string, Variable_ptr> &Imu::get_defaults() {
         {"cal_acc", std::make_shared<NumberVariable>()},
         {"cal_mag", std::make_shared<NumberVariable>()},
     };
-    return defaults;
 }
 
 Imu::Imu(const std::string name, i2c_port_t i2c_port, gpio_num_t sda_pin, gpio_num_t scl_pin, uint8_t address, int clk_speed)

--- a/main/modules/imu.h
+++ b/main/modules/imu.h
@@ -18,5 +18,5 @@ private:
 public:
     Imu(const std::string name, i2c_port_t i2c_port, gpio_num_t sda_pin, gpio_num_t scl_pin, uint8_t address, int clk_speed);
     void step() override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/input.cpp
+++ b/main/modules/input.cpp
@@ -4,14 +4,13 @@
 #include <memory>
 #include <stdexcept>
 
-const std::map<std::string, Variable_ptr> &Input::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> Input::get_defaults() {
+    return {
         {"level", std::make_shared<IntegerVariable>()},
         {"change", std::make_shared<IntegerVariable>()},
         {"inverted", std::make_shared<BooleanVariable>()},
         {"active", std::make_shared<BooleanVariable>()},
     };
-    return defaults;
 }
 
 Input::Input(const std::string name) : Module(input, name) {

--- a/main/modules/input.h
+++ b/main/modules/input.h
@@ -17,8 +17,7 @@ protected:
 public:
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
-
+    static const std::map<std::string, Variable_ptr> get_defaults();
     std::string get_output() const override;
     virtual bool get_level() const = 0;
 };

--- a/main/modules/linear_motor.cpp
+++ b/main/modules/linear_motor.cpp
@@ -1,12 +1,11 @@
 #include "linear_motor.h"
 #include <memory>
 
-const std::map<std::string, Variable_ptr> &LinearMotor::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> LinearMotor::get_defaults() {
+    return {
         {"in", std::make_shared<BooleanVariable>()},
         {"out", std::make_shared<BooleanVariable>()},
     };
-    return defaults;
 }
 
 LinearMotor::LinearMotor(const std::string name) : Module(output, name) {

--- a/main/modules/linear_motor.h
+++ b/main/modules/linear_motor.h
@@ -17,7 +17,7 @@ protected:
 public:
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
 };
 
 class GpioLinearMotor : public LinearMotor {

--- a/main/modules/mcp23017.cpp
+++ b/main/modules/mcp23017.cpp
@@ -4,13 +4,12 @@
 #define I2C_MASTER_TX_BUF_DISABLE 0
 #define I2C_MASTER_RX_BUF_DISABLE 0
 
-const std::map<std::string, Variable_ptr> &Mcp23017::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> Mcp23017::get_defaults() {
+    return {
         {"levels", std::make_shared<IntegerVariable>()},
         {"inputs", std::make_shared<IntegerVariable>(0xffff)}, // default: all pins input
         {"pullups", std::make_shared<IntegerVariable>()},
     };
-    return defaults;
 }
 
 Mcp23017::Mcp23017(const std::string name, i2c_port_t i2c_port, gpio_num_t sda_pin, gpio_num_t scl_pin, uint8_t address, int clk_speed)

--- a/main/modules/mcp23017.h
+++ b/main/modules/mcp23017.h
@@ -31,7 +31,7 @@ public:
     Mcp23017(const std::string name, i2c_port_t i2c_port, gpio_num_t sda_pin, gpio_num_t scl_pin, uint8_t address, int clk_speed);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
 
     bool get_level(const uint8_t number) const;
     void set_level(const uint8_t number, const bool value) const;

--- a/main/modules/module.cpp
+++ b/main/modules/module.cpp
@@ -420,7 +420,7 @@ void Module::handle_can_msg(const uint32_t id, const int count, const uint8_t *d
     throw std::runtime_error("CAN message handler is not implemented");
 }
 
-const std::map<std::string, Variable_ptr> &Module::get_module_defaults(const std::string &type_name) {
+const std::map<std::string, Variable_ptr> Module::get_module_defaults(const std::string &type_name) {
     if (type_name == "Expander") {
         return Expander::get_defaults();
     } else if (type_name == "Input") {

--- a/main/modules/module.h
+++ b/main/modules/module.h
@@ -62,7 +62,7 @@ public:
                              MessageHandler message_handler);
     virtual void step();
     virtual void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments);
-    static const std::map<std::string, Variable_ptr> &get_module_defaults(const std::string &type_name);
+    static const std::map<std::string, Variable_ptr> get_module_defaults(const std::string &type_name);
     void call_with_shadows(const std::string method_name, const std::vector<ConstExpression_ptr> arguments);
     virtual std::string get_output() const;
     Variable_ptr get_property(const std::string property_name) const;

--- a/main/modules/motor_axis.cpp
+++ b/main/modules/motor_axis.cpp
@@ -2,9 +2,8 @@
 #include "utils/uart.h"
 #include <stdexcept>
 
-const std::map<std::string, Variable_ptr> &MotorAxis::get_defaults() {
-    static std::map<std::string, Variable_ptr> defaults = {};
-    return defaults;
+const std::map<std::string, Variable_ptr> MotorAxis::get_defaults() {
+    return {};
 }
 
 MotorAxis::MotorAxis(const std::string name, const Motor_ptr motor, const Input_ptr input1, const Input_ptr input2)

--- a/main/modules/motor_axis.h
+++ b/main/modules/motor_axis.h
@@ -15,5 +15,5 @@ public:
     MotorAxis(const std::string name, const Motor_ptr motor, const Input_ptr input1, const Input_ptr input2);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/odrive_motor.cpp
+++ b/main/modules/odrive_motor.cpp
@@ -2,8 +2,8 @@
 #include <cstring>
 #include <memory>
 
-const std::map<std::string, Variable_ptr> &ODriveMotor::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> ODriveMotor::get_defaults() {
+    return {
         {"position", std::make_shared<NumberVariable>()},
         {"speed", std::make_shared<NumberVariable>()},
         {"tick_offset", std::make_shared<NumberVariable>()},
@@ -13,7 +13,6 @@ const std::map<std::string, Variable_ptr> &ODriveMotor::get_defaults() {
         {"axis_error", std::make_shared<IntegerVariable>()},
         {"motor_error_flag", std::make_shared<IntegerVariable>()},
     };
-    return defaults;
 }
 
 ODriveMotor::ODriveMotor(const std::string name, const Can_ptr can, const uint32_t can_id, const uint32_t version)

--- a/main/modules/odrive_motor.h
+++ b/main/modules/odrive_motor.h
@@ -25,7 +25,7 @@ public:
     void subscribe_to_can();
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     void handle_can_msg(const uint32_t id, const int count, const uint8_t *const data) override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
     void power(const float torque);
     void speed(const float speed);
     void position(const float position);

--- a/main/modules/odrive_wheels.cpp
+++ b/main/modules/odrive_wheels.cpp
@@ -2,14 +2,13 @@
 #include "../utils/timing.h"
 #include <memory>
 
-const std::map<std::string, Variable_ptr> &ODriveWheels::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> ODriveWheels::get_defaults() {
+    return {
         {"width", std::make_shared<NumberVariable>(1.0)},
         {"linear_speed", std::make_shared<NumberVariable>()},
         {"angular_speed", std::make_shared<NumberVariable>()},
         {"enabled", std::make_shared<BooleanVariable>(true)},
     };
-    return defaults;
 }
 
 ODriveWheels::ODriveWheels(const std::string name, const ODriveMotor_ptr left_motor, const ODriveMotor_ptr right_motor)

--- a/main/modules/odrive_wheels.h
+++ b/main/modules/odrive_wheels.h
@@ -17,5 +17,5 @@ public:
     ODriveWheels(const std::string name, const ODriveMotor_ptr left_motor, const ODriveMotor_ptr right_motor);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/output.cpp
+++ b/main/modules/output.cpp
@@ -3,12 +3,11 @@
 #include <math.h>
 #include <stdexcept>
 
-const std::map<std::string, Variable_ptr> &Output::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> Output::get_defaults() {
+    return {
         {"level", std::make_shared<IntegerVariable>()},
         {"change", std::make_shared<IntegerVariable>()},
     };
-    return defaults;
 }
 
 Output::Output(const std::string name) : Module(output, name) {

--- a/main/modules/output.h
+++ b/main/modules/output.h
@@ -17,7 +17,7 @@ protected:
 public:
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
 };
 
 class GpioOutput : public Output {

--- a/main/modules/pwm_output.cpp
+++ b/main/modules/pwm_output.cpp
@@ -1,12 +1,11 @@
 #include "pwm_output.h"
 #include <driver/ledc.h>
 
-const std::map<std::string, Variable_ptr> &PwmOutput::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> PwmOutput::get_defaults() {
+    return {
         {"frequency", std::make_shared<IntegerVariable>(1000)},
         {"duty", std::make_shared<IntegerVariable>(128)},
     };
-    return defaults;
 }
 
 PwmOutput::PwmOutput(const std::string name,

--- a/main/modules/pwm_output.h
+++ b/main/modules/pwm_output.h
@@ -18,5 +18,5 @@ public:
               const ledc_channel_t ledc_channel);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/rmd_motor.cpp
+++ b/main/modules/rmd_motor.cpp
@@ -6,15 +6,14 @@
 #include <math.h>
 #include <memory>
 
-const std::map<std::string, Variable_ptr> &RmdMotor::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> RmdMotor::get_defaults() {
+    return {
         {"position", std::make_shared<NumberVariable>()},
         {"torque", std::make_shared<NumberVariable>()},
         {"speed", std::make_shared<NumberVariable>()},
         {"temperature", std::make_shared<NumberVariable>()},
         {"can_age", std::make_shared<NumberVariable>()},
     };
-    return defaults;
 }
 
 RmdMotor::RmdMotor(const std::string name, const Can_ptr can, const uint8_t motor_id, const int ratio)

--- a/main/modules/rmd_motor.h
+++ b/main/modules/rmd_motor.h
@@ -29,7 +29,7 @@ public:
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     void handle_can_msg(const uint32_t id, const int count, const uint8_t *const data) override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
 
     bool power(double target_power);
     bool speed(double target_speed);

--- a/main/modules/rmd_pair.cpp
+++ b/main/modules/rmd_pair.cpp
@@ -3,12 +3,11 @@
 #include "utils/uart.h"
 #include <math.h>
 
-const std::map<std::string, Variable_ptr> &RmdPair::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> RmdPair::get_defaults() {
+    return {
         {"v_max", std::make_shared<NumberVariable>(360)},
         {"a_max", std::make_shared<NumberVariable>(10000)},
     };
-    return defaults;
 }
 
 RmdPair::RmdPair(const std::string name, const RmdMotor_ptr rmd1, const RmdMotor_ptr rmd2)

--- a/main/modules/rmd_pair.h
+++ b/main/modules/rmd_pair.h
@@ -29,5 +29,5 @@ private:
 public:
     RmdPair(const std::string name, const RmdMotor_ptr rmd1, const RmdMotor_ptr rmd2);
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/roboclaw.cpp
+++ b/main/modules/roboclaw.cpp
@@ -5,11 +5,10 @@
 #define SetDWORDval(arg) (uint8_t)(((uint32_t)arg) >> 24), (uint8_t)(((uint32_t)arg) >> 16), (uint8_t)(((uint32_t)arg) >> 8), (uint8_t)arg
 #define SetWORDval(arg) (uint8_t)(((uint16_t)arg) >> 8), (uint8_t)arg
 
-const std::map<std::string, Variable_ptr> &RoboClaw::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> RoboClaw::get_defaults() {
+    return {
         {"temperature", std::make_shared<NumberVariable>()},
     };
-    return defaults;
 }
 
 RoboClaw::RoboClaw(const std::string name, const ConstSerial_ptr serial, const uint8_t address)

--- a/main/modules/roboclaw.h
+++ b/main/modules/roboclaw.h
@@ -117,7 +117,7 @@ class RoboClaw : public Module {
 public:
     RoboClaw(const std::string name, const ConstSerial_ptr serial, const uint8_t address);
     void step() override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
 
     bool ForwardM1(uint8_t speed);
     bool BackwardM1(uint8_t speed);

--- a/main/modules/roboclaw_motor.cpp
+++ b/main/modules/roboclaw_motor.cpp
@@ -4,11 +4,10 @@
 
 #define constrain(amt, low, high) ((amt) < (low) ? (low) : ((amt) > (high) ? (high) : (amt)))
 
-const std::map<std::string, Variable_ptr> &RoboClawMotor::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> RoboClawMotor::get_defaults() {
+    return {
         {"position", std::make_shared<IntegerVariable>()},
     };
-    return defaults;
 }
 
 RoboClawMotor::RoboClawMotor(const std::string name, const RoboClaw_ptr roboclaw, const unsigned int motor_number)

--- a/main/modules/roboclaw_motor.h
+++ b/main/modules/roboclaw_motor.h
@@ -15,7 +15,7 @@ public:
     RoboClawMotor(const std::string name, const RoboClaw_ptr roboclaw, const unsigned int motor_number);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
 
     int64_t get_position() const;
     void power(double value);

--- a/main/modules/roboclaw_wheels.cpp
+++ b/main/modules/roboclaw_wheels.cpp
@@ -2,15 +2,14 @@
 #include "../utils/timing.h"
 #include <memory>
 
-const std::map<std::string, Variable_ptr> &RoboClawWheels::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> RoboClawWheels::get_defaults() {
+    return {
         {"width", std::make_shared<NumberVariable>(1)},
         {"linear_speed", std::make_shared<NumberVariable>()},
         {"angular_speed", std::make_shared<NumberVariable>()},
         {"enabled", std::make_shared<BooleanVariable>(true)},
         {"m_per_tick", std::make_shared<NumberVariable>(1)},
     };
-    return defaults;
 }
 
 RoboClawWheels::RoboClawWheels(const std::string name, const RoboClawMotor_ptr left_motor, const RoboClawMotor_ptr right_motor)

--- a/main/modules/roboclaw_wheels.h
+++ b/main/modules/roboclaw_wheels.h
@@ -16,5 +16,5 @@ public:
     RoboClawWheels(const std::string name, const RoboClawMotor_ptr left_motor, const RoboClawMotor_ptr right_motor);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/serial.cpp
+++ b/main/modules/serial.cpp
@@ -8,9 +8,8 @@
 #define TX_BUF_SIZE 2048
 #define UART_PATTERN_QUEUE_SIZE 100
 
-const std::map<std::string, Variable_ptr> &Serial::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {};
-    return defaults;
+const std::map<std::string, Variable_ptr> Serial::get_defaults() {
+    return {};
 }
 
 Serial::Serial(const std::string name,

--- a/main/modules/serial.h
+++ b/main/modules/serial.h
@@ -32,5 +32,5 @@ public:
     void clear() const;
     std::string get_output() const override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/stepper_motor.cpp
+++ b/main/modules/stepper_motor.cpp
@@ -13,13 +13,12 @@
 
 #define MIN_SPEED 490
 
-const std::map<std::string, Variable_ptr> &StepperMotor::get_defaults() {
-    static const std::map<std::string, Variable_ptr> defaults = {
+const std::map<std::string, Variable_ptr> StepperMotor::get_defaults() {
+    return {
         {"position", std::make_shared<IntegerVariable>()},
         {"speed", std::make_shared<IntegerVariable>()},
         {"idle", std::make_shared<BooleanVariable>(true)},
     };
-    return defaults;
 }
 
 StepperMotor::StepperMotor(const std::string name,

--- a/main/modules/stepper_motor.h
+++ b/main/modules/stepper_motor.h
@@ -45,7 +45,7 @@ public:
                  const ledc_channel_t ledc_channel);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
-    static const std::map<std::string, Variable_ptr> &get_defaults();
+    static const std::map<std::string, Variable_ptr> get_defaults();
 
     StepperState get_state() const { return this->state; }
     int32_t get_target_position() const { return this->target_position; }


### PR DESCRIPTION
This fixes the creation of properties. They were all linking to the same property. The examples show the same lizard startup script

Before (just changed the input of the last added pin):
```
core 3913755 0 false 0 false 0 false 0 false 0 false 0 false 
core 3913765 1 true 1 true 1 true 1 true 1 true 1 true
```
Now (again, changing the last added pin):
The first line looks different, since it is now configured correctly.
```
core 290031 1 true 1 true 1 false 0 false 1 true 1 true
core 290021 1 true 1 true 1 false 1 true 1 true 1 true
```