### PR TITLE
Introduce espresso.py to replace flash.py in the future

### DIFF
--- a/.github/zip_content.txt
+++ b/.github/zip_content.txt
@@ -6,6 +6,7 @@ backtrace.sh
 configure.py
 core_dumper.py
 esp.py
+espresso.py
 flash.py
 monitor.py
 README.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
   "editor.formatOnSave": true,
   "prettier.printWidth": 120,
   "pylint.args": [
+    "--disable=C0103", // Invalid name
     "--disable=C0114", // Missing module docstring
     "--disable=C0115", // Missing class docstring
     "--disable=C0116", // Missing function or method docstring

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -4,7 +4,7 @@
 
 1. Download and unpack the zip file of the [latest release](https://github.com/zauberzeug/lizard/releases).
 2. Attach an Espressif ESP32 microcontroller via serial to your computer.
-3. Run `sudo ./flash.py /dev/<serial device name>` to install Lizard on the ESP32.
+3. Run `sudo ./espresso.py flash -d /dev/<serial device name>` to install Lizard on the ESP32.
 
 ## Try Out
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -7,7 +7,7 @@
 To install Lizard on your ESP32 run
 
 ```bash
-sudo ./flash.py [<device_path>]
+sudo ./espresso.py flash -d <device_path>
 ```
 
 Note that flashing may require root access (hence the sudo).
@@ -15,7 +15,8 @@ The command also does not work while the serial interface is busy communicating 
 
 ### Robot Brain
 
-The `flash.py` script can also upload firmware on a [Robot Brain](https://www.zauberzeug.com/product-robot-brain.html) where the microcontroller is connected to the pin header of an NVIDIA Jetson computer.
+The `espresso.py` script can also upload firmware on a [Robot Brain](https://www.zauberzeug.com/product-robot-brain.html)
+where the microcontroller is connected to the pin header of an NVIDIA Jetson computer.
 
 ## Interaction
 
@@ -71,7 +72,7 @@ After making changes to the Lizard language definition or its C++ implementation
 ./compile.sh
 ```
 
-To upload the compiled firmware you can use the `./flash.py` command described above.
+To upload the compiled firmware you can use the `./espresso.py` command described above.
 
 ### Backtrace
 

--- a/espresso.py
+++ b/espresso.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+
+import argparse
+from typing import Generator, Union
+import time
+from pathlib import Path
+from contextlib import contextmanager
+
+parser = argparse.ArgumentParser(description='Flash and control an ESP32 microcontroller from a Jetson board')
+
+parser.add_argument('command', choices=['flash', 'enable', 'disable', 'reset', 'erase'], help='Command to execute')
+parser.add_argument('-j', '--jetson', choices=['nano', 'xavier', 'orin'], help='Jetson board type')
+parser.add_argument('--nand', action='store_true', help='Board has NAND gates')
+parser.add_argument('--swap_pins', action='store_true',
+                    help='Swap EN and G0 pins (for Jetson Orin with piggyback older than V0.5)')
+parser.add_argument('--bootloader', default='build/bootloader/bootloader.bin', help='Path to bootloader')
+parser.add_argument('--partition-table', default='build/partition_table/partition-table.bin',
+                    help='Path to partition table')
+parser.add_argument('--firmware', default='build/lizard.bin', help='Path to firmware binary')
+parser.add_argument('-d', '--dry-run', action='store_true', help='Dry run')
+parser.add_argument('device', default='/dev/tty.SLAB_USBtoUART', help='Serial device path')
+
+args = parser.parse_args()
+
+EN_PIN = {'nano': 216, 'xavier': 436, 'orin': 460}[args.jetson]
+G0_PIN = {'nano': 50, 'xavier': 428, 'orin': 492}[args.jetson]
+GPIO_EN = 'PR.04' if args.jetson == 'orin' else f'gpio{EN_PIN}'
+GPIO_G0 = 'PAC.06' if args.jetson == 'orin' else f'gpio{G0_PIN}'
+if args.swap_pins:
+    EN_PIN, G0_PIN = G0_PIN, EN_PIN
+    GPIO_EN, GPIO_G0 = GPIO_G0, GPIO_EN
+DEVICE = args.device or {
+    'nano': '/dev/ttyTHS1',
+    'xavier': '/dev/ttyTHS0',
+    'orin': '/dev/ttyTHS0',
+}[args.jetson]
+ON = 1 if args.nand else 0
+OFF = 0 if args.nand else 1
+DRY_RUN = args.dry_run
+
+
+@contextmanager
+def pin_config() -> Generator[None, None, None]:
+    """Configure the EN and G0 pins to control the microcontroller."""
+    print_bold('Configuring EN and G0 pins...')
+    write_gpio('export', EN_PIN)
+    time.sleep(0.5)
+    write_gpio('export', G0_PIN)
+    time.sleep(0.5)
+    write_gpio(f'{GPIO_EN}/direction', 'out')
+    time.sleep(0.5)
+    write_gpio(f'{GPIO_G0}/direction', 'out')
+    time.sleep(0.5)
+    yield
+    write_gpio('unexport', EN_PIN)
+    time.sleep(0.5)
+    write_gpio('unexport', G0_PIN)
+
+
+@contextmanager
+def flash_mode() -> Generator[None, None, None]:
+    """Bring the microcontroller into flash mode."""
+    print_bold('Bringing the microcontroller into flash mode...')
+    write_gpio(f'{GPIO_EN}/value', ON)
+    time.sleep(0.5)
+    write_gpio(f'{GPIO_G0}/value', ON)
+    time.sleep(0.5)
+    write_gpio(f'{GPIO_EN}/value', OFF)
+    time.sleep(0.5)
+    yield
+    reset()
+
+
+def enable() -> None:
+    """Enable the microcontroller."""
+    print_bold('Enabling the microcontroller...')
+    with pin_config():
+        write_gpio(f'{GPIO_G0}/value', OFF)
+        time.sleep(0.5)
+        write_gpio(f'{GPIO_EN}/value', OFF)
+
+
+def disable() -> None:
+    """Disable the microcontroller."""
+    print_bold('Disabling the microcontroller...')
+    with pin_config():
+        write_gpio(f'{GPIO_EN}/value', ON)
+
+
+def reset() -> None:
+    """Reset the microcontroller."""
+    print_bold('Resetting the microcontroller...')
+    with pin_config():
+        write_gpio(f'{GPIO_G0}/value', OFF)
+        time.sleep(0.5)
+        write_gpio(f'{GPIO_EN}/value', ON)
+        time.sleep(0.5)
+        write_gpio(f'{GPIO_EN}/value', OFF)
+
+
+def erase() -> None:
+    """Erase the microcontroller."""
+    print_bold('Erasing the microcontroller...')
+    with pin_config():
+        with flash_mode():
+            success = run(
+                'esptool.py',
+                '--chip', 'esp32',
+                '--port', DEVICE,
+                '--baud', '921600',
+                '--before', 'default_reset',
+                '--after', 'hard_reset',
+                'erase_flash',
+            )
+            if not success:
+                print('Failed to erase flash.')
+                sys.exit(1)
+
+
+def flash() -> None:
+    """Flash the microcontroller."""
+    print_bold('Flashing...')
+    with pin_config():
+        with flash_mode():
+            success = run(
+                'esptool.py',
+                '--chip', 'esp32',
+                '--port', DEVICE,
+                '--baud', '921600',
+                '--before', 'default_reset',
+                '--after', 'hard_reset',
+                'write_flash',
+                '-z',
+                '--flash_mode', 'dio',
+                '--flash_freq', '40m',
+                '--flash_size', 'detect',
+                '0x1000', args.bootloader,
+                '0x8000', args.partition_table,
+                '0x20000', args.firmware,
+            )
+            if not success:
+                print_fail('Flashing failed. Maybe you need different parameters? Or you forgot "sudo"?\n')
+                sys.exit(1)
+
+
+def run(*run_args: str) -> bool:
+    """Run a command and return whether it was successful."""
+    print(f'  {" ".join(run_args)}')
+    if DRY_RUN:
+        return True
+    result = subprocess.run(run_args, check=False)
+    return result.returncode == 0
+
+
+def write_gpio(path: str, value: Union[str, int]) -> None:
+    """Write a value to a GPIO file."""
+    print(f'  echo {value:3} > /sys/class/gpio/{path}')
+    if DRY_RUN:
+        return
+    Path(f'/sys/class/gpio/{path}').write_text(f'{value}\n', encoding='utf-8')
+
+
+def print_ok(message: str) -> None:
+    print_bold(f'\033[94m{message}\033[0m')
+
+
+def print_bold(message: str) -> None:
+    print(f'\033[1m{message}\033[0m')
+
+
+def print_fail(message: str) -> None:
+    print(f'\033[91m{message}\033[0m')
+
+
+def main(command: str) -> None:
+    print_ok('Espresso dry-running...' if DRY_RUN else 'Espresso running...')
+    if command == 'enable':
+        enable()
+    elif command == 'disable':
+        disable()
+    elif command == 'reset':
+        reset()
+    elif command == 'erase':
+        erase()
+    elif command == 'flash':
+        flash()
+    else:
+        print(f'Invalid command "{command}".')
+        sys.exit(1)
+    print_ok('Finished. ☕️')
+
+
+if __name__ == '__main__':
+    main(args.command)

--- a/espresso.py
+++ b/espresso.py
@@ -20,7 +20,8 @@ parser.add_argument('--partition-table', default='build/partition_table/partitio
                     help='Path to partition table')
 parser.add_argument('--firmware', default='build/lizard.bin', help='Path to firmware binary')
 parser.add_argument('-d', '--dry-run', action='store_true', help='Dry run')
-parser.add_argument('device', default='/dev/tty.SLAB_USBtoUART', help='Serial device path (overwritten by --jetson)')
+parser.add_argument('device', nargs='?', default='/dev/tty.SLAB_USBtoUART',
+                    help='Serial device path (overwritten by --jetson)')
 
 args = parser.parse_args()
 

--- a/espresso.py
+++ b/espresso.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 parser = argparse.ArgumentParser(description='Flash and control an ESP32 microcontroller from a Jetson board')
 
 parser.add_argument('command', choices=['flash', 'enable', 'disable', 'reset', 'erase'], help='Command to execute')
-parser.add_argument('-j', '--jetson', choices=['nano', 'xavier', 'orin'], help='Jetson board type')
+parser.add_argument('-j', '--jetson', choices=['nano', 'xavier', 'orin'], default=None, help='Jetson board type')
 parser.add_argument('--nand', action='store_true', help='Board has NAND gates')
 parser.add_argument('--swap_pins', action='store_true',
                     help='Swap EN and G0 pins (for Jetson Orin with piggyback older than V0.5)')
@@ -20,22 +20,22 @@ parser.add_argument('--partition-table', default='build/partition_table/partitio
                     help='Path to partition table')
 parser.add_argument('--firmware', default='build/lizard.bin', help='Path to firmware binary')
 parser.add_argument('-d', '--dry-run', action='store_true', help='Dry run')
-parser.add_argument('device', default='/dev/tty.SLAB_USBtoUART', help='Serial device path')
+parser.add_argument('device', default='/dev/tty.SLAB_USBtoUART', help='Serial device path (overwritten by --jetson)')
 
 args = parser.parse_args()
 
-EN_PIN = {'nano': 216, 'xavier': 436, 'orin': 460}[args.jetson]
-G0_PIN = {'nano': 50, 'xavier': 428, 'orin': 492}[args.jetson]
+EN_PIN = {'nano': 216, 'xavier': 436, 'orin': 460}.get(args.jetson, -1)
+G0_PIN = {'nano': 50, 'xavier': 428, 'orin': 492}.get(args.jetson, -1)
 GPIO_EN = 'PR.04' if args.jetson == 'orin' else f'gpio{EN_PIN}'
 GPIO_G0 = 'PAC.06' if args.jetson == 'orin' else f'gpio{G0_PIN}'
 if args.swap_pins:
     EN_PIN, G0_PIN = G0_PIN, EN_PIN
     GPIO_EN, GPIO_G0 = GPIO_G0, GPIO_EN
-DEVICE = args.device or {
+DEVICE = {
     'nano': '/dev/ttyTHS1',
     'xavier': '/dev/ttyTHS0',
     'orin': '/dev/ttyTHS0',
-}[args.jetson]
+}.get(args.jetson, args.device)
 ON = 1 if args.nand else 0
 OFF = 0 if args.nand else 1
 DRY_RUN = args.dry_run
@@ -44,6 +44,9 @@ DRY_RUN = args.dry_run
 @contextmanager
 def pin_config() -> Generator[None, None, None]:
     """Configure the EN and G0 pins to control the microcontroller."""
+    if not args.jetson:
+        yield
+        return
     print_bold('Configuring EN and G0 pins...')
     write_gpio('export', EN_PIN)
     time.sleep(0.5)
@@ -62,6 +65,9 @@ def pin_config() -> Generator[None, None, None]:
 @contextmanager
 def flash_mode() -> Generator[None, None, None]:
     """Bring the microcontroller into flash mode."""
+    if not args.jetson:
+        yield
+        return
     print_bold('Bringing the microcontroller into flash mode...')
     write_gpio(f'{GPIO_EN}/value', ON)
     time.sleep(0.5)

--- a/flash.py
+++ b/flash.py
@@ -50,12 +50,6 @@ if 'enable' in sys.argv:
         esp.enable()
     sys.exit()
 
-if 'disable' in sys.argv:
-    with esp.pin_config():
-        print('Disabling ESP...')
-        esp.disable()
-    sys.exit()
-
 if 'reset' in sys.argv:
     with esp.pin_config():
         print('Resetting ESP...')

--- a/flash.py
+++ b/flash.py
@@ -6,7 +6,7 @@ from esp import Esp
 
 
 def show_help() -> None:
-    print(f'{sys.argv[0]} [nano | xavier | orin] [nand | v05] [usb | /dev/<name>] [enable] [disable] [-e | --erase] [reset]')
+    print(f'{sys.argv[0]} [nano | xavier | orin] [nand | v05] [usb | /dev/<name>] [enable] [-e | --erase] [reset]')
     print('   -e, --erase   erase the flash before flashing the new firmware')
     print('   nano          flashing Jetson Nano (default)')
     print('   xavier        flashing Jetson Xavier')
@@ -16,7 +16,6 @@ def show_help() -> None:
     print('   usb           use /dev/tty.SLAB_USBtoUART as serial device')
     print('   /dev/<name>   use /dev/<name> as serial device')
     print('   enable        enable the ESP32 microcontroller')
-    print('   disable       disable the ESP32 microcontroller')
     print('   reset         reset the ESP32 microcontroller')
 
 

--- a/flash.py
+++ b/flash.py
@@ -6,7 +6,7 @@ from esp import Esp
 
 
 def show_help() -> None:
-    print(f'{sys.argv[0]} [nano | xavier | orin] [nand | v05] [usb | /dev/<name>] [enable] [-e | --erase] [reset]')
+    print(f'{sys.argv[0]} [nano | xavier | orin] [nand | v05] [usb | /dev/<name>] [enable] [disable] [-e | --erase] [reset]')
     print('   -e, --erase   erase the flash before flashing the new firmware')
     print('   nano          flashing Jetson Nano (default)')
     print('   xavier        flashing Jetson Xavier')
@@ -16,6 +16,7 @@ def show_help() -> None:
     print('   usb           use /dev/tty.SLAB_USBtoUART as serial device')
     print('   /dev/<name>   use /dev/<name> as serial device')
     print('   enable        enable the ESP32 microcontroller')
+    print('   disable       disable the ESP32 microcontroller')
     print('   reset         reset the ESP32 microcontroller')
 
 
@@ -24,15 +25,17 @@ if any(h in sys.argv for h in ['--help', '-help', 'help', '-h']):
     sys.exit()
 
 erase_flash = any(e in sys.argv for e in ['-e', '--erase'])
-device = None
-if 'usb' in sys.argv:
-    device = '/dev/tty.SLAB_USBtoUART'
+device = '/dev/tty.SLAB_USBtoUART' if 'usb' in sys.argv else None
 for p in sys.argv:
     if p.startswith('/dev/'):
         device = p
 
-esp = Esp(nand='nand' in sys.argv, xavier='xavier' in sys.argv,
-          orin='orin' in sys.argv, v05='v05' in sys.argv, device=device)
+esp = Esp(
+    jetson='xavier' if 'xavier' in sys.argv else 'orin' if 'orin' in sys.argv else 'nano',
+    nand='nand' in sys.argv,
+    v05='v05' in sys.argv,
+    device=device,
+)
 
 
 # Check if the device should be enabled

--- a/flash.py
+++ b/flash.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import warnings
 import subprocess
 import sys
 
@@ -19,6 +20,14 @@ def show_help() -> None:
     print('   disable       disable the ESP32 microcontroller')
     print('   reset         reset the ESP32 microcontroller')
 
+
+warnings.warn(
+    "\033[93m\033[1m"
+    "This script will be deprecated in version 1.0.0."
+    "Please consider using the new 'espresso.py' script instead."
+    "\033[0m",
+    DeprecationWarning,
+)
 
 if any(h in sys.argv for h in ['--help', '-help', 'help', '-h']):
     show_help()

--- a/flash.py
+++ b/flash.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import warnings
 import subprocess
 import sys
 
@@ -21,12 +20,11 @@ def show_help() -> None:
     print('   reset         reset the ESP32 microcontroller')
 
 
-warnings.warn(
-    "\033[93m\033[1m"
-    "This script will be deprecated in version 1.0.0."
-    "Please consider using the new 'espresso.py' script instead."
-    "\033[0m",
-    DeprecationWarning,
+print(
+    '\033[93m\033[1m'
+    'This script will be deprecated in version 1.0.0. '
+    'Please consider using the new espresso.py script instead.'
+    '\033[0m',
 )
 
 if any(h in sys.argv for h in ['--help', '-help', 'help', '-h']):

--- a/flash.py
+++ b/flash.py
@@ -37,8 +37,6 @@ esp = Esp(
     device=device,
 )
 
-
-# Check if the device should be enabled
 if 'enable' in sys.argv:
     with esp.pin_config():
         print('Enabling ESP...')


### PR DESCRIPTION
This PR introduces a new script to flash and configure an ESP microcontroller from a Jetson computer inside a Zauberzeug Robot Brain. It uses argparse to define a clean command line API. In order to avoid breaking changes with downstream libraries like RoSys, we decided to start a new script next to flash.py, which we can deprecate (and remove in Lizard 1.0).

The script comes with a `-d` or `--dry-run` option to test it without a Robot Brain:
```bash
./espresso.py --help
./espresso.py flash -j nano -d /dev/foo
```
![Screenshot 2025-05-09 at 15 34 01](https://github.com/user-attachments/assets/f6469b83-a2fa-4647-9420-89b9941f977a)

We chose argparse over Typer to avoid an extra dependency (which can be cumbersome in robotics projects).

@pascalzauberzeug will test the new script on Monday. Everyone else is invited to share thoughts and opinions.

We plan to release it in version 0.7.1, even though it is technically a new feature and should wait for 0.8. PR https://github.com/zauberzeug/rosys/pull/284 needs it to prevent conflicts with older versions of flash.py. So we'd argue it is more like an infrastructure tool and can be sneaked into a patch release.

Open tasks:

- [x] update getting_started.md and tools.md
- [x] add espresso.py to zip_content.txt
- [x] update upload_ssh.py (use livesync?) or add SSH mode to espresso? --> maybe later
- [x] deprecate flash.py?
