### PR TITLE
Fix BLE advertising race on ESP32-S3

### DIFF
--- a/main/utils/ble_command.cpp
+++ b/main/utils/ble_command.cpp
@@ -406,14 +406,13 @@ void init(const std::string_view &device_name, CommandCallback on_command) {
 
     ble_svc_gap_device_name_set(ble_device_name.data());
 
+    running = true;
     nimble_port_freertos_init(run_host_task);
 
     if (!idle_timer) {
         idle_timer = xTimerCreate("ble_idle", pdMS_TO_TICKS(IDLE_TIMEOUT_MS),
                                   pdFALSE, nullptr, on_idle_timeout);
     }
-
-    running = true;
 }
 
 int send(const std::string_view &data) {


### PR DESCRIPTION
### Motivation

Fixes #202.

On ESP32-S3, `Bluetooth("name")` initializes NimBLE correctly but never transmits any advertising packets -- the device is invisible to all BLE scanners. Classic ESP32 is unaffected.

The cause is a race in `ble_command.cpp` `init()`: `running = true` was set *after* `nimble_port_freertos_init()`. On S3 (dual-core, fast controller sync), the host task reaches `on_sync()` before the main thread returns, triggering `advertise()` while `running` is still `false`. `advertise()` gates on that flag and silently skips.

Classic ESP32 worked only by timing luck.

### Implementation

One-line reorder: set `running = true` before calling `nimble_port_freertos_init(run_host_task)`. The flag is only checked in `advertise()` (to prevent advertising after `finalize()`) and at the top of `init()` (to prevent double-init). Setting it earlier is safe for both.

### Progress

- [x] The implementation is complete.
- [x] Tested on hardware (ESP32-S3-WROOM-1U + Classic ESP32-WROVER-IE, both advertise and accept connections after the fix).
- [x] Documentation has been updated (or is not necessary). -- not necessary, fix is internal.
