### PR TITLE
Add UART queue to prevent reset crashes

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -397,7 +397,7 @@ void app_main() {
     };
     uart_param_config(UART_NUM_0, &uart_config);
     QueueHandle_t uart_queue;
-    uart_driver_install(UART_NUM_0, BUFFER_SIZE * 2, BUFFER_SIZE * 2, 20, &uart_queue, 0);
+    uart_driver_install(UART_NUM_0, BUFFER_SIZE * 2, 0, 20, &uart_queue, 0);
     uart_enable_pattern_det_baud_intr(UART_NUM_0, '\n', 1, 9, 0, 0);
     uart_pattern_queue_reset(UART_NUM_0, 100);
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -396,7 +396,8 @@ void app_main() {
         .flags = {},
     };
     uart_param_config(UART_NUM_0, &uart_config);
-    uart_driver_install(UART_NUM_0, BUFFER_SIZE * 2, 0, 0, NULL, 0);
+    QueueHandle_t uart_queue;
+    uart_driver_install(UART_NUM_0, BUFFER_SIZE * 2, BUFFER_SIZE * 2, 20, &uart_queue, 0);
     uart_enable_pattern_det_baud_intr(UART_NUM_0, '\n', 1, 9, 0, 0);
     uart_pattern_queue_reset(UART_NUM_0, 100);
 


### PR DESCRIPTION
Fixed a crash that occurred when resetting the ESP while it was connected over serial. The UART now has a proper queue to handle incoming data during boot, preventing interrupt crashes.

The issue manifested as a boot loop with the following error when connected via serial:
`assert failed: xQueueGenericSendFromISR queue.c:1180 (pxQueue)`

I noticed the fail with RoSys and Basekit.