### PR TITLE
Fix braking for position control of the stepper motor

### DIFF
--- a/main/modules/stepper_motor.cpp
+++ b/main/modules/stepper_motor.cpp
@@ -140,8 +140,8 @@ void StepperMotor::step() {
             } else {
                 double squared_speed = (double)speed * speed;
                 uint32_t braking_distance = squared_speed / this->target_acceleration / 2.0;
-                int32_t remaining_distance = (this->target_position - position) * (speed > 0 ? 1 : -1);
-                if (remaining_distance < braking_distance) {
+                int32_t remaining_distance = (this->target_position - position) * (this->target_speed > 0 ? 1 : -1);
+                if (remaining_distance < (int32_t)braking_distance) {
                     this->target_speed = target_speed = 0;
                 }
             }

--- a/main/modules/stepper_motor.cpp
+++ b/main/modules/stepper_motor.cpp
@@ -139,9 +139,9 @@ void StepperMotor::step() {
                 }
             } else {
                 double squared_speed = (double)speed * speed;
-                int32_t braking_distance = squared_speed / this->target_acceleration / 2.0;
-                int32_t remaining_distance = this->target_position - position;
-                if (std::abs(remaining_distance) < std::abs(braking_distance)) {
+                uint32_t braking_distance = squared_speed / this->target_acceleration / 2.0;
+                int32_t remaining_distance = (this->target_position - position) * (speed > 0 ? 1 : -1);
+                if (remaining_distance < braking_distance) {
                     this->target_speed = target_speed = 0;
                 }
             }

--- a/main/modules/stepper_motor.cpp
+++ b/main/modules/stepper_motor.cpp
@@ -139,8 +139,8 @@ void StepperMotor::step() {
                 }
             } else {
                 double squared_speed = (double)speed * speed;
-                int32_t remaining_distance = (this->target_position - position) * (this->target_speed > 0 ? 1 : -1);
                 uint32_t braking_distance = squared_speed / this->target_acceleration / 2.0;
+                int32_t remaining_distance = (this->target_position - position) * (this->target_speed > 0 ? 1 : -1);
                 if (remaining_distance < (int32_t)braking_distance) {
                     this->target_speed = target_speed = 0;
                 }

--- a/main/modules/stepper_motor.cpp
+++ b/main/modules/stepper_motor.cpp
@@ -139,8 +139,8 @@ void StepperMotor::step() {
                 }
             } else {
                 double squared_speed = (double)speed * speed;
-                uint32_t braking_distance = squared_speed / this->target_acceleration / 2.0;
                 int32_t remaining_distance = (this->target_position - position) * (this->target_speed > 0 ? 1 : -1);
+                uint32_t braking_distance = squared_speed / this->target_acceleration / 2.0;
                 if (remaining_distance < (int32_t)braking_distance) {
                     this->target_speed = target_speed = 0;
                 }


### PR DESCRIPTION
The stepper motor did not calculate its `remaining_distance` to the target correctly and did not stop.
Now it correctly stops when `remaining_distance < braking_distance`.
 