### PR TITLE
Document optional LEDC timer and channel for PwmOutput

### DIFF
--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -162,9 +162,13 @@ When the output is disabled, it will deactivate and ignore on/off or level comma
 
 The PWM output module is associated with a digital output pin that is connected to an LED, actuator or other output signal.
 
-| Constructor            | Description                            | Arguments |
-| ---------------------- | -------------------------------------- | --------- |
-| `pwm = PwmOutput(pin)` | `pin` is the corresponding GPIO number | `int`     |
+| Constructor                        | Description                            | Arguments  |
+| ---------------------------------- | -------------------------------------- | ---------- |
+| `pwm = PwmOutput(pin[, lt[, lc]])` | `pin` is the corresponding GPIO number | 1–3x `int` |
+
+The constructor arguments `lt` (LEDC timer) and `lc` (LEDC channel) are optional and default to 0.
+When using multiple PWM outputs, set different channel IDs to avoid conflicts.
+Channels sharing a timer also share its frequency; use different timers to run outputs at independent frequencies.
 
 | Properties         | Description                              | Data type |
 | ------------------ | ---------------------------------------- | --------- |


### PR DESCRIPTION
### Motivation & Implementation

`PwmOutput` has accepted optional `lt` (LEDC timer) and `lc` (LEDC channel) arguments since its initial implementation, but the module reference docs only advertise the single-arg form `PwmOutput(pin)`.
Users who need multiple PWM outputs on the same chip either had to read `module.cpp` to discover the optional args — or hit cryptic LEDC errors and silent channel collisions at runtime (e.g. last pin silently wins when two PwmOutputs share timer 0 / channel 0).

### Progress

- [x] The implementation is complete.
- [x] Tested on hardware (or is not necessary).
- [x] Documentation has been updated (or is not necessary).