### PR TITLE
fix reset and enable confusion

### DIFF
--- a/esp.py
+++ b/esp.py
@@ -65,10 +65,16 @@ class Esp:
         yield
         self.activate()
 
-    def activate(self) -> None:
-        print('Bringing microcontroller into normal operation mode...')
+    def reset(self) -> None:
+        print('Resetting microcontroller...')
         self.write(f'{self.gpio_g0}/value', self.off)
         sleep(0.5)
         self.write(f'{self.gpio_en}/value', self.on)
+        sleep(0.5)
+        self.write(f'{self.gpio_en}/value', self.off)
+
+    def enable(self) -> None:
+        print('Enabling microcontroller...')
+        self.write(f'{self.gpio_g0}/value', self.off)
         sleep(0.5)
         self.write(f'{self.gpio_en}/value', self.off)

--- a/esp.py
+++ b/esp.py
@@ -63,7 +63,7 @@ class Esp:
         self.write(f'{self.gpio_en}/value', self.off)
         sleep(0.5)
         yield
-        self.activate()
+        self.reset()
 
     def reset(self) -> None:
         print('Resetting microcontroller...')

--- a/flash.py
+++ b/flash.py
@@ -6,7 +6,7 @@ from esp import Esp
 
 
 def show_help() -> None:
-    print(f'{sys.argv[0]} [nano | xavier | orin] [nand | v05] [usb | /dev/<name>] [enable] [-e | --erase]')
+    print(f'{sys.argv[0]} [nano | xavier | orin] [nand | v05] [usb | /dev/<name>] [enable] [-e | --erase] [reset]')
     print('   -e, --erase   erase the flash before flashing the new firmware')
     print('   nano          flashing Jetson Nano (default)')
     print('   xavier        flashing Jetson Xavier')
@@ -16,6 +16,7 @@ def show_help() -> None:
     print('   usb           use /dev/tty.SLAB_USBtoUART as serial device')
     print('   /dev/<name>   use /dev/<name> as serial device')
     print('   enable        enable the ESP32 microcontroller')
+    print('   reset         reset the ESP32 microcontroller')
 
 
 if any(h in sys.argv for h in ['--help', '-help', 'help', '-h']):

--- a/flash.py
+++ b/flash.py
@@ -38,7 +38,13 @@ esp = Esp(nand='nand' in sys.argv, xavier='xavier' in sys.argv,
 if 'enable' in sys.argv:
     with esp.pin_config():
         print('Enabling ESP...')
-        esp.activate()
+        esp.enable()
+    sys.exit()
+
+if 'reset' in sys.argv:
+    with esp.pin_config():
+        print('Resetting ESP...')
+        esp.reset()
     sys.exit()
 
 with esp.pin_config(), esp.flash_mode():


### PR DESCRIPTION
When debugging some Hardware Problems, we noticed, that enabel resets the ESP and does not simply enable it. To fix this I added a new enable function to the flash script and changed the enable function to reset. 
This should fix the confusion of the naming. 