### PR TITLE
Proxy persistent property handling

### DIFF
--- a/main/modules/expander.cpp
+++ b/main/modules/expander.cpp
@@ -139,7 +139,7 @@ void Expander::handle_messages(bool check_for_strapping_pins) {
 void Expander::add_proxy(const std::string module_name,
                          const std::string module_type,
                          const std::vector<ConstExpression_ptr> arguments) {
-    ProxyInformation proxy = {module_name, module_type, arguments, false};
+    ProxyInformation proxy = {module_name, module_type, arguments, {}, false};
     this->proxies.push_back(proxy);
 
     if (this->properties.at("is_ready")->boolean_value) {
@@ -157,6 +157,10 @@ void Expander::setup_proxy(ProxyInformation &proxy) {
     pos += csprintf(&buffer[pos], sizeof(buffer) - pos, "); ");
     pos += csprintf(&buffer[pos], sizeof(buffer) - pos, "%s.broadcast()", proxy.module_name.c_str());
     this->serial->write_checked_line(buffer, pos);
+    delay(50);
+    for (const auto &[property_name, expression] : proxy.properties) {
+        setup_property(proxy.module_name, property_name, expression);
+    }
     proxy.is_setup = true;
 }
 
@@ -241,4 +245,24 @@ void Expander::deinstall() {
         gpio_set_pull_mode(this->boot_pin, GPIO_FLOATING);
         gpio_set_pull_mode(this->enable_pin, GPIO_FLOATING);
     }
+}
+
+void Expander::setup_property(const std::string proxy_name, const std::string property_name, const ConstExpression_ptr expression) {
+    static char buffer[256];
+    int pos = csprintf(buffer, sizeof(buffer), "%s.%s = ", proxy_name.c_str(), property_name.c_str());
+    pos += expression->print_to_buffer(&buffer[pos], sizeof(buffer) - pos);
+    this->serial->write_checked_line(buffer, pos);
+}
+
+void Expander::add_property(const std::string proxy_name, const std::string property_name, const ConstExpression_ptr expression) {
+    for (auto &proxy : proxies) {
+        if (proxy.module_name == proxy_name) {
+            proxy.properties[property_name] = expression;
+            if (proxy.is_setup) {
+                setup_property(proxy_name, property_name, expression);
+            }
+            return;
+        }
+    }
+    throw std::runtime_error("Proxy not found: " + proxy_name);
 }

--- a/main/modules/expander.cpp
+++ b/main/modules/expander.cpp
@@ -159,7 +159,7 @@ void Expander::setup_proxy(ProxyInformation &proxy) {
     this->serial->write_checked_line(buffer, pos);
     delay(50);
     for (const auto &[property_name, expression] : proxy.properties) {
-        setup_property(proxy.module_name, property_name, expression);
+        this->setup_property(proxy.module_name, property_name, expression);
     }
     proxy.is_setup = true;
 }
@@ -259,7 +259,7 @@ void Expander::add_property(const std::string proxy_name, const std::string prop
         if (proxy.module_name == proxy_name) {
             proxy.properties[property_name] = expression;
             if (proxy.is_setup) {
-                setup_property(proxy_name, property_name, expression);
+                this->setup_property(proxy_name, property_name, expression);
             }
             return;
         }

--- a/main/modules/expander.h
+++ b/main/modules/expander.h
@@ -13,6 +13,7 @@ private:
         std::string module_name;
         std::string module_type;
         std::vector<ConstExpression_ptr> arguments;
+        std::map<std::string, ConstExpression_ptr> properties;
         bool is_setup = false;
     };
 
@@ -27,6 +28,7 @@ private:
     void restart();
     void handle_messages(bool check_for_strapping_pins = false);
     void setup_proxy(ProxyInformation &proxy);
+    void setup_property(const std::string proxy_name, const std::string property_name, const ConstExpression_ptr expression);
     void check_strapping_pins(const char *buffer);
 
 public:
@@ -45,5 +47,6 @@ public:
     void add_proxy(const std::string module_name,
                    const std::string module_type,
                    const std::vector<ConstExpression_ptr> arguments);
+    void add_property(const std::string proxy_name, const std::string property_name, const ConstExpression_ptr expression);
     static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/proxy.cpp
+++ b/main/modules/proxy.cpp
@@ -29,10 +29,7 @@ void Proxy::write_property(const std::string property_name, const ConstExpressio
         echo("%s: Unknown property \"%s\"", this->name.c_str(), property_name.c_str());
     }
     if (!from_expander) {
-        static char buffer[256];
-        int pos = csprintf(buffer, sizeof(buffer), "%s.%s = ", this->name.c_str(), property_name.c_str());
-        pos += expression->print_to_buffer(&buffer[pos], sizeof(buffer) - pos);
-        this->expander->serial->write_checked_line(buffer, pos);
+        this->expander->add_property(this->name, property_name, expression);
     }
     Module::get_property(property_name)->assign(expression);
 }


### PR DESCRIPTION
This adds the ability for the expander module to set expressions even if the expander esp is not ready yet. It will restore them on reboot as well.