### PR TITLE
Add more IMU properties and allow setting the operation mode

### DIFF
--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -189,35 +189,50 @@ The constructor expects up to five arguments:
 - `address`: client address of the MCP (0x28 or 0x29, default: 0x28)
 - `clk_speed`: I2C clock speed (default: 100000)
 
-| Properties    | Description                                     | Data type |
-| ------------- | ----------------------------------------------- | --------- |
-| `imu.cal_sys` | calibration: system (0 to 3)                    | `int`     |
-| `imu.cal_gyr` | calibration: gyroscope (0 to 3)                 | `int`     |
-| `imu.cal_acc` | calibration: accelerometer (0 to 3)             | `int`     |
-| `imu.cal_mag` | calibration: magnetometer (0 to 3)              | `int`     |
-| `imu.acc_x`   | acceleration incl. gravity: x direction (m/s^2) | `float`   |
-| `imu.acc_y`   | acceleration incl. gravity: y direction (m/s^2) | `float`   |
-| `imu.acc_z`   | acceleration incl. gravity: z direction (m/s^2) | `float`   |
-| `imu.mag_x`   | magnetic field strength: x direction (µT)       | `float`   |
-| `imu.mag_y`   | magnetic field strength: y direction (µT)       | `float`   |
-| `imu.mag_z`   | magnetic field strength: z direction (µT)       | `float`   |
-| `imu.gyr_x`   | gyroscope: x direction (degrees/s)              | `float`   |
-| `imu.gyr_y`   | gyroscope: y direction (degrees/s)              | `float`   |
-| `imu.gyr_z`   | gyroscope: z direction (degrees/s)              | `float`   |
-| `imu.yaw`     | orientation: Euler angle yaw (degrees)          | `float`   |
-| `imu.roll`    | orientation: Euler angle roll (degrees)         | `float`   |
-| `imu.pitch`   | orientation: Euler angle pitch (degrees)        | `float`   |
-| `imu.quat_w`  | orientation: quaternion component w             | `float`   |
-| `imu.quat_x`  | orientation: quaternion component x             | `float`   |
-| `imu.quat_y`  | orientation: quaternion component y             | `float`   |
-| `imu.quat_z`  | orientation: quaternion component z             | `float`   |
-| `imu.lin_x`   | acceleration excl. gravity: x direction (m/s^2) | `float`   |
-| `imu.lin_y`   | acceleration excl. gravity: y direction (m/s^2) | `float`   |
-| `imu.lin_z`   | acceleration excl. gravity: z direction (m/s^2) | `float`   |
-| `imu.grav_x`  | gravity: x direction (m/s^2)                    | `float`   |
-| `imu.grav_y`  | gravity: y direction (m/s^2)                    | `float`   |
-| `imu.grav_z`  | gravity: z direction (m/s^2)                    | `float`   |
-| `imu.temp`    | temperature (degrees Celsius)                   | `int`     |
+| Properties        | Description                                     | Data type |
+| ----------------- | ----------------------------------------------- | --------- |
+| `imu.cal_sys`     | calibration: system (0 to 3)                    | `int`     |
+| `imu.cal_gyr`     | calibration: gyroscope (0 to 3)                 | `int`     |
+| `imu.cal_acc`     | calibration: accelerometer (0 to 3)             | `int`     |
+| `imu.cal_mag`     | calibration: magnetometer (0 to 3)              | `int`     |
+| `imu.acc_x`       | acceleration incl. gravity: x direction (m/s^2) | `float`   |
+| `imu.acc_y`       | acceleration incl. gravity: y direction (m/s^2) | `float`   |
+| `imu.acc_z`       | acceleration incl. gravity: z direction (m/s^2) | `float`   |
+| `imu.mag_x`       | magnetic field strength: x direction (µT)       | `float`   |
+| `imu.mag_y`       | magnetic field strength: y direction (µT)       | `float`   |
+| `imu.mag_z`       | magnetic field strength: z direction (µT)       | `float`   |
+| `imu.gyr_x`       | gyroscope: x direction (degrees/s)              | `float`   |
+| `imu.gyr_y`       | gyroscope: y direction (degrees/s)              | `float`   |
+| `imu.gyr_z`       | gyroscope: z direction (degrees/s)              | `float`   |
+| `imu.yaw`         | orientation: Euler angle yaw (degrees)          | `float`   |
+| `imu.roll`        | orientation: Euler angle roll (degrees)         | `float`   |
+| `imu.pitch`       | orientation: Euler angle pitch (degrees)        | `float`   |
+| `imu.quat_w`      | orientation: quaternion component w             | `float`   |
+| `imu.quat_x`      | orientation: quaternion component x             | `float`   |
+| `imu.quat_y`      | orientation: quaternion component y             | `float`   |
+| `imu.quat_z`      | orientation: quaternion component z             | `float`   |
+| `imu.lin_x`       | acceleration excl. gravity: x direction (m/s^2) | `float`   |
+| `imu.lin_y`       | acceleration excl. gravity: y direction (m/s^2) | `float`   |
+| `imu.lin_z`       | acceleration excl. gravity: z direction (m/s^2) | `float`   |
+| `imu.grav_x`      | gravity: x direction (m/s^2)                    | `float`   |
+| `imu.grav_y`      | gravity: y direction (m/s^2)                    | `float`   |
+| `imu.grav_z`      | gravity: z direction (m/s^2)                    | `float`   |
+| `imu.temp`        | temperature (degrees Celsius)                   | `int`     |
+| `imu.data_select` | data selection                                  | `int`     |
+
+The `data_select` property can be used to select which data is read from the IMU.
+The default value is 0xffff, which means all data is read.
+The following bits are available:
+
+- 0x0001: calibration status
+- 0x0002: accelerometer data
+- 0x0004: magnetometer data
+- 0x0008: gyroscope data
+- 0x0010: Euler angles
+- 0x0020: quaternion
+- 0x0040: linear acceleration
+- 0x0080: gravity
+- 0x0100: temperature
 
 | Methods              | Description                   | Arguments |
 | -------------------- | ----------------------------- | --------- |

--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -189,22 +189,71 @@ The constructor expects up to five arguments:
 - `address`: client address of the MCP (0x28 or 0x29, default: 0x28)
 - `clk_speed`: I2C clock speed (default: 100000)
 
-| Properties    | Description                           | Data type |
-| ------------- | ------------------------------------- | --------- |
-| `imu.acc_x`   | acceleration in x direction (m/s^2)   | `float`   |
-| `imu.acc_y`   | acceleration in y direction (m/s^2)   | `float`   |
-| `imu.acc_z`   | acceleration in z direction (m/s^2)   | `float`   |
-| `imu.roll`    | roll (degrees, see datasheet)         | `float`   |
-| `imu.pitch`   | pitch (degrees, see datasheet)        | `float`   |
-| `imu.yaw`     | yaw (degrees, see datasheet)          | `float`   |
-| `imu.quat_w`  | quaternion component w                | `float`   |
-| `imu.quat_x`  | quaternion component x                | `float`   |
-| `imu.quat_y`  | quaternion component y                | `float`   |
-| `imu.quat_z`  | quaternion component z                | `float`   |
-| `imu.cal_sys` | calibration of system (0 to 3)        | `float`   |
-| `imu.cal_gyr` | calibration of gyroscope (0 to 3)     | `float`   |
-| `imu.cal_acc` | calibration of accelerometer (0 to 3) | `float`   |
-| `imu.cal_mag` | calibration of magnetometer (0 to 3)  | `float`   |
+| Properties    | Description                                     | Data type |
+| ------------- | ----------------------------------------------- | --------- |
+| `imu.cal_sys` | calibration: system (0 to 3)                    | `int`     |
+| `imu.cal_gyr` | calibration: gyroscope (0 to 3)                 | `int`     |
+| `imu.cal_acc` | calibration: accelerometer (0 to 3)             | `int`     |
+| `imu.cal_mag` | calibration: magnetometer (0 to 3)              | `int`     |
+| `imu.acc_x`   | acceleration incl. gravity: x direction (m/s^2) | `float`   |
+| `imu.acc_y`   | acceleration incl. gravity: y direction (m/s^2) | `float`   |
+| `imu.acc_z`   | acceleration incl. gravity: z direction (m/s^2) | `float`   |
+| `imu.mag_x`   | magnetic field strength: x direction (µT)       | `float`   |
+| `imu.mag_y`   | magnetic field strength: y direction (µT)       | `float`   |
+| `imu.mag_z`   | magnetic field strength: z direction (µT)       | `float`   |
+| `imu.gyr_x`   | gyroscope: x direction (degrees/s)              | `float`   |
+| `imu.gyr_y`   | gyroscope: y direction (degrees/s)              | `float`   |
+| `imu.gyr_z`   | gyroscope: z direction (degrees/s)              | `float`   |
+| `imu.yaw`     | orientation: Euler angle yaw (degrees)          | `float`   |
+| `imu.roll`    | orientation: Euler angle roll (degrees)         | `float`   |
+| `imu.pitch`   | orientation: Euler angle pitch (degrees)        | `float`   |
+| `imu.quat_w`  | orientation: quaternion component w             | `float`   |
+| `imu.quat_x`  | orientation: quaternion component x             | `float`   |
+| `imu.quat_y`  | orientation: quaternion component y             | `float`   |
+| `imu.quat_z`  | orientation: quaternion component z             | `float`   |
+| `imu.lin_x`   | acceleration excl. gravity: x direction (m/s^2) | `float`   |
+| `imu.lin_y`   | acceleration excl. gravity: y direction (m/s^2) | `float`   |
+| `imu.lin_z`   | acceleration excl. gravity: z direction (m/s^2) | `float`   |
+| `imu.grav_x`  | gravity: x direction (m/s^2)                    | `float`   |
+| `imu.grav_y`  | gravity: y direction (m/s^2)                    | `float`   |
+| `imu.grav_z`  | gravity: z direction (m/s^2)                    | `float`   |
+| `imu.temp`    | temperature (degrees Celsius)                   | `int`     |
+
+| Methods              | Description                   | Arguments |
+| -------------------- | ----------------------------- | --------- |
+| `imu.set_mode(mode)` | Set operation mode of the IMU | `str`     |
+
+The `mode` parameter can be one of the following:
+
+| Mode           | Accel | Mag | Gyro | Relative Orientation | Absolute Orientation |
+| -------------- | ----- | --- | ---- | -------------------- | -------------------- |
+| `configmode`   | -     | -   | -    | -                    | -                    |
+| `acconly`      | X     | -   | -    | -                    | -                    |
+| `magonly`      | -     | X   | -    | -                    | -                    |
+| `gyroonly`     | -     | -   | X    | -                    | -                    |
+| `accmag`       | X     | X   | -    | -                    | -                    |
+| `accgyro`      | X     | -   | X    | -                    | -                    |
+| `maggyro`      | -     | X   | X    | -                    | -                    |
+| `amg`          | X     | X   | X    | -                    | -                    |
+| `imu`          | X     | -   | X    | X                    | -                    |
+| `compass`      | X     | X   | -    | -                    | X                    |
+| `m4g`          | X     | X   |      | X                    | -                    |
+| `ndof_fmc_off` | X     | X   | X    | -                    | X                    |
+| `ndof`         | X     | X   | X    | -                    | X                    |
+
+In non-fusion modes (`acconly`, `magonly`, `gyroonly`, `accmag`, `accgyro`, `maggyro`, `amg`),
+the sensor signals (Accel, Mag, Gyro) are uncompensated and fusion data (Relative and Absolute Orientation) is not available.
+
+In fusion modes (`imu`, `compass`, `m4g`, `ndof_fmc_off`, `ndof`),
+the sensor signals (Accel, Mag, Gyro) are compensated and fusion data (Relative and Absolute Orientation) is available.
+
+Note that the individual sensors need to be calibrated before the compensated and fused data is accurate.
+
+| Sensor        | Calibration                                            |
+| ------------- | ------------------------------------------------------ |
+| Accelerometer | Position the sensor in 6 different stable orientations |
+| Magnetometer  | Move the sensor in a figure-8 pattern in space         |
+| Gyroscope     | Keep the sensor still for a few seconds                |
 
 ## CAN interface
 

--- a/main/modules/imu.cpp
+++ b/main/modules/imu.cpp
@@ -8,20 +8,33 @@ REGISTER_MODULE_DEFAULTS(Imu)
 
 const std::map<std::string, Variable_ptr> Imu::get_defaults() {
     return {
+        {"cal_sys", std::make_shared<IntegerVariable>()},
+        {"cal_gyr", std::make_shared<IntegerVariable>()},
+        {"cal_acc", std::make_shared<IntegerVariable>()},
+        {"cal_mag", std::make_shared<IntegerVariable>()},
         {"acc_x", std::make_shared<NumberVariable>()},
         {"acc_y", std::make_shared<NumberVariable>()},
         {"acc_z", std::make_shared<NumberVariable>()},
+        {"mag_x", std::make_shared<NumberVariable>()},
+        {"mag_y", std::make_shared<NumberVariable>()},
+        {"mag_z", std::make_shared<NumberVariable>()},
+        {"gyr_x", std::make_shared<NumberVariable>()},
+        {"gyr_y", std::make_shared<NumberVariable>()},
+        {"gyr_z", std::make_shared<NumberVariable>()},
+        {"yaw", std::make_shared<NumberVariable>()},
         {"roll", std::make_shared<NumberVariable>()},
         {"pitch", std::make_shared<NumberVariable>()},
-        {"yaw", std::make_shared<NumberVariable>()},
         {"quat_w", std::make_shared<NumberVariable>()},
         {"quat_x", std::make_shared<NumberVariable>()},
         {"quat_y", std::make_shared<NumberVariable>()},
         {"quat_z", std::make_shared<NumberVariable>()},
-        {"cal_sys", std::make_shared<NumberVariable>()},
-        {"cal_gyr", std::make_shared<NumberVariable>()},
-        {"cal_acc", std::make_shared<NumberVariable>()},
-        {"cal_mag", std::make_shared<NumberVariable>()},
+        {"lin_x", std::make_shared<NumberVariable>()},
+        {"lin_y", std::make_shared<NumberVariable>()},
+        {"lin_z", std::make_shared<NumberVariable>()},
+        {"grav_x", std::make_shared<NumberVariable>()},
+        {"grav_y", std::make_shared<NumberVariable>()},
+        {"grav_z", std::make_shared<NumberVariable>()},
+        {"temp", std::make_shared<IntegerVariable>()},
     };
 }
 
@@ -49,8 +62,6 @@ Imu::Imu(const std::string name, i2c_port_t i2c_port, gpio_num_t sda_pin, gpio_n
         this->bno->begin();
         this->bno->enableExternalCrystal();
         this->bno->setOprModeNdof();
-    } catch (BNO055BaseException &ex) {
-        throw std::runtime_error(std::string("imu setup failed: ") + ex.what());
     } catch (std::exception &ex) {
         throw std::runtime_error(std::string("imu setup failed: ") + ex.what());
     }
@@ -58,15 +69,31 @@ Imu::Imu(const std::string name, i2c_port_t i2c_port, gpio_num_t sda_pin, gpio_n
 }
 
 void Imu::step() {
+    bno055_calibration_t c = this->bno->getCalibration();
+    this->properties.at("cal_sys")->integer_value = c.sys;
+    this->properties.at("cal_gyr")->integer_value = c.gyro;
+    this->properties.at("cal_acc")->integer_value = c.accel;
+    this->properties.at("cal_mag")->integer_value = c.mag;
+
     bno055_vector_t v = this->bno->getVectorAccelerometer();
     this->properties.at("acc_x")->number_value = v.x;
     this->properties.at("acc_y")->number_value = v.y;
     this->properties.at("acc_z")->number_value = v.z;
 
-    bno055_vector_t e = this->bno->getVectorEuler();
-    this->properties.at("yaw")->number_value = e.x;
-    this->properties.at("roll")->number_value = e.y;
-    this->properties.at("pitch")->number_value = e.z;
+    v = this->bno->getVectorMagnetometer();
+    this->properties.at("mag_x")->number_value = v.x;
+    this->properties.at("mag_y")->number_value = v.y;
+    this->properties.at("mag_z")->number_value = v.z;
+
+    v = this->bno->getVectorGyroscope();
+    this->properties.at("gyr_x")->number_value = v.x;
+    this->properties.at("gyr_y")->number_value = v.y;
+    this->properties.at("gyr_z")->number_value = v.z;
+
+    v = this->bno->getVectorEuler();
+    this->properties.at("yaw")->number_value = v.x;
+    this->properties.at("roll")->number_value = v.y;
+    this->properties.at("pitch")->number_value = v.z;
 
     bno055_quaternion_t q = this->bno->getQuaternion();
     this->properties.at("quat_w")->number_value = q.w;
@@ -74,11 +101,60 @@ void Imu::step() {
     this->properties.at("quat_y")->number_value = q.y;
     this->properties.at("quat_z")->number_value = q.z;
 
-    bno055_calibration_t c = this->bno->getCalibration();
-    this->properties.at("cal_sys")->number_value = c.sys;
-    this->properties.at("cal_gyr")->number_value = c.gyro;
-    this->properties.at("cal_acc")->number_value = c.accel;
-    this->properties.at("cal_mag")->number_value = c.mag;
+    v = this->bno->getVectorLinearAccel();
+    this->properties.at("lin_x")->number_value = v.x;
+    this->properties.at("lin_y")->number_value = v.y;
+    this->properties.at("lin_z")->number_value = v.z;
+
+    bno055_vector_t g = this->bno->getVectorGravity();
+    this->properties.at("grav_x")->number_value = g.x;
+    this->properties.at("grav_y")->number_value = g.y;
+    this->properties.at("grav_z")->number_value = g.z;
+
+    this->properties.at("temp")->number_value = this->bno->getTemp();
 
     Module::step();
+}
+
+void Imu::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
+    if (method_name == "set_mode") {
+        Module::expect(arguments, 1, string);
+        std::string mode = arguments[0]->evaluate_string();
+        std::transform(mode.begin(), mode.end(), mode.begin(), ::tolower);
+        try {
+            if (mode == "configmode") {
+                this->bno->setOprModeConfig();
+            } else if (mode == "acconly") {
+                this->bno->setOprModeAccOnly();
+            } else if (mode == "magonly") {
+                this->bno->setOprModeMagOnly();
+            } else if (mode == "gyroonly") {
+                this->bno->setOprModeGyroOnly();
+            } else if (mode == "accmag") {
+                this->bno->setOprModeAccMag();
+            } else if (mode == "accgyro") {
+                this->bno->setOprModeAccGyro();
+            } else if (mode == "maggyro") {
+                this->bno->setOprModeMagGyro();
+            } else if (mode == "amg") {
+                this->bno->setOprModeAMG();
+            } else if (mode == "imu") {
+                this->bno->setOprModeIMU();
+            } else if (mode == "compass") {
+                this->bno->setOprModeCompass();
+            } else if (mode == "m4g") {
+                this->bno->setOprModeM4G();
+            } else if (mode == "ndof_fmc_off") {
+                this->bno->setOprModeNdofFmcOff();
+            } else if (mode == "ndof") {
+                this->bno->setOprModeNdof();
+            } else {
+                throw std::runtime_error("invalid mode: " + mode);
+            }
+        } catch (std::exception &ex) {
+            throw std::runtime_error(std::string("setting imu mode failed: ") + ex.what());
+        }
+    } else {
+        Module::call(method_name, arguments);
+    }
 }

--- a/main/modules/imu.h
+++ b/main/modules/imu.h
@@ -18,5 +18,6 @@ private:
 public:
     Imu(const std::string name, i2c_port_t i2c_port, gpio_num_t sda_pin, gpio_num_t scl_pin, uint8_t address, int clk_speed);
     void step() override;
+    void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
 };


### PR DESCRIPTION
This PR allows to access more properties (calibration, acceleration, magnetometer, gyroscope, Euler/quaternion orientation, linear acceleration, gravity, temperature) and to change the operation mode.

Open tasks:

- [x] measure time for reading _all_ data -> about 15ms
- [x] change `set_mode` method to a read-/writable `mode` property -> maybe later, not necessary right now
- [x] selectively read attributes from BNO055 based on current value of ~~this property~~ a new `data_select` property

The latter is an idea to reduce the I2C traffic. If the operation mode is GYROONLY, it doesn't make too much sense to fetch acceleration data.
But on the other hand, it might still be useful to fetch orientation data, even though the datasheet says such fused data isn't available in non-fusion modes. Empirically it looks like orientation data is still provided and would be useful to avoid the need to integrate angular velocities on the host system.