### PR TITLE
Fix escape character handling in parser.h

### DIFF
--- a/gen_parser.sh
+++ b/gen_parser.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-echo "This generator is does not include changes from PR #107 and should not be used."
-exit 1
-
 echo "Generating parser..."
 if [[ "language.owl" -nt main/parser.h ]]
 then
+    echo "This generator does not include changes from PRs #107 and #112 and should not be used."
+    exit 1
+
     pushd owl
     make
     popd

--- a/main/parser.h
+++ b/main/parser.h
@@ -2000,7 +2000,7 @@ static bool OWL_DONT_INLINE owl_default_tokenizer_advance(struct owl_default_tok
                 size_t j = 0;
                 for (size_t i = 0;
                 i < content_length;
-                i++) {
+                ++i) {
                     if (string[i] == '\\' && i + 1 < content_length) {
                         i++;
                         output[j++] = ESCAPE_CHAR(string[i], tokenizer->info);

--- a/main/parser.h
+++ b/main/parser.h
@@ -1998,7 +1998,9 @@ static bool OWL_DONT_INLINE owl_default_tokenizer_advance(struct owl_default_tok
             if (has_escapes) {
                 char *output = malloc(content_length);
                 size_t j = 0;
-                for (size_t i = 0; i < content_length; i++) {
+                for (size_t i = 0;
+                i < content_length;
+                i++) {
                     if (string[i] == '\\' && i + 1 < content_length) {
                         i++;
                         output[j++] = ESCAPE_CHAR(string[i], tokenizer->info);

--- a/main/parser.h
+++ b/main/parser.h
@@ -1996,22 +1996,20 @@ static bool OWL_DONT_INLINE owl_default_tokenizer_advance(struct owl_default_tok
             const char *string = text + content_offset;
             size_t string_length = content_length;
             if (has_escapes) {
-                for (size_t i = 0;
-                i < content_length;
-                ++i) {
-                    if (text[content_offset + i] == '\\') {
-                        string_length--;
+                char *output = malloc(content_length);
+                size_t j = 0;
+                for (size_t i = 0; i < content_length; i++) {
+                    if (string[i] == '\\' && i + 1 < content_length) {
                         i++;
+                        output[j++] = ESCAPE_CHAR(string[i], tokenizer->info);
+                    } else {
+                        output[j++] = string[i];
                     }
                 }
+                string_length = j;
                 char *unescaped = allocate_string_contents(string_length, tokenizer->info);
-                size_t j = 0;
-                for (size_t i = 0;
-                i < content_length;
-                ++i) {
-                    if (text[content_offset + i] == '\\') i++;
-                    unescaped[j++] = ESCAPE_CHAR(text[content_offset + i], tokenizer->info);
-                }
+                memcpy(unescaped, output, string_length);
+                free(output);
                 string = unescaped;
             }
             write_string_token(offset, token_length, string, string_length, has_escapes, tokenizer->info);


### PR DESCRIPTION
This is a fix for #24 

Test outputs:
```
> core.print('boo\nbobobobobob')
"boo
bobobobobob"

> core.print('rbnr\nt')
"rbnr
t"

> core.print('boo\n')
"boo
"
```

No characters were lost in printing
