### PR TITLE
Wait for uart TX to be done

### DIFF
--- a/main/utils/uart.cpp
+++ b/main/utils/uart.cpp
@@ -4,6 +4,7 @@
 #include <stdexcept>
 #include <stdio.h>
 #include <string>
+
 void echo(const char *format, ...) {
     static char buffer[1024];
 

--- a/main/utils/uart.cpp
+++ b/main/utils/uart.cpp
@@ -1,9 +1,9 @@
 #include "uart.h"
+#include "driver/uart.h"
 #include <cstdarg>
 #include <stdexcept>
 #include <stdio.h>
 #include <string>
-
 void echo(const char *format, ...) {
     static char buffer[1024];
 
@@ -26,6 +26,10 @@ void echo(const char *format, ...) {
         } else {
             checksum ^= buffer[i];
         }
+    }
+    esp_err_t err = uart_wait_tx_done(UART_NUM_0, 500 / portTICK_PERIOD_MS);
+    if (err != ESP_OK) {
+        printf("uart_wait_tx_done failed: %s\n", esp_err_to_name(err));
     }
 }
 


### PR DESCRIPTION
This will fix the problem from #134 
It will wait for each echo to be fully send out. We tested this already on a robot, and my stress test also does not result in checksum mismatches.

Sometimes, there are still checksum mismatches, but they are caused by a different problem. Yet, they are not breaking like this one was.