### PR TITLE
Add a workaround for a bug in the TWAI driver

### DIFF
--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -33,3 +33,7 @@ CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH=y
 CONFIG_ESP_COREDUMP_FLASH_SAVE=y
 CONFIG_ESP_COREDUMP_MAX_TASKS_NUM=16
 CONFIG_ESP_COREDUMP_FLASH_PARTITION="coredump"
+
+# This is a workaround for a bug in the ESP-IDF TWAI driver
+# See https://github.com/zauberzeug/lizard/issues/126 for more details.
+CONFIG_TWAI_ERRATA_FIX_TX_INTR_LOST=n


### PR DESCRIPTION
This fixes an older bug in the twai driver. It disables the [SW workaround for TX interrupt lost errata](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/kconfig.html#config-twai-errata-fix-tx-intr-lost). 
Testet on robot for almost 15 hours without crash.

Disabling CONFIG_TWAI_ERRATA_FIX_TX_INTR_LOST may lead to lost transmit interrupts, affecting message transmission reliability. A fix was not implemented yet and only mentioned in this [thread](https://github.com/espressif/esp-idf/issues/9697). I also asked what the status is on this.