### PR TITLE
Allow reading voltages from dunker motors

### DIFF
--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -698,11 +698,15 @@ This module controls [dunkermotoren](https://www.dunkermotoren.de/) motor via CA
 | ----------------------------------- | ------------------------------- | ----------------- |
 | `motor = DunkerMotor(can, node_id)` | CAN module and node ID (1..127) | CAN module, `int` |
 
-| Properties         | Description                     | Data type |
-| ------------------ | ------------------------------- | --------- |
-| `motor.speed`      | Motor speed (meters per second) | `float`   |
-| `motor.m_per_turn` | Meters per turn                 | `float`   |
-| `motor.reversed`   | Reverse motor direction         | `bool`    |
+| Properties            | Description                     | Data type |
+| --------------------- | ------------------------------- | --------- |
+| `motor.speed`         | Motor speed (meters per second) | `float`   |
+| `motor.voltage_logic` | Voltage logic (V)               | `float`   |
+| `motor.voltage_power` | Voltage power (V)               | `float`   |
+| `motor.m_per_turn`    | Meters per turn                 | `float`   |
+| `motor.reversed`      | Reverse motor direction         | `bool`    |
+
+Note: To reduce bandwidth, voltages are only queried when explicitly requested by calling `update_voltages()`.
 
 | Methods                                         | Description                   | Arguments |
 | ----------------------------------------------- | ----------------------------- | --------- |
@@ -711,6 +715,7 @@ This module controls [dunkermotoren](https://www.dunkermotoren.de/) motor via CA
 | `motor.disable()`                               | Disable motor                 |           |
 | `motor.sdo_read(index[, subindex])`             | Read SDO                      | 2x `int`  |
 | `motor.sdo_write(index, subindex, bits, value)` | Write SDO                     | 4x `int`  |
+| `motor.update_voltages()`                       | Update voltages               |           |
 
 ## DunkerWheels
 

--- a/main/modules/dunker_motor.cpp
+++ b/main/modules/dunker_motor.cpp
@@ -1,7 +1,7 @@
 #include "dunker_motor.h"
 #include "canopen.h"
-#include "uart.h"
 #include "utils/timing.h"
+#include "utils/uart.h"
 #include <cinttypes>
 
 REGISTER_MODULE_DEFAULTS(DunkerMotor)
@@ -9,6 +9,8 @@ REGISTER_MODULE_DEFAULTS(DunkerMotor)
 const std::map<std::string, Variable_ptr> DunkerMotor::get_defaults() {
     return {
         {"speed", std::make_shared<NumberVariable>()},
+        {"voltage_logic", std::make_shared<NumberVariable>()},
+        {"voltage_power", std::make_shared<NumberVariable>()},
         {"m_per_turn", std::make_shared<NumberVariable>(1.0)},
         {"reversed", std::make_shared<BooleanVariable>()},
     };
@@ -115,6 +117,10 @@ void DunkerMotor::call(const std::string method_name, const std::vector<ConstExp
     } else if (method_name == "speed") {
         Module::expect(arguments, 1, numbery);
         this->speed(arguments[0]->evaluate_number());
+    } else if (method_name == "update_voltages") {
+        Module::expect(arguments, 0);
+        this->sdo_read(0x4110, 1);
+        this->sdo_read(0x4111, 1);
     } else {
         Module::call(method_name, arguments);
     }
@@ -126,6 +132,12 @@ void DunkerMotor::handle_can_msg(const uint32_t id, const int count, const uint8
     }
     if (id == 0x580 + this->node_id) {
         this->waiting_sdo_writes--;
+        if (data[0] == 0x43 && data[1] == 0x10 && data[2] == 0x41 && data[3] == 0x01) {
+            this->properties["voltage_logic"]->number_value = ((data[5] << 8) | data[4]) / 1000.0;
+        }
+        if (data[0] == 0x43 && data[1] == 0x11 && data[2] == 0x41 && data[3] == 0x01) {
+            this->properties["voltage_power"]->number_value = ((data[5] << 8) | data[4]) / 1000.0;
+        }
     }
     if (id == 0x180 + this->node_id) {
         const int32_t motor_speed = demarshal_i32(data);


### PR DESCRIPTION
This PR adds properties "voltage_logic" and "voltage_power" as well as the method "update_voltages()" to the DunkerMotor module. I couldn't manage to setup TPDOs to automatically update voltages in a fixed interval, so I decided to leave it up to the user to update them on demand.