### PR TITLE
Add disable function to esp class

### DIFF
--- a/.syncignore
+++ b/.syncignore
@@ -4,6 +4,7 @@ __pycache__/
 *.tmp
 .env
 .venv
+.mypy_cache
 
 # Ignore everything in build except li*, bo* and pa*
 build/[c-kC-K]*

--- a/esp.py
+++ b/esp.py
@@ -83,7 +83,5 @@ class Esp:
 
     def disable(self) -> None:
         print('Disabling microcontroller...')
-        self.write(f'{self.gpio_g0}/value', self.on)
-        sleep(0.5)
         self.write(f'{self.gpio_en}/value', self.on)
         print('disable complete')

--- a/esp.py
+++ b/esp.py
@@ -72,14 +72,18 @@ class Esp:
         self.write(f'{self.gpio_en}/value', self.on)
         sleep(0.5)
         self.write(f'{self.gpio_en}/value', self.off)
+        print('reset complete')
 
     def enable(self) -> None:
         print('Enabling microcontroller...')
         self.write(f'{self.gpio_g0}/value', self.off)
         sleep(0.5)
         self.write(f'{self.gpio_en}/value', self.off)
+        print('enable complete')
+
     def disable(self) -> None:
         print('Disabling microcontroller...')
         self.write(f'{self.gpio_g0}/value', self.on)
         sleep(0.5)
         self.write(f'{self.gpio_en}/value', self.on)
+        print('disable complete')

--- a/esp.py
+++ b/esp.py
@@ -78,3 +78,8 @@ class Esp:
         self.write(f'{self.gpio_g0}/value', self.off)
         sleep(0.5)
         self.write(f'{self.gpio_en}/value', self.off)
+    def disable(self) -> None:
+        print('Disabling microcontroller...')
+        self.write(f'{self.gpio_g0}/value', self.on)
+        sleep(0.5)
+        self.write(f'{self.gpio_en}/value', self.on)

--- a/flash.py
+++ b/flash.py
@@ -42,6 +42,12 @@ if 'enable' in sys.argv:
         esp.enable()
     sys.exit()
 
+if 'disable' in sys.argv:
+    with esp.pin_config():
+        print('Disabling ESP...')
+        esp.disable()
+    sys.exit()
+
 if 'reset' in sys.argv:
     with esp.pin_config():
         print('Resetting ESP...')


### PR DESCRIPTION
The esp class already supports enabling and resetting the microcontroller, this adds functionality to disable it.
This will be used in a future security feature to shut the microcontroller down, when it doesn't respond anymore.

After it's disabled, it needs to be reset to get running again; not to be enabled.