### PR TITLE
Function calls with properties

### DIFF
--- a/main/modules/analog.cpp
+++ b/main/modules/analog.cpp
@@ -15,7 +15,7 @@ const std::map<std::string, Variable_ptr> Analog::get_defaults() {
 
 Analog::Analog(const std::string name, uint8_t unit, uint8_t channel, float attenuation_level)
     : Module(analog, name), unit(unit), channel(channel) {
-    this->properties = Analog::get_defaults();
+    this->merge_properties(Analog::get_defaults());
 
     if (unit < 1 || unit > 2) {
         echo("error: invalid unit, using default 1");

--- a/main/modules/bluetooth.cpp
+++ b/main/modules/bluetooth.cpp
@@ -15,7 +15,7 @@ Bluetooth::Bluetooth(const std::string name, const std::string device_name, Mess
             echo("error in bluetooth message handler: %s", e.what());
         }
     });
-    this->properties = Bluetooth::get_defaults();
+    this->merge_properties(Bluetooth::get_defaults());
 }
 
 void Bluetooth::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {

--- a/main/modules/can.cpp
+++ b/main/modules/can.cpp
@@ -57,7 +57,7 @@ Can::Can(const std::string name, const gpio_num_t rx_pin, const gpio_num_t tx_pi
     g_config.rx_queue_len = 20;
     g_config.tx_queue_len = 20;
 
-    this->properties = Can::get_defaults();
+    this->merge_properties(Can::get_defaults());
 
     ESP_ERROR_CHECK(twai_driver_install(&g_config, &t_config, &f_config));
     ESP_ERROR_CHECK(twai_start());

--- a/main/modules/can.cpp
+++ b/main/modules/can.cpp
@@ -190,3 +190,26 @@ void Can::subscribe(const uint32_t id, const Module_ptr module) {
     }
     this->subscribers[id] = module;
 }
+
+void Can::write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) {
+    if (property_name == "can_mode") {
+        const std::string can_mode = expression->evaluate_string();
+        if (can_mode == "start") {
+            if (twai_start() != ESP_OK) {
+                throw std::runtime_error("could not start twai driver");
+            }
+        } else if (can_mode == "stop") {
+            if (twai_stop() != ESP_OK) {
+                throw std::runtime_error("could not stop twai driver");
+            }
+        } else if (can_mode == "recover") {
+            if (twai_initiate_recovery() != ESP_OK) {
+                throw std::runtime_error("could not initiate recovery");
+            }
+        } else {
+            throw std::runtime_error("unsupported can_mode");
+        }
+    } else {
+        Module::write_property(property_name, expression, from_expander);
+    }
+}

--- a/main/modules/can.cpp
+++ b/main/modules/can.cpp
@@ -102,7 +102,7 @@ bool Can::receive() {
             message.data);
     }
 
-    if (this->properties.at("output_on")->boolean_value) {
+    if (!this->properties.at("muted")->boolean_value) {
         static char buffer[256];
         int pos = csprintf(buffer, sizeof(buffer), "%s %03lx", this->name.c_str(), message.identifier);
         if (!(message.flags & TWAI_MSG_FLAG_RTR)) {

--- a/main/modules/can.cpp
+++ b/main/modules/can.cpp
@@ -102,7 +102,7 @@ bool Can::receive() {
             message.data);
     }
 
-    if (this->output_on) {
+    if (this->properties.at("output_on")->boolean_value) {
         static char buffer[256];
         int pos = csprintf(buffer, sizeof(buffer), "%s %03lx", this->name.c_str(), message.identifier);
         if (!(message.flags & TWAI_MSG_FLAG_RTR)) {

--- a/main/modules/can.h
+++ b/main/modules/can.h
@@ -15,6 +15,7 @@ public:
     Can(const std::string name, const gpio_num_t rx_pin, const gpio_num_t tx_pin, const long baud_rate);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
 
     bool receive();

--- a/main/modules/canopen_master.cpp
+++ b/main/modules/canopen_master.cpp
@@ -8,7 +8,7 @@ const std::map<std::string, Variable_ptr> CanOpenMaster::get_defaults() {
 
 CanOpenMaster::CanOpenMaster(const std::string &name, const Can_ptr can)
     : Module(canopen_master, name), can(can) {
-    this->properties = CanOpenMaster::get_defaults();
+    this->merge_properties(CanOpenMaster::get_defaults());
 }
 
 void CanOpenMaster::step() {

--- a/main/modules/canopen_motor.cpp
+++ b/main/modules/canopen_motor.cpp
@@ -74,7 +74,7 @@ CanOpenMotor::CanOpenMotor(const std::string &name, Can_ptr can, int64_t node_id
     : Module(canopen_motor, name), can(can), node_id(check_node_id(node_id)),
       current_op_mode_disp(OP_MODE_NONE), current_op_mode(OP_MODE_NONE) {
 
-    this->properties = CanOpenMotor::get_defaults();
+    this->merge_properties(CanOpenMotor::get_defaults());
 }
 
 void CanOpenMotor::wait_for_sdo_writes(uint32_t timeout_ms) {

--- a/main/modules/canopen_motor.h
+++ b/main/modules/canopen_motor.h
@@ -57,6 +57,7 @@ public:
     CanOpenMotor(const std::string &name, const Can_ptr can, int64_t node_id);
     void subscribe_to_can();
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;
     void handle_can_msg(const uint32_t id, const int count, const uint8_t *const data) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
 

--- a/main/modules/core.cpp
+++ b/main/modules/core.cpp
@@ -73,7 +73,7 @@ void Core::call(const std::string method_name, const std::vector<ConstExpression
                 this->output_list.push_back({module, property_name, precision});
             }
         }
-        this->properties.at("output_on")->boolean_value = true;
+        this->properties.at("muted")->boolean_value = false;
     } else if (method_name == "startup_checksum") {
         uint16_t checksum = 0;
         for (char const &c : Storage::startup) {

--- a/main/modules/core.cpp
+++ b/main/modules/core.cpp
@@ -73,7 +73,7 @@ void Core::call(const std::string method_name, const std::vector<ConstExpression
                 this->output_list.push_back({module, property_name, precision});
             }
         }
-        this->output_on = true;
+        this->properties.at("output_on")->boolean_value = true;
     } else if (method_name == "startup_checksum") {
         uint16_t checksum = 0;
         for (char const &c : Storage::startup) {

--- a/main/modules/d1_motor.cpp
+++ b/main/modules/d1_motor.cpp
@@ -21,7 +21,7 @@ const std::map<std::string, Variable_ptr> D1Motor::get_defaults() {
 
 D1Motor::D1Motor(const std::string &name, Can_ptr can, int64_t node_id)
     : Module(d1_motor, name), can(can), node_id(check_node_id(node_id)) {
-    this->properties = D1Motor::get_defaults();
+    this->merge_properties(D1Motor::get_defaults());
 }
 
 void D1Motor::subscribe_to_can() {

--- a/main/modules/d1_motor.cpp
+++ b/main/modules/d1_motor.cpp
@@ -197,3 +197,23 @@ void D1Motor::profile_velocity(const int32_t velocity) {
 void D1Motor::stop() {
     this->sdo_write(0x6040, 0, 16, 7);
 }
+
+void D1Motor::write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) {
+    if (property_name == "setup") {
+        this->setup();
+    } else if (property_name == "home") {
+        this->home();
+    } else if (property_name == "profile_position") {
+        int32_t position = expression->evaluate_integer();
+        this->profile_position(position);
+    } else if (property_name == "profile_velocity") {
+        int32_t velocity = expression->evaluate_integer();
+        this->profile_velocity(velocity);
+    } else if (property_name == "stop") {
+        this->stop();
+    } else if (property_name == "reset") {
+        this->sdo_write(0x6040, 0, 16, 143);
+    } else {
+        Module::write_property(property_name, expression, from_expander);
+    }
+}

--- a/main/modules/d1_motor.h
+++ b/main/modules/d1_motor.h
@@ -24,6 +24,7 @@ public:
     D1Motor(const std::string &name, const Can_ptr can, int64_t node_id);
     void subscribe_to_can();
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;
     void step() override;
     void handle_can_msg(const uint32_t id, const int count, const uint8_t *const data) override;
     static const std::map<std::string, Variable_ptr> get_defaults();

--- a/main/modules/dunker_motor.cpp
+++ b/main/modules/dunker_motor.cpp
@@ -145,3 +145,20 @@ void DunkerMotor::speed(const double speed) {
 double DunkerMotor::get_speed() {
     return this->properties.at("speed")->number_value;
 }
+
+void DunkerMotor::write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) {
+    if (property_name == "enable") {
+        if (expression->evaluate_boolean()) {
+            this->sdo_write(0x4004, 1, 8, 1);
+        }
+    } else if (property_name == "disable") {
+        if (expression->evaluate_boolean()) {
+            this->sdo_write(0x4004, 1, 8, 0);
+        }
+    } else if (property_name == "speed") {
+        double speed = expression->evaluate_number();
+        this->speed(speed);
+    } else {
+        Module::write_property(property_name, expression, from_expander);
+    }
+}

--- a/main/modules/dunker_motor.cpp
+++ b/main/modules/dunker_motor.cpp
@@ -14,7 +14,7 @@ const std::map<std::string, Variable_ptr> DunkerMotor::get_defaults() {
 
 DunkerMotor::DunkerMotor(const std::string &name, Can_ptr can, int64_t node_id)
     : Module(dunker_motor, name), can(can), node_id(check_node_id(node_id)) {
-    this->properties = DunkerMotor::get_defaults();
+    this->merge_properties(DunkerMotor::get_defaults());
 }
 
 void DunkerMotor::subscribe_to_can() {

--- a/main/modules/dunker_motor.h
+++ b/main/modules/dunker_motor.h
@@ -24,6 +24,7 @@ public:
     DunkerMotor(const std::string &name, const Can_ptr can, int64_t node_id);
     void subscribe_to_can();
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;
     void handle_can_msg(const uint32_t id, const int count, const uint8_t *const data) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
     void speed(const double speed);

--- a/main/modules/dunker_wheels.cpp
+++ b/main/modules/dunker_wheels.cpp
@@ -11,7 +11,7 @@ const std::map<std::string, Variable_ptr> DunkerWheels::get_defaults() {
 
 DunkerWheels::DunkerWheels(const std::string name, const DunkerMotor_ptr left_motor, const DunkerMotor_ptr right_motor)
     : Module(dunker_wheels, name), left_motor(left_motor), right_motor(right_motor) {
-    this->properties = DunkerWheels::get_defaults();
+    this->merge_properties(DunkerWheels::get_defaults());
 }
 
 void DunkerWheels::step() {

--- a/main/modules/expander.cpp
+++ b/main/modules/expander.cpp
@@ -30,7 +30,7 @@ Expander::Expander(const std::string name,
       enable_pin(enable_pin),
       message_handler(message_handler) {
 
-    this->properties = Expander::get_defaults();
+    this->merge_properties(Expander::get_defaults());
 
     this->serial->enable_line_detection();
     if (boot_pin != GPIO_NUM_NC && enable_pin != GPIO_NUM_NC) {

--- a/main/modules/imu.cpp
+++ b/main/modules/imu.cpp
@@ -52,7 +52,7 @@ Imu::Imu(const std::string name, i2c_port_t i2c_port, gpio_num_t sda_pin, gpio_n
     } catch (std::exception &ex) {
         throw std::runtime_error(std::string("imu setup failed: ") + ex.what());
     }
-    this->properties = Imu::get_defaults();
+    this->merge_properties(Imu::get_defaults());
 }
 
 void Imu::step() {

--- a/main/modules/input.cpp
+++ b/main/modules/input.cpp
@@ -14,15 +14,7 @@ const std::map<std::string, Variable_ptr> Input::get_defaults() {
 }
 
 Input::Input(const std::string name) : Module(input, name) {
-    // Get default properties
-    const auto defaults = Input::get_defaults();
-
-    // Merge defaults into properties, without overwriting existing properties
-    for (const auto &[key, value] : defaults) {
-        if (!this->properties.count(key)) {
-            this->properties[key] = value;
-        }
-    }
+    this->merge_properties(Input::get_defaults());
 }
 
 void Input::step() {

--- a/main/modules/input.cpp
+++ b/main/modules/input.cpp
@@ -80,3 +80,20 @@ void McpInput::set_pull_mode(const gpio_pull_mode_t mode) const {
     }
     this->mcp->set_pullup(this->number, mode == GPIO_PULLUP_ONLY);
 }
+
+void Input::write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) {
+    if (property_name == "pullmode") {
+        const std::string pull_mode = expression->evaluate_string();
+        if (pull_mode == "pullup") {
+            this->set_pull_mode(GPIO_PULLUP_ONLY);
+        } else if (pull_mode == "pulldown") {
+            this->set_pull_mode(GPIO_PULLDOWN_ONLY);
+        } else if (pull_mode == "pulloff") {
+            this->set_pull_mode(GPIO_FLOATING);
+        } else {
+            throw std::runtime_error("invalid pullmode");
+        }
+    } else {
+        Module::write_property(property_name, expression, from_expander);
+    }
+}

--- a/main/modules/input.cpp
+++ b/main/modules/input.cpp
@@ -14,7 +14,15 @@ const std::map<std::string, Variable_ptr> Input::get_defaults() {
 }
 
 Input::Input(const std::string name) : Module(input, name) {
-    this->properties = Input::get_defaults();
+    // Get default properties
+    const auto defaults = Input::get_defaults();
+
+    // Merge defaults into properties, without overwriting existing properties
+    for (const auto &[key, value] : defaults) {
+        if (!this->properties.count(key)) {
+            this->properties[key] = value;
+        }
+    }
 }
 
 void Input::step() {

--- a/main/modules/input.h
+++ b/main/modules/input.h
@@ -17,6 +17,7 @@ protected:
 public:
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
     std::string get_output() const override;
     virtual bool get_level() const = 0;

--- a/main/modules/linear_motor.cpp
+++ b/main/modules/linear_motor.cpp
@@ -1,5 +1,6 @@
 #include "linear_motor.h"
 #include <memory>
+#include <stdexcept>
 
 const std::map<std::string, Variable_ptr> LinearMotor::get_defaults() {
     return {
@@ -99,4 +100,24 @@ void McpLinearMotor::set_in(bool level) const {
 
 void McpLinearMotor::set_out(bool level) const {
     return this->mcp->set_level(this->move_out, level);
+}
+
+void LinearMotor::write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) {
+    if (property_name == "mode") {
+        const std::string mode = expression->evaluate_string();
+        if (mode == "in") {
+            this->set_in(1);
+            this->set_out(0);
+        } else if (mode == "out") {
+            this->set_in(0);
+            this->set_out(1);
+        } else if (mode == "stop") {
+            this->set_in(0);
+            this->set_out(0);
+        } else {
+            throw std::runtime_error("invalid mode");
+        }
+    } else {
+        Module::write_property(property_name, expression, from_expander);
+    }
 }

--- a/main/modules/linear_motor.cpp
+++ b/main/modules/linear_motor.cpp
@@ -9,7 +9,7 @@ const std::map<std::string, Variable_ptr> LinearMotor::get_defaults() {
 }
 
 LinearMotor::LinearMotor(const std::string name) : Module(output, name) {
-    this->properties = LinearMotor::get_defaults();
+    this->merge_properties(LinearMotor::get_defaults());
 }
 
 void LinearMotor::step() {

--- a/main/modules/linear_motor.h
+++ b/main/modules/linear_motor.h
@@ -17,6 +17,7 @@ protected:
 public:
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
 };
 

--- a/main/modules/mcp23017.cpp
+++ b/main/modules/mcp23017.cpp
@@ -157,3 +157,21 @@ void Mcp23017::set_pullup(const uint8_t number, const bool value) const {
     this->properties.at("pullups")->integer_value = pullups;
     this->set_pullups(pullups);
 }
+
+void Mcp23017::write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) {
+    if (property_name == "levels") {
+        uint16_t value = expression->evaluate_integer();
+        this->properties.at("levels")->integer_value = value;
+        this->write_pins(value);
+    } else if (property_name == "pullups") {
+        uint16_t value = expression->evaluate_integer();
+        this->properties.at("pullups")->integer_value = value;
+        this->set_pullups(value);
+    } else if (property_name == "inputs") {
+        uint16_t value = expression->evaluate_integer();
+        this->properties.at("inputs")->integer_value = value;
+        this->set_inputs(value);
+    } else {
+        Module::write_property(property_name, expression, from_expander);
+    }
+}

--- a/main/modules/mcp23017.cpp
+++ b/main/modules/mcp23017.cpp
@@ -29,7 +29,7 @@ Mcp23017::Mcp23017(const std::string name, i2c_port_t i2c_port, gpio_num_t sda_p
         throw std::runtime_error("could not install i2c driver");
     }
 
-    this->properties = Mcp23017::get_defaults();
+    this->merge_properties(Mcp23017::get_defaults());
 
     this->set_inputs(this->properties.at("inputs")->integer_value);
     this->set_pullups(this->properties.at("pullups")->integer_value);

--- a/main/modules/mcp23017.h
+++ b/main/modules/mcp23017.h
@@ -31,6 +31,7 @@ public:
     Mcp23017(const std::string name, i2c_port_t i2c_port, gpio_num_t sda_pin, gpio_num_t scl_pin, uint8_t address, int clk_speed);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
 
     bool get_level(const uint8_t number) const;

--- a/main/modules/module.cpp
+++ b/main/modules/module.cpp
@@ -32,9 +32,15 @@
 #include "stepper_motor.h"
 #include <stdarg.h>
 
+const std::map<std::string, Variable_ptr> Module::get_defaults() {
+    return {
+        {"muted", std::make_shared<BooleanVariable>(true)},
+        {"broadcast", std::make_shared<BooleanVariable>(false)},
+    };
+}
+
 Module::Module(const ModuleType type, const std::string name) : type(type), name(name) {
-    this->properties["muted"] = std::make_shared<BooleanVariable>(true);
-    this->properties["broadcast"] = std::make_shared<BooleanVariable>(false);
+    this->merge_properties(Module::get_defaults());
 }
 
 void Module::Module::expect(const std::vector<ConstExpression_ptr> arguments, const int num, ...) {

--- a/main/modules/module.cpp
+++ b/main/modules/module.cpp
@@ -480,8 +480,6 @@ const std::map<std::string, Variable_ptr> Module::get_module_defaults(const std:
 
 void Module::merge_properties(const std::map<std::string, Variable_ptr> &defaults) {
     for (const auto &[key, value] : defaults) {
-        if (!this->properties.count(key)) {
-            this->properties[key] = value;
-        }
+        this->properties[key] = value;
     }
 }

--- a/main/modules/module.cpp
+++ b/main/modules/module.cpp
@@ -477,3 +477,11 @@ const std::map<std::string, Variable_ptr> Module::get_module_defaults(const std:
         throw std::runtime_error("module type \"" + type_name + "\" not found in defaults list");
     }
 }
+
+void Module::merge_properties(const std::map<std::string, Variable_ptr> &defaults) {
+    for (const auto &[key, value] : defaults) {
+        if (!this->properties.count(key)) {
+            this->properties[key] = value;
+        }
+    }
+}

--- a/main/modules/module.cpp
+++ b/main/modules/module.cpp
@@ -369,6 +369,9 @@ void Module::step() {
         static char buffer[1024];
         int pos = csprintf(buffer, sizeof(buffer), "!!");
         for (auto const &[property_name, property] : this->properties) {
+            if (property_name == "broadcast" || property_name == "muted") {
+                continue;
+            }
             pos += csprintf(&buffer[pos], sizeof(buffer) - pos, "%s.%s=", this->name.c_str(), property_name.c_str());
             pos += property->print_to_buffer(&buffer[pos], sizeof(buffer) - pos);
             pos += csprintf(&buffer[pos], sizeof(buffer) - pos, ";");

--- a/main/modules/module.cpp
+++ b/main/modules/module.cpp
@@ -486,6 +486,10 @@ const std::map<std::string, Variable_ptr> Module::get_module_defaults(const std:
 
 void Module::merge_properties(const std::map<std::string, Variable_ptr> &defaults) {
     for (const auto &[key, value] : defaults) {
+        if (this->properties.count(key) > 0) {
+            echo("Warning: Module %s: Property '%s' already exists, skipping", this->name.c_str(), key.c_str());
+            continue;
+        }
         this->properties[key] = value;
     }
 }

--- a/main/modules/module.cpp
+++ b/main/modules/module.cpp
@@ -33,7 +33,7 @@
 #include <stdarg.h>
 
 Module::Module(const ModuleType type, const std::string name) : type(type), name(name) {
-    this->properties["output_on"] = std::make_shared<BooleanVariable>(false);
+    this->properties["muted"] = std::make_shared<BooleanVariable>(true);
     this->properties["broadcast"] = std::make_shared<BooleanVariable>(false);
 }
 
@@ -353,7 +353,7 @@ Module_ptr Module::create(const std::string type,
 }
 
 void Module::step() {
-    if (this->properties["output_on"]->boolean_value) {
+    if (!this->properties["muted"]->boolean_value) {
         const std::string output = this->get_output();
         if (!output.empty()) {
             echo("%s %s", this->name.c_str(), output.c_str());
@@ -374,10 +374,10 @@ void Module::step() {
 void Module::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
     if (method_name == "mute") {
         Module::expect(arguments, 0);
-        this->properties.at("output_on")->boolean_value = false;
+        this->properties.at("muted")->boolean_value = true;
     } else if (method_name == "unmute") {
         Module::expect(arguments, 0);
-        this->properties.at("output_on")->boolean_value = true;
+        this->properties.at("muted")->boolean_value = false;
     } else if (method_name == "broadcast") {
         Module::expect(arguments, 0);
         this->properties.at("broadcast")->boolean_value = true;

--- a/main/modules/module.h
+++ b/main/modules/module.h
@@ -60,6 +60,7 @@ public:
                              MessageHandler message_handler);
     virtual void step();
     virtual void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments);
+    static const std::map<std::string, Variable_ptr> get_defaults();
     static const std::map<std::string, Variable_ptr> get_module_defaults(const std::string &type_name);
     void call_with_shadows(const std::string method_name, const std::vector<ConstExpression_ptr> arguments);
     virtual std::string get_output() const;

--- a/main/modules/module.h
+++ b/main/modules/module.h
@@ -47,8 +47,6 @@ private:
 
 protected:
     std::map<std::string, Variable_ptr> properties;
-    bool output_on = false;
-    bool broadcast = false;
 
 public:
     const ModuleType type;

--- a/main/modules/module.h
+++ b/main/modules/module.h
@@ -66,4 +66,5 @@ public:
     Variable_ptr get_property(const std::string property_name) const;
     virtual void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander = false);
     virtual void handle_can_msg(const uint32_t id, const int count, const uint8_t *const data);
+    virtual void merge_properties(const std::map<std::string, Variable_ptr> &defaults);
 };

--- a/main/modules/motor_axis.cpp
+++ b/main/modules/motor_axis.cpp
@@ -8,7 +8,7 @@ const std::map<std::string, Variable_ptr> MotorAxis::get_defaults() {
 
 MotorAxis::MotorAxis(const std::string name, const Motor_ptr motor, const Input_ptr input1, const Input_ptr input2)
     : Module(motor_axis, name), motor(motor), input1(input1), input2(input2) {
-    this->properties = MotorAxis::get_defaults();
+    this->merge_properties(MotorAxis::get_defaults());
 }
 
 bool MotorAxis::can_move(const float speed) const {

--- a/main/modules/motor_axis.cpp
+++ b/main/modules/motor_axis.cpp
@@ -60,3 +60,18 @@ void MotorAxis::call(const std::string method_name, const std::vector<ConstExpre
         Module::call(method_name, arguments);
     }
 }
+
+void MotorAxis::write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) {
+    if (property_name == "speed") {
+        float speed = expression->evaluate_number();
+        if (this->can_move(speed)) {
+            this->motor->speed(speed, 0); // Use default acceleration of 0
+        } else {
+            this->motor->stop();
+        }
+    } else if (property_name == "stop") {
+        this->motor->stop();
+    } else {
+        Module::write_property(property_name, expression, from_expander);
+    }
+}

--- a/main/modules/motor_axis.h
+++ b/main/modules/motor_axis.h
@@ -15,5 +15,6 @@ public:
     MotorAxis(const std::string name, const Motor_ptr motor, const Input_ptr input1, const Input_ptr input2);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/odrive_motor.cpp
+++ b/main/modules/odrive_motor.cpp
@@ -177,3 +177,27 @@ double ODriveMotor::get_speed() {
 void ODriveMotor::speed(const double speed, const double acceleration) {
     this->speed(static_cast<float>(speed));
 }
+
+void ODriveMotor::write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) {
+    if (property_name == "zero") {
+        this->properties.at("tick_offset")->number_value +=
+            this->properties.at("position")->number_value /
+            this->properties.at("m_per_tick")->number_value *
+            (this->properties.at("reversed")->boolean_value ? -1 : 1);
+    } else if (property_name == "power") {
+        float torque = expression->evaluate_number();
+        this->power(torque);
+    } else if (property_name == "speed") {
+        float speed = expression->evaluate_number();
+        this->speed(speed);
+    } else if (property_name == "position") {
+        float position = expression->evaluate_number();
+        this->position(position);
+    } else if (property_name == "off") {
+        this->off();
+    } else if (property_name == "reset_motor") {
+        this->reset_motor_error();
+    } else {
+        Module::write_property(property_name, expression, from_expander);
+    }
+}

--- a/main/modules/odrive_motor.cpp
+++ b/main/modules/odrive_motor.cpp
@@ -17,7 +17,7 @@ const std::map<std::string, Variable_ptr> ODriveMotor::get_defaults() {
 
 ODriveMotor::ODriveMotor(const std::string name, const Can_ptr can, const uint32_t can_id, const uint32_t version)
     : Module(odrive_motor, name), can_id(can_id), can(can), version(version) {
-    this->properties = ODriveMotor::get_defaults();
+    this->merge_properties(ODriveMotor::get_defaults());
 }
 
 void ODriveMotor::subscribe_to_can() {

--- a/main/modules/odrive_motor.h
+++ b/main/modules/odrive_motor.h
@@ -24,6 +24,7 @@ public:
     ODriveMotor(const std::string name, const Can_ptr can, const uint32_t can_id, const uint32_t version);
     void subscribe_to_can();
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;
     void handle_can_msg(const uint32_t id, const int count, const uint8_t *const data) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
     void power(const float torque);

--- a/main/modules/odrive_wheels.cpp
+++ b/main/modules/odrive_wheels.cpp
@@ -13,7 +13,7 @@ const std::map<std::string, Variable_ptr> ODriveWheels::get_defaults() {
 
 ODriveWheels::ODriveWheels(const std::string name, const ODriveMotor_ptr left_motor, const ODriveMotor_ptr right_motor)
     : Module(odrive_wheels, name), left_motor(left_motor), right_motor(right_motor) {
-    this->properties = ODriveWheels::get_defaults();
+    this->merge_properties(ODriveWheels::get_defaults());
 }
 
 void ODriveWheels::step() {

--- a/main/modules/odrive_wheels.cpp
+++ b/main/modules/odrive_wheels.cpp
@@ -60,3 +60,14 @@ void ODriveWheels::call(const std::string method_name, const std::vector<ConstEx
         Module::call(method_name, arguments);
     }
 }
+
+void ODriveWheels::write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) {
+    if (property_name == "off") {
+        if (expression->evaluate_boolean()) {
+            this->left_motor->off();
+            this->right_motor->off();
+        }
+    } else {
+        Module::write_property(property_name, expression, from_expander);
+    }
+}

--- a/main/modules/odrive_wheels.h
+++ b/main/modules/odrive_wheels.h
@@ -17,5 +17,6 @@ public:
     ODriveWheels(const std::string name, const ODriveMotor_ptr left_motor, const ODriveMotor_ptr right_motor);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/output.cpp
+++ b/main/modules/output.cpp
@@ -70,3 +70,23 @@ McpOutput::McpOutput(const std::string name, const Mcp23017_ptr mcp, const uint8
 void McpOutput::set_level(bool level) const {
     this->mcp->set_level(this->number, level);
 }
+
+void Output::write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) {
+    if (property_name == "enabled") {
+        bool enabled = expression->evaluate_boolean();
+        this->target_level = enabled ? 1 : 0;
+        this->pulse_interval = 0;
+        this->step();
+    } else if (property_name == "level") {
+        bool level = expression->evaluate_boolean();
+        this->target_level = level;
+        this->pulse_interval = 0;
+        this->step();
+    } else if (property_name == "pulse") {
+        double interval = expression->evaluate_number();
+        this->pulse_interval = interval;
+        this->pulse_duty_cycle = 0.5;
+    } else {
+        Module::write_property(property_name, expression, from_expander);
+    }
+}

--- a/main/modules/output.cpp
+++ b/main/modules/output.cpp
@@ -11,7 +11,7 @@ const std::map<std::string, Variable_ptr> Output::get_defaults() {
 }
 
 Output::Output(const std::string name) : Module(output, name) {
-    this->properties = Output::get_defaults();
+    this->merge_properties(Output::get_defaults());
 }
 
 void Output::step() {

--- a/main/modules/output.h
+++ b/main/modules/output.h
@@ -17,6 +17,7 @@ protected:
 public:
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
 };
 

--- a/main/modules/proxy.cpp
+++ b/main/modules/proxy.cpp
@@ -10,7 +10,8 @@ Proxy::Proxy(const std::string name,
              const Expander_ptr expander,
              const std::vector<ConstExpression_ptr> arguments)
     : Module(proxy, name), expander(expander) {
-    this->properties = Module::get_module_defaults(module_type);
+    this->merge_properties(Module::get_defaults());
+    this->merge_properties(Module::get_module_defaults(module_type));
     this->properties["is_ready"] = expander->get_property("is_ready");
     expander->add_proxy(name, module_type, arguments);
 }
@@ -32,4 +33,9 @@ void Proxy::write_property(const std::string property_name, const ConstExpressio
         this->expander->add_property(this->name, property_name, expression);
     }
     Module::get_property(property_name)->assign(expression);
+}
+
+void Proxy::step() {
+    // proxies should not broadcast or be muted themselves
+    return;
 }

--- a/main/modules/proxy.cpp
+++ b/main/modules/proxy.cpp
@@ -10,7 +10,6 @@ Proxy::Proxy(const std::string name,
              const Expander_ptr expander,
              const std::vector<ConstExpression_ptr> arguments)
     : Module(proxy, name), expander(expander) {
-    this->merge_properties(Module::get_defaults());
     this->merge_properties(Module::get_module_defaults(module_type));
     this->properties["is_ready"] = expander->get_property("is_ready");
     expander->add_proxy(name, module_type, arguments);

--- a/main/modules/proxy.h
+++ b/main/modules/proxy.h
@@ -15,4 +15,5 @@ public:
           const std::vector<ConstExpression_ptr> arguments);
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;
+    void step() override;
 };

--- a/main/modules/pwm_output.cpp
+++ b/main/modules/pwm_output.cpp
@@ -60,3 +60,11 @@ void PwmOutput::call(const std::string method_name, const std::vector<ConstExpre
         Module::call(method_name, arguments);
     }
 }
+
+void PwmOutput::write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) {
+    if (property_name == "enabled") {
+        this->is_on = expression->evaluate_boolean();
+    } else {
+        Module::write_property(property_name, expression, from_expander);
+    }
+}

--- a/main/modules/pwm_output.cpp
+++ b/main/modules/pwm_output.cpp
@@ -15,7 +15,7 @@ PwmOutput::PwmOutput(const std::string name,
     : Module(pwm_output, name), pin(pin), ledc_timer(ledc_timer), ledc_channel(ledc_channel) {
     gpio_reset_pin(pin);
 
-    this->properties = PwmOutput::get_defaults();
+    this->merge_properties(PwmOutput::get_defaults());
 
     ledc_timer_config_t timer_config = {
         .speed_mode = LEDC_HIGH_SPEED_MODE,

--- a/main/modules/pwm_output.h
+++ b/main/modules/pwm_output.h
@@ -18,5 +18,6 @@ public:
               const ledc_channel_t ledc_channel);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/rmd_motor.cpp
+++ b/main/modules/rmd_motor.cpp
@@ -18,7 +18,7 @@ const std::map<std::string, Variable_ptr> RmdMotor::get_defaults() {
 
 RmdMotor::RmdMotor(const std::string name, const Can_ptr can, const uint8_t motor_id, const int ratio)
     : Module(rmd_motor, name), motor_id(motor_id), can(can), ratio(ratio), encoder_range(262144.0 / ratio) {
-    this->properties = RmdMotor::get_defaults();
+    this->merge_properties(RmdMotor::get_defaults());
 }
 
 void RmdMotor::subscribe_to_can() {

--- a/main/modules/rmd_motor.cpp
+++ b/main/modules/rmd_motor.cpp
@@ -277,3 +277,26 @@ bool RmdMotor::set_acceleration(const uint8_t index, const uint32_t acceleration
                       *((uint8_t *)(&acceleration) + 3),
                       20);
 }
+
+void RmdMotor::write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) {
+    if (property_name == "power") {
+        double power = expression->evaluate_number();
+        this->power(power);
+    } else if (property_name == "speed") {
+        double speed = expression->evaluate_number();
+        this->speed(speed);
+    } else if (property_name == "position") {
+        double position = expression->evaluate_number();
+        this->position(position, 0); // Use default speed of 0
+    } else if (property_name == "stop") {
+        this->stop();
+    } else if (property_name == "off") {
+        this->off();
+    } else if (property_name == "hold") {
+        this->hold();
+    } else if (property_name == "clear_errors") {
+        this->clear_errors();
+    } else {
+        Module::write_property(property_name, expression, from_expander);
+    }
+}

--- a/main/modules/rmd_motor.h
+++ b/main/modules/rmd_motor.h
@@ -28,6 +28,7 @@ public:
     void subscribe_to_can();
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;
     void handle_can_msg(const uint32_t id, const int count, const uint8_t *const data) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
 

--- a/main/modules/rmd_pair.cpp
+++ b/main/modules/rmd_pair.cpp
@@ -12,7 +12,7 @@ const std::map<std::string, Variable_ptr> RmdPair::get_defaults() {
 
 RmdPair::RmdPair(const std::string name, const RmdMotor_ptr rmd1, const RmdMotor_ptr rmd2)
     : Module(rmd_pair, name), rmd1(rmd1), rmd2(rmd2) {
-    this->properties = RmdPair::get_defaults();
+    this->merge_properties(RmdPair::get_defaults());
 }
 
 RmdPair::TrajectoryTriple RmdPair::compute_trajectory(double x0, double x1, double v0, double v1) const {

--- a/main/modules/rmd_pair.cpp
+++ b/main/modules/rmd_pair.cpp
@@ -111,3 +111,21 @@ void RmdPair::call(const std::string method_name, const std::vector<ConstExpress
         Module::call(method_name, arguments);
     }
 }
+
+void RmdPair::write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) {
+    if (property_name == "stop") {
+        this->rmd1->stop();
+        this->rmd2->stop();
+    } else if (property_name == "off") {
+        this->rmd1->off();
+        this->rmd2->off();
+    } else if (property_name == "hold") {
+        this->rmd1->hold();
+        this->rmd2->hold();
+    } else if (property_name == "clear_errors") {
+        this->rmd1->clear_errors();
+        this->rmd2->clear_errors();
+    } else {
+        Module::write_property(property_name, expression, from_expander);
+    }
+}

--- a/main/modules/rmd_pair.h
+++ b/main/modules/rmd_pair.h
@@ -29,5 +29,6 @@ private:
 public:
     RmdPair(const std::string name, const RmdMotor_ptr rmd1, const RmdMotor_ptr rmd2);
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/roboclaw.cpp
+++ b/main/modules/roboclaw.cpp
@@ -13,7 +13,7 @@ const std::map<std::string, Variable_ptr> RoboClaw::get_defaults() {
 
 RoboClaw::RoboClaw(const std::string name, const ConstSerial_ptr serial, const uint8_t address)
     : Module(roboclaw, name), address(address), serial(serial) {
-    this->properties = RoboClaw::get_defaults();
+    this->merge_properties(RoboClaw::get_defaults());
 }
 
 void RoboClaw::step() {

--- a/main/modules/roboclaw_motor.cpp
+++ b/main/modules/roboclaw_motor.cpp
@@ -15,7 +15,7 @@ RoboClawMotor::RoboClawMotor(const std::string name, const RoboClaw_ptr roboclaw
     if (this->motor_number != motor_number) {
         throw std::runtime_error("illegal motor number");
     }
-    this->properties = RoboClawMotor::get_defaults();
+    this->merge_properties(RoboClawMotor::get_defaults());
 }
 
 void RoboClawMotor::step() {

--- a/main/modules/roboclaw_motor.cpp
+++ b/main/modules/roboclaw_motor.cpp
@@ -75,3 +75,22 @@ void RoboClawMotor::speed(int value) {
     }
     throw std::runtime_error("could not set speed after " + std::to_string(max_retries) + " retries");
 }
+
+void RoboClawMotor::write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) {
+    if (property_name == "power") {
+        double power = expression->evaluate_number();
+        this->power(power);
+    } else if (property_name == "speed") {
+        double speed = expression->evaluate_number();
+        this->speed(speed);
+    } else if (property_name == "zero") {
+        if (expression->evaluate_boolean()) {
+            bool success = this->motor_number == 1 ? this->roboclaw->SetEncM1(0) : this->roboclaw->SetEncM2(0);
+            if (!success) {
+                throw std::runtime_error("could not reset position");
+            }
+        }
+    } else {
+        Module::write_property(property_name, expression, from_expander);
+    }
+}

--- a/main/modules/roboclaw_motor.h
+++ b/main/modules/roboclaw_motor.h
@@ -15,6 +15,7 @@ public:
     RoboClawMotor(const std::string name, const RoboClaw_ptr roboclaw, const unsigned int motor_number);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
 
     int64_t get_position() const;

--- a/main/modules/roboclaw_wheels.cpp
+++ b/main/modules/roboclaw_wheels.cpp
@@ -14,7 +14,7 @@ const std::map<std::string, Variable_ptr> RoboClawWheels::get_defaults() {
 
 RoboClawWheels::RoboClawWheels(const std::string name, const RoboClawMotor_ptr left_motor, const RoboClawMotor_ptr right_motor)
     : Module(roboclaw_wheels, name), left_motor(left_motor), right_motor(right_motor) {
-    this->properties = RoboClawWheels::get_defaults();
+    this->merge_properties(RoboClawWheels::get_defaults());
 }
 
 /* Catch unsigned wrap-around by detecting large jumps in encoder deltas */

--- a/main/modules/roboclaw_wheels.cpp
+++ b/main/modules/roboclaw_wheels.cpp
@@ -76,3 +76,14 @@ void RoboClawWheels::call(const std::string method_name, const std::vector<Const
         Module::call(method_name, arguments);
     }
 }
+
+void RoboClawWheels::write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) {
+    if (property_name == "off") {
+        if (expression->evaluate_boolean()) {
+            this->left_motor->power(0);
+            this->right_motor->power(0);
+        }
+    } else {
+        Module::write_property(property_name, expression, from_expander);
+    }
+}

--- a/main/modules/roboclaw_wheels.h
+++ b/main/modules/roboclaw_wheels.h
@@ -16,5 +16,6 @@ public:
     RoboClawWheels(const std::string name, const RoboClawMotor_ptr left_motor, const RoboClawMotor_ptr right_motor);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/serial.cpp
+++ b/main/modules/serial.cpp
@@ -16,7 +16,7 @@ const std::map<std::string, Variable_ptr> Serial::get_defaults() {
 Serial::Serial(const std::string name,
                const gpio_num_t rx_pin, const gpio_num_t tx_pin, const long baud_rate, const uart_port_t uart_num)
     : Module(serial, name), rx_pin(rx_pin), tx_pin(tx_pin), baud_rate(baud_rate), uart_num(uart_num) {
-    this->properties = Serial::get_defaults();
+    this->merge_properties(Serial::get_defaults());
 
     if (uart_is_driver_installed(uart_num)) {
         throw std::runtime_error("serial interface is already in use");

--- a/main/modules/stepper_motor.cpp
+++ b/main/modules/stepper_motor.cpp
@@ -219,3 +219,16 @@ void StepperMotor::speed(const double speed, const double acceleration) {
     this->target_acceleration = static_cast<uint32_t>(acceleration);
     set_state(this->target_speed == 0 ? Idle : Speeding);
 }
+
+void StepperMotor::write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) {
+    if (property_name == "speed") {
+        double speed = expression->evaluate_number();
+        this->speed(speed, 0);
+    } else if (property_name == "stop") {
+        if (expression->evaluate_boolean()) {
+            this->stop();
+        }
+    } else {
+        Module::write_property(property_name, expression, from_expander);
+    }
+}

--- a/main/modules/stepper_motor.cpp
+++ b/main/modules/stepper_motor.cpp
@@ -38,7 +38,7 @@ StepperMotor::StepperMotor(const std::string name,
     gpio_reset_pin(step_pin);
     gpio_reset_pin(dir_pin);
 
-    this->properties = StepperMotor::get_defaults();
+    this->merge_properties(StepperMotor::get_defaults());
 
     pcnt_config_t pcnt_config = {
         .pulse_gpio_num = step_pin,

--- a/main/modules/stepper_motor.h
+++ b/main/modules/stepper_motor.h
@@ -45,6 +45,7 @@ public:
                  const ledc_channel_t ledc_channel);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
 
     StepperState get_state() const { return this->state; }


### PR DESCRIPTION
This will change the mute(), unmute() and broadcast() call, so they also work with properties.

- [x] Implement module properties instead of variables -> module level properties, that can be changed as call or property
- [x] add call properties -> Properties that handle like calls
- [ ] documentation