### PR TITLE
External expander for IDF 5.3.1

### DIFF
--- a/main/modules/core.cpp
+++ b/main/modules/core.cpp
@@ -185,6 +185,8 @@ void Core::call(const std::string method_name, const std::vector<ConstExpression
         } catch (const std::runtime_error &e) {
             echo("error in core module: %s", e.what());
         }
+    } else if (method_name == "ee") {
+        echo("EE status: %d", is_external_expander);
     } else {
         Module::call(method_name, arguments);
     }

--- a/main/modules/core.h
+++ b/main/modules/core.h
@@ -17,6 +17,8 @@ class Core : public Module {
 private:
     std::list<struct output_element_t> output_list;
     unsigned long int last_message_millis = 0;
+    uint8_t expander_id = 255;
+    bool is_external_expander = false;
 
 public:
     Core(const std::string name);
@@ -26,4 +28,8 @@ public:
     void set(std::string property_name, double value);
     std::string get_output() const override;
     void keep_alive();
+    uint8_t get_expander_id() const;
+    void set_expander_id(uint8_t id);
+    void set_external_mode(bool external);
+    bool is_external() const;
 };

--- a/main/modules/expandable.h
+++ b/main/modules/expandable.h
@@ -1,0 +1,11 @@
+#pragma once
+#include "module.h"
+
+class Expandable {
+public:
+    virtual void send_proxy(const std::string module_name, const std::string module_type, const std::vector<ConstExpression_ptr> arguments) = 0;
+    virtual void send_property(const std::string proxy_name, const std::string property_name, const ConstExpression_ptr expression) = 0;
+    virtual void send_call(const std::string proxy_name, const std::string method_name, const std::vector<ConstExpression_ptr> arguments) = 0;
+    virtual bool is_ready() const = 0;
+    virtual ~Expandable() = default;
+};

--- a/main/modules/expander.cpp
+++ b/main/modules/expander.cpp
@@ -239,3 +239,7 @@ void Expander::send_call(const std::string proxy_name, const std::string method_
     pos += csprintf(&buffer[pos], sizeof(buffer) - pos, ")");
     this->serial->write_checked_line(buffer, pos);
 }
+
+bool Expander::is_ready() const {
+    return this->properties.at("is_ready")->boolean_value;
+}

--- a/main/modules/expander.h
+++ b/main/modules/expander.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "expandable.h"
 #include "module.h"
 #include "serial.h"
 #include <string>
@@ -7,7 +8,7 @@
 class Expander;
 using Expander_ptr = std::shared_ptr<Expander>;
 
-class Expander : public Module {
+class Expander : public Module, public Expandable {
 private:
     unsigned long int last_message_millis = 0;
     bool ping_pending = false;
@@ -33,8 +34,11 @@ public:
              MessageHandler message_handler);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
-    void send_proxy(const std::string module_name, const std::string module_type, const std::vector<ConstExpression_ptr> arguments);
-    void send_property(const std::string proxy_name, const std::string property_name, const ConstExpression_ptr expression);
-    void send_call(const std::string proxy_name, const std::string method_name, const std::vector<ConstExpression_ptr> arguments);
+    void send_proxy(const std::string module_name, const std::string module_type, const std::vector<ConstExpression_ptr> arguments) override;
+    void send_property(const std::string proxy_name, const std::string property_name, const ConstExpression_ptr expression) override;
+    void send_call(const std::string proxy_name, const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
+
+    // Expandable interface
+    bool is_ready() const override;
 };

--- a/main/modules/external_expander.cpp
+++ b/main/modules/external_expander.cpp
@@ -152,3 +152,7 @@ void ExternalExpander::send_call(const std::string proxy_name, const std::string
     pos += csprintf(&buffer[pos], sizeof(buffer) - pos, ")");
     this->serial->write_checked_line(buffer, pos);
 }
+
+bool ExternalExpander::is_ready() const {
+    return this->properties.at("is_ready")->boolean_value;
+}

--- a/main/modules/external_expander.cpp
+++ b/main/modules/external_expander.cpp
@@ -1,0 +1,119 @@
+#include "external_expander.h"
+#include "utils/string_utils.h"
+#include "utils/timing.h"
+#include "utils/uart.h"
+#include <cstdlib>
+#include <cstring>
+#include <stdexcept>
+
+REGISTER_MODULE_DEFAULTS(ExternalExpander)
+
+const std::map<std::string, Variable_ptr> ExternalExpander::get_defaults() {
+    return {
+        {"ping_interval", std::make_shared<NumberVariable>(1.0)},
+        {"ping_timeout", std::make_shared<NumberVariable>(2.0)},
+        {"is_ready", std::make_shared<BooleanVariable>(false)},
+        {"last_message_age", std::make_shared<IntegerVariable>(0)},
+    };
+}
+
+ExternalExpander::ExternalExpander(const std::string name, const ConstSerial_ptr serial)
+    : Module(external_expander, name), serial(serial) {
+    this->properties = ExternalExpander::get_defaults();
+    this->serial->enable_line_detection();
+}
+
+void ExternalExpander::step() {
+    if (this->properties.at("is_ready")->boolean_value) {
+        this->ping();
+
+        // Request step from all registered expanders
+        for (const auto &[id, name] : expander_names) {
+            this->serial->write_checked_line("@%d:core.run_step()", id);
+        }
+
+        this->handle_messages();
+    }
+    this->properties.at("last_message_age")->integer_value = millis_since(this->last_message_millis);
+    Module::step();
+}
+
+void ExternalExpander::handle_messages() {
+    static char buffer[1024];
+    while (this->serial->has_buffered_lines()) {
+        int len = this->serial->read_line(buffer, sizeof(buffer));
+        check(buffer, len);
+        this->last_message_millis = millis();
+        this->ping_pending = false;
+
+        if (buffer[0] == '!' && buffer[1] == '!') {
+            // Property update from expander
+            // Format: !!property_name=value
+            char *equals = strchr(buffer + 2, '=');
+            if (equals) {
+                *equals = 0;
+                std::string property_name = buffer + 2;
+                std::string property_value = equals + 1;
+
+                // Update property in manager
+                if (!this->properties.count(property_name)) {
+                    // Create property if it doesn't exist
+                    this->properties[property_name] = std::make_shared<StringVariable>();
+                }
+                this->properties[property_name]->string_value = property_value;
+            }
+        } else if (strcmp("\"__PONG__\"", buffer) == 0) {
+            // No echo for pong
+        } else {
+            echo("%s: %s", this->name.c_str(), buffer);
+        }
+    }
+}
+
+void ExternalExpander::ping() {
+    const double last_message_age = this->get_property("last_message_age")->integer_value / 1000.0;
+    const double ping_interval = this->get_property("ping_interval")->number_value;
+    const double ping_timeout = this->get_property("ping_timeout")->number_value;
+
+    if (!this->ping_pending) {
+        if (last_message_age >= ping_interval) {
+            // Ping all expanders
+            for (const auto &[id, name] : expander_names) {
+                this->serial->write_checked_line("@%d:core.print('__PONG__')", id);
+            }
+            this->ping_pending = true;
+        }
+    } else {
+        if (last_message_age >= ping_interval + ping_timeout) {
+            echo("warning: external expander connection lost");
+            this->properties.at("is_ready")->boolean_value = false;
+        }
+    }
+}
+
+void ExternalExpander::register_expander(uint8_t id, const std::string &name) {
+    expander_names[id] = name;
+    echo("Registered external expander %s with ID %d", name.c_str(), id);
+}
+
+void ExternalExpander::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
+    if (method_name == "register") {
+        Module::expect(arguments, 2, integer, string);
+        uint8_t id = arguments[0]->evaluate_integer();
+        std::string name = arguments[1]->evaluate_string();
+        register_expander(id, name);
+    } else if (method_name == "send") {
+        Module::expect(arguments, 2, integer, string);
+        uint8_t id = arguments[0]->evaluate_integer();
+        std::string command = arguments[1]->evaluate_string();
+        if (expander_names.count(id)) {
+            char buffer[256];
+            int pos = csprintf(buffer, sizeof(buffer), "@%d:%s", id, command.c_str());
+            this->serial->write_checked_line(buffer, pos);
+        } else {
+            throw std::runtime_error("unknown expander id");
+        }
+    } else {
+        Module::call(method_name, arguments);
+    }
+}

--- a/main/modules/external_expander.cpp
+++ b/main/modules/external_expander.cpp
@@ -37,7 +37,6 @@ ExternalExpander::ExternalExpander(const std::string name,
     char buffer[256];
     int pos = csprintf(buffer, sizeof(buffer), "%c%ccore.print('__%u_READY__')", ID_TAG, expander_id, expander_id);
     this->serial->write_checked_line(buffer, pos);
-    echo("Debug: writing: %s", buffer);
     this->handle_messages();
 }
 
@@ -62,6 +61,8 @@ void ExternalExpander::handle_messages() {
         check(buffer, len);
         this->last_message_millis = millis();
         this->ping_pending = false;
+
+        echo("Debug: received message: %s", buffer);
 
         if (buffer[0] == '!' && buffer[1] == '!') {
             // Property update from expander

--- a/main/modules/external_expander.h
+++ b/main/modules/external_expander.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "expandable.h"
 #include "module.h"
 #include "serial.h"
 #include <map>
@@ -8,7 +9,7 @@
 class ExternalExpander;
 using ExternalExpander_ptr = std::shared_ptr<ExternalExpander>;
 
-class ExternalExpander : public Module {
+class ExternalExpander : public Module, public Expandable {
 private:
     unsigned long int last_message_millis = 0;
     bool ping_pending = false;
@@ -30,8 +31,11 @@ public:
                      MessageHandler message_handler);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
-    void send_proxy(const std::string module_name, const std::string module_type, const std::vector<ConstExpression_ptr> arguments);
-    void send_property(const std::string proxy_name, const std::string property_name, const ConstExpression_ptr expression);
-    void send_call(const std::string proxy_name, const std::string method_name, const std::vector<ConstExpression_ptr> arguments);
+    void send_proxy(const std::string module_name, const std::string module_type, const std::vector<ConstExpression_ptr> arguments) override;
+    void send_property(const std::string proxy_name, const std::string property_name, const ConstExpression_ptr expression) override;
+    void send_call(const std::string proxy_name, const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
+
+    // Expandable interface
+    bool is_ready() const override;
 };

--- a/main/modules/external_expander.h
+++ b/main/modules/external_expander.h
@@ -5,23 +5,33 @@
 #include <map>
 #include <string>
 
+class ExternalExpander;
+using ExternalExpander_ptr = std::shared_ptr<ExternalExpander>;
+
 class ExternalExpander : public Module {
 private:
-    const ConstSerial_ptr serial;
     unsigned long int last_message_millis = 0;
     bool ping_pending = false;
-    std::map<uint8_t, std::string> expander_names; // Maps expander IDs to their names
+    unsigned long boot_start_time;
 
-    void handle_messages();
+    void check_boot_progress();
     void ping();
+    void restart();
+    void handle_messages();
 
 public:
-    ExternalExpander(const std::string name, const ConstSerial_ptr serial);
+    const ConstSerial_ptr serial;
+    const char *expander_id;
+    MessageHandler message_handler;
+
+    ExternalExpander(const std::string name,
+                     const ConstSerial_ptr serial,
+                     const char *expander_id,
+                     MessageHandler message_handler);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
-
-    // Register a new external expander
-    void register_expander(uint8_t id, const std::string &name);
-
+    void send_proxy(const std::string module_name, const std::string module_type, const std::vector<ConstExpression_ptr> arguments);
+    void send_property(const std::string proxy_name, const std::string property_name, const ConstExpression_ptr expression);
+    void send_call(const std::string proxy_name, const std::string method_name, const std::vector<ConstExpression_ptr> arguments);
     static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/external_expander.h
+++ b/main/modules/external_expander.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "module.h"
+#include "serial.h"
+#include <map>
+#include <string>
+
+class ExternalExpander : public Module {
+private:
+    const ConstSerial_ptr serial;
+    unsigned long int last_message_millis = 0;
+    bool ping_pending = false;
+    std::map<uint8_t, std::string> expander_names; // Maps expander IDs to their names
+
+    void handle_messages();
+    void ping();
+
+public:
+    ExternalExpander(const std::string name, const ConstSerial_ptr serial);
+    void step() override;
+    void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+
+    // Register a new external expander
+    void register_expander(uint8_t id, const std::string &name);
+
+    static const std::map<std::string, Variable_ptr> get_defaults();
+};

--- a/main/modules/external_expander.h
+++ b/main/modules/external_expander.h
@@ -22,12 +22,12 @@ private:
 
 public:
     const ConstSerial_ptr serial;
-    const char *expander_id;
+    const uint8_t expander_id;
     MessageHandler message_handler;
 
     ExternalExpander(const std::string name,
                      const ConstSerial_ptr serial,
-                     const char *expander_id,
+                     uint8_t expander_id,
                      MessageHandler message_handler);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;

--- a/main/modules/module.cpp
+++ b/main/modules/module.cpp
@@ -14,6 +14,7 @@
 #include "dunker_motor.h"
 #include "dunker_wheels.h"
 #include "expander.h"
+#include "external_expander.h"
 #include "imu.h"
 #include "input.h"
 #include "linear_motor.h"
@@ -81,6 +82,16 @@ Module_ptr Module::create(const std::string type,
         const gpio_num_t boot_pin = arguments.size() > 1 ? (gpio_num_t)arguments[1]->evaluate_integer() : GPIO_NUM_NC;
         const gpio_num_t enable_pin = arguments.size() > 2 ? (gpio_num_t)arguments[2]->evaluate_integer() : GPIO_NUM_NC;
         return std::make_shared<Expander>(name, serial, boot_pin, enable_pin, message_handler);
+    } else if (type == "ExternalExpander") {
+        Module::expect(arguments, 2, identifier, integer);
+        std::string serial_name = arguments[0]->evaluate_identifier();
+        Module_ptr module = Global::get_module(serial_name);
+        if (module->type != serial) {
+            throw std::runtime_error("module \"" + serial_name + "\" is no serial connection");
+        }
+        const ConstSerial_ptr serial = std::static_pointer_cast<const Serial>(module);
+        uint8_t id = arguments[1]->evaluate_integer();
+        return std::make_shared<ExternalExpander>(name, serial, id, message_handler);
     } else if (type == "Bluetooth") {
         Module::expect(arguments, 1, string);
         std::string device_name = arguments[0]->evaluate_string();

--- a/main/modules/module.h
+++ b/main/modules/module.h
@@ -45,6 +45,7 @@ enum ModuleType {
     dunker_wheels,
     analog,
     proxy,
+    external_expander,
 };
 
 class Module;

--- a/main/modules/proxy.cpp
+++ b/main/modules/proxy.cpp
@@ -1,19 +1,18 @@
 #include "proxy.h"
 #include "../utils/string_utils.h"
 #include "../utils/uart.h"
-#include "driver/uart.h"
 #include <memory>
 
 Proxy::Proxy(const std::string name,
              const std::string expander_name,
              const std::string module_type,
-             const Expander_ptr expander,
+             std::shared_ptr<Expandable> expander,
              const std::vector<ConstExpression_ptr> arguments)
     : Module(proxy, name), expander(expander) {
     this->properties = Module::get_module_defaults(module_type);
     this->properties["is_ready"] = std::make_shared<BooleanVariable>(false);
 
-    if (this->expander->get_property("is_ready")->boolean_value) {
+    if (this->expander->is_ready()) {
         this->expander->send_proxy(name, module_type, arguments);
         this->properties["is_ready"]->boolean_value = true;
     } else {

--- a/main/modules/proxy.h
+++ b/main/modules/proxy.h
@@ -1,17 +1,17 @@
 #pragma once
 
-#include "expander.h"
+#include "expandable.h"
 #include "module.h"
 
 class Proxy : public Module {
 private:
-    const Expander_ptr expander;
+    std::shared_ptr<Expandable> expander;
 
 public:
     Proxy(const std::string name,
           const std::string expander_name,
           const std::string module_type,
-          const Expander_ptr expander,
+          std::shared_ptr<Expandable> expander,
           const std::vector<ConstExpression_ptr> arguments);
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) override;

--- a/main/modules/serial.cpp
+++ b/main/modules/serial.cpp
@@ -169,3 +169,11 @@ void Serial::call(const std::string method_name, const std::vector<ConstExpressi
         Module::call(method_name, arguments);
     }
 }
+
+void Serial::activate_external_mode() const {
+    uart_write_bytes(this->uart_num, "\x80", 1);
+}
+
+void Serial::deactivate_external_mode() const {
+    uart_write_bytes(this->uart_num, "\x81", 1);
+}

--- a/main/modules/serial.cpp
+++ b/main/modules/serial.cpp
@@ -171,9 +171,11 @@ void Serial::call(const std::string method_name, const std::vector<ConstExpressi
 }
 
 void Serial::activate_external_mode() const {
-    uart_write_bytes(this->uart_num, "\x80", 1);
+    uart_write_bytes(this->uart_num, "\x80\n", 2);
+    echo("Debug: Activated external mode");
 }
 
 void Serial::deactivate_external_mode() const {
-    uart_write_bytes(this->uart_num, "\x81", 1);
+    uart_write_bytes(this->uart_num, "\x81\n", 2);
+    echo("Debug: Deactivated external mode");
 }

--- a/main/modules/serial.h
+++ b/main/modules/serial.h
@@ -32,6 +32,8 @@ public:
     void write_checked_line(const char *message, const int length) const;
     void flush() const;
     void clear() const;
+    void activate_external_mode() const;
+    void deactivate_external_mode() const;
     std::string get_output() const override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     static const std::map<std::string, Variable_ptr> get_defaults();


### PR DESCRIPTION
This is the external expander module for 5.3.1. It is recreated in here, since there were major changes on Lizard since the last development of the external expander.

- [ ] Untested / not confirmed working changes from the old 4.7 external expander
- [ ] Initialize external expander with _<ID>_READY_ check
- [ ] Confirmed one-way communication with ID-tag and ID being handled correctly
- [ ] Activate and deactivate external expander mode on esp
- [ ] Confirmed two-way communication with ID-tag and ID
- [ ] Setting up proxies
- [ ] Update proxies with external expander
- [ ] Work with multiple external expanders
- [ ] Handle mode switches correctly (no spam from multiple expanders on deactivation)