### PR TITLE
split requirements into docs, macOS and all

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
         with:
           python-version: "3.x"
       - name: Install dependencies
-        run: python3 -m pip install -r requirements.txt
+        run: python3 -m pip install -r requirements-docs.txt
       - name: Build docs
         run: mkdocs build -v
       - name: Deploy gh-pages

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -132,6 +132,8 @@ Install Python requirements:
 python3 -m pip install -r requirements.txt
 ```
 
+On macOS, use `requirements-macos.txt` instead, which omits `gpiod` (not available on macOS).
+
 Install UART drivers: https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers
 
 Get all sub modules:

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,3 @@
+mkdocs
+mkdocs-material
+mdx-include

--- a/requirements-macos.txt
+++ b/requirements-macos.txt
@@ -1,0 +1,4 @@
+esp-coredump
+esptool
+prompt_toolkit
+pyserial

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,2 @@
-esp-coredump
-esptool
+-r requirements-macos.txt
 gpiod
-mkdocs
-mkdocs-material
-mdx-include
-prompt_toolkit
-pyserial


### PR DESCRIPTION
### Motivation

Until now, anyone working on Lizard had to install the full requirements.txt, which pulls in gpiod (Linux-only, fails to install on macOS) and the docs toolchain (mkdocs & friends) regardless of what they're actually doing. That makes macOS development unnecessarily painful and bloats the docs CI job with packages it doesn't need.

###  Implementation

Split requirements.txt into three focused files:

- `requirements-docs.txt` — mkdocs, mkdocs-material, mdx-include
- `requirements-macos.txt` — esp-coredump, esptool, prompt_toolkit, pyserial (no gpiod)
- `requirements.txt` — extends requirements-macos.txt via -r and adds gpiod on top, so Linux behavior is unchanged

The docs job in `.github/workflows/release.yml` now installs `requirements-docs.txt` instead of the full set, and `docs/tools.md` got a short note pointing macOS developers to `requirements-macos.txt`.

### Progress

- [x] The implementation is complete.
- [x] Tested on hardware (or is not necessary).
- [x] Documentation has been updated (or is not necessary).
