### PR TITLE
Add silent heartbeat to core

### DIFF
--- a/docs/machine_safety.md
+++ b/docs/machine_safety.md
@@ -25,6 +25,9 @@ The following example stops a motor when there is no serial communication for 50
 when core.last_message_age > 500 then motor.stop(); end
 ```
 
+Any successfully interpreted input message resets `last_message_age`.
+If the host controller has no command to send but wants to signal that it is still alive, it can call `core.keep_alive()`, which resets the timer silently without producing any output.
+
 ## Expander watchdog
 
 The `expander` module provides a watchdog feature that restarts the port expander when it gets stuck and does not send messages anymore.

--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -39,7 +39,7 @@ It is automatically created right after the boot sequence.
 | `core.forget_serial_bus()`       | Remove the saved SerialBus configuration from NVS  |              |
 | `core.pause_broadcasts()`        | Pause property broadcasts (all modules)            |              |
 | `core.resume_broadcasts()`       | Resume property broadcasts                         |              |
-| `core.heartbeat()`               | Reset `last_message_age` without producing output  |              |
+| `core.keep_alive()`              | Reset `last_message_age` without producing output  |              |
 
 The output `format` is a string with multiple space-separated elements of the pattern `<module>.<property>[:<precision>]` or `<variable>[:<precision>]`.
 The `precision` is an optional integer specifying the number of decimal places for a floating point number.

--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -18,11 +18,12 @@ The `broadcast` method is used internally with [port expanders](#expander).
 The core module encapsulates various properties and methods that are related to the microcontroller itself.
 It is automatically created right after the boot sequence.
 
-| Properties    | Description                                             | Data type |
-| ------------- | ------------------------------------------------------- | --------- |
-| `core.debug`  | Whether to output debug information to the command line | `bool`    |
-| `core.millis` | Time since booting the microcontroller (ms)             | `int`     |
-| `core.heap`   | Free heap memory (bytes)                                | `int`     |
+| Properties              | Description                                                     | Data type |
+| ----------------------- | --------------------------------------------------------------- | --------- |
+| `core.debug`            | Whether to output debug information to the command line         | `bool`    |
+| `core.millis`           | Time since booting the microcontroller (ms)                     | `int`     |
+| `core.heap`             | Free heap memory (bytes)                                        | `int`     |
+| `core.last_message_age` | Time since last input message was received and interpreted (ms) | `int`     |
 
 | Methods                          | Description                                        | Arguments    |
 | -------------------------------- | -------------------------------------------------- | ------------ |
@@ -38,6 +39,7 @@ It is automatically created right after the boot sequence.
 | `core.forget_serial_bus()`       | Remove the saved SerialBus configuration from NVS  |              |
 | `core.pause_broadcasts()`        | Pause property broadcasts (all modules)            |              |
 | `core.resume_broadcasts()`       | Resume property broadcasts                         |              |
+| `core.heartbeat()`               | Reset `last_message_age` without producing output  |              |
 
 The output `format` is a string with multiple space-separated elements of the pattern `<module>.<property>[:<precision>]` or `<variable>[:<precision>]`.
 The `precision` is an optional integer specifying the number of decimal places for a floating point number.

--- a/main/modules/core.cpp
+++ b/main/modules/core.cpp
@@ -166,6 +166,9 @@ void Core::call(const std::string method_name, const std::vector<ConstExpression
         Module::expect(arguments, 0);
         Module::broadcast_paused = false;
         echo("broadcasts resumed");
+    } else if (method_name == "heartbeat") {
+        Module::expect(arguments, 0);
+        this->keep_alive();
     } else {
         Module::call(method_name, arguments);
     }

--- a/main/modules/core.cpp
+++ b/main/modules/core.cpp
@@ -166,7 +166,7 @@ void Core::call(const std::string method_name, const std::vector<ConstExpression
         Module::expect(arguments, 0);
         Module::broadcast_paused = false;
         echo("broadcasts resumed");
-    } else if (method_name == "heartbeat") {
+    } else if (method_name == "keep_alive") {
         Module::expect(arguments, 0);
         this->keep_alive();
     } else {


### PR DESCRIPTION
### Motivation

Safety rules like `when core.last_message_age > 1000 then wheels.speed(0, 0); end` trigger permanently when the host controller has nothing to send — even though it's still running. Previously this was masked by the BMS accidentally resetting the timer every 5 seconds.

Any successfully interpreted input already resets `last_message_age`, but there was no way for the host to signal "still alive" without also triggering some other side effect or producing output.

Fixes #198

### Implementation

- Exposes the existing private `Core::keep_alive()` helper as a callable Lizard method `core.keep_alive()`. The host controller (e.g. rosys/Feldfreund) can call it periodically to silently reset `last_message_age`, so the safety rule only fires when communication actually stops.
- Documents the previously-undocumented `core.last_message_age` property in the module reference.
- Extends `docs/machine_safety.md` to describe the new heartbeat method alongside the existing property.

### Progress

- [x] The implementation is complete.
- [x] Tested on hardware (or is not necessary).
- [x] Documentation has been updated (or is not necessary).
