### PR TITLE
Free up locked pin configuration

### DIFF
--- a/espresso.py
+++ b/espresso.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 
 parser = argparse.ArgumentParser(description='Flash and control an ESP32 microcontroller from a Jetson board')
 
-parser.add_argument('command', choices=['flash', 'enable', 'disable', 'reset', 'erase'], help='Command to execute')
+parser.add_argument('command', choices=['flash', 'enable', 'disable', 'reset', 'erase', 'free'], help='Command to execute')
 parser.add_argument('-j', '--jetson', choices=['nano', 'xavier', 'orin'], default=None, help='Jetson board type')
 parser.add_argument('--nand', action='store_true', help='Board has NAND gates')
 parser.add_argument('--swap_pins', action='store_true',
@@ -61,6 +61,11 @@ def _pin_config() -> Generator[None, None, None]:
     write_gpio(f'{GPIO_G0}/direction', 'out')
     time.sleep(0.5)
     yield
+    _reset_pin_config()
+
+
+def _reset_pin_config() -> None:
+    """Reset the pin configuration of _pin_config."""
     write_gpio('unexport', EN_PIN)
     time.sleep(0.5)
     write_gpio('unexport', G0_PIN)
@@ -199,6 +204,8 @@ def main(command: str) -> None:
         erase()
     elif command == 'flash':
         flash()
+    elif command == 'free':
+        _reset_pin_config()
     else:
         raise RuntimeError(f'Invalid command "{command}".')
     print_ok('Finished. ☕️')


### PR DESCRIPTION
We encountered this issue when trying to reset the ESP. Seems like a previous attempt was not cleaned up properly, because the pins are still in their exported state.

```python
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/zauberzeug/.lizard/./espresso.py", line 208, in <module>
    main(args.command)
  File "/home/zauberzeug/.lizard/./espresso.py", line 196, in main
    reset()
  File "/home/zauberzeug/.lizard/./espresso.py", line 102, in reset
    with _pin_config():
         ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/home/zauberzeug/.lizard/./espresso.py", line 52, in _pin_config
    write_gpio('export', EN_PIN)
  File "/home/zauberzeug/.lizard/./espresso.py", line 174, in write_gpio
    Path(f'/sys/class/gpio/{path}').write_text(f'{value}\n', encoding='utf-8')
  File "/usr/local/lib/python3.12/pathlib.py", line 1047, in write_text
    with self.open(mode='w', encoding=encoding, errors=errors, newline=newline) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: [Errno 16] Device or resource busy
```

Therefore I added a command to `espresso.py` to free up these pins. We could also just wrap the calls in `_pin_config` in a `try-except`, like this:
```python
try:
    write_gpio('export', EN_PIN)
except OSError as e:
    # EBUSY (16) means somebody else already exported it
    if e.errno != errno.EBUSY:
        raise
 ```

**ToDos:**

- [ ] Think about the naming; free is probably not the best choice
- [ ] Consider the try-except approach