### PR TITLE
Expander fixes: Proxy call with wrong name and ping conditions

### DIFF
--- a/main/modules/expander.cpp
+++ b/main/modules/expander.cpp
@@ -231,9 +231,9 @@ void Expander::send_property(const std::string proxy_name, const std::string pro
     this->serial->write_checked_line(buffer, pos);
 }
 
-void Expander::send_call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
+void Expander::send_call(const std::string proxy_name, const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
     static char buffer[256];
-    int pos = csprintf(buffer, sizeof(buffer), "%s.%s(", this->name.c_str(), method_name.c_str());
+    int pos = csprintf(buffer, sizeof(buffer), "%s.%s(", proxy_name.c_str(), method_name.c_str());
     pos += write_arguments_to_buffer(arguments, &buffer[pos], sizeof(buffer) - pos);
     pos += csprintf(&buffer[pos], sizeof(buffer) - pos, ")");
     this->serial->write_checked_line(buffer, pos);

--- a/main/modules/expander.cpp
+++ b/main/modules/expander.cpp
@@ -82,11 +82,9 @@ void Expander::ping() {
     const double last_message_age = this->get_property("last_message_age")->integer_value / 1000.0;
     const double ping_interval = this->get_property("ping_interval")->number_value;
     const double ping_timeout = this->get_property("ping_timeout")->number_value;
-    if (!this->ping_pending && !this->has_proxies_configured) {
-        if (last_message_age >= ping_interval) {
-            this->serial->write_checked_line("core.print('__PONG__')");
-            this->ping_pending = true;
-        }
+    if (!this->ping_pending && last_message_age >= ping_interval) {
+        this->serial->write_checked_line("core.print('__PONG__')");
+        this->ping_pending = true;
     } else {
         if (last_message_age >= ping_interval + ping_timeout) {
             echo("warning: expander %s connection lost", this->name.c_str());
@@ -221,7 +219,6 @@ void Expander::send_proxy(const std::string module_name, const std::string modul
     pos += csprintf(&buffer[pos], sizeof(buffer) - pos, "); ");
     pos += csprintf(&buffer[pos], sizeof(buffer) - pos, "%s.broadcast()", module_name.c_str());
     this->serial->write_checked_line(buffer, pos);
-    this->has_proxies_configured = true;
 }
 
 void Expander::send_property(const std::string proxy_name, const std::string property_name, const ConstExpression_ptr expression) {

--- a/main/modules/expander.h
+++ b/main/modules/expander.h
@@ -36,6 +36,6 @@ public:
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     void send_proxy(const std::string module_name, const std::string module_type, const std::vector<ConstExpression_ptr> arguments);
     void send_property(const std::string proxy_name, const std::string property_name, const ConstExpression_ptr expression);
-    void send_call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments);
+    void send_call(const std::string proxy_name, const std::string method_name, const std::vector<ConstExpression_ptr> arguments);
     static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/expander.h
+++ b/main/modules/expander.h
@@ -12,7 +12,6 @@ private:
     unsigned long int last_message_millis = 0;
     bool ping_pending = false;
     unsigned long boot_start_time;
-    bool has_proxies_configured = false;
 
     void deinstall();
     void check_boot_progress();

--- a/main/modules/proxy.cpp
+++ b/main/modules/proxy.cpp
@@ -22,7 +22,7 @@ Proxy::Proxy(const std::string name,
 }
 
 void Proxy::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
-    this->expander->send_call(method_name, arguments);
+    this->expander->send_call(this->name, method_name, arguments);
 }
 
 void Proxy::write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) {


### PR DESCRIPTION
These are two fixes for the expander module.

The first fixes proxy calls, they were using the wrong name. 

The second fix changes the ping conditions. There are proxy modules (like Serial) that can be created, but do not create an output immediately, these would cause a timeout of the expander module, even if everything is correct. I noticed this while debugging for the first fix.