### PR TITLE
Bus send format

### DIFF
--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -82,10 +82,10 @@ The serial bus module lets multiple ESP32s share a UART link with a coordinator 
 | ----------------------------- | ---------------------------------------------- | --------------- |
 | `bus = SerialBus(serial, id)` | Attach to a serial module with local node `id` | `Serial`, `int` |
 
-| Methods                             | Description                                                | Arguments    |
-| ----------------------------------- | ---------------------------------------------------------- | ------------ |
-| `bus.send(receiver, payload)`       | Send a single line of text to a peer `receiver` (0-255)    | `int`, `str` |
-| `bus.make_coordinator(peer_ids...)` | Set the list of peer IDs, making this node the coordinator | `int`s       |
+| Methods                             | Description                                                                                                                                 | Arguments         |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `bus.send(receiver, fmt, args...)`  | Send a printf-formatted line to peer `receiver` (0-254). Specifiers: `%d` int, `%f` number (opt. `%.Nf`), `%s` string (bool→`true`/`false`) | `int`, `str`, ... |
+| `bus.make_coordinator(peer_ids...)` | Set the list of peer IDs, making this node the coordinator                                                                                  | `int`s            |
 
 **Bus Backup:**
 When a SerialBus is created, its configuration (pins, baud rate, UART number, node ID) is automatically saved to non-volatile storage.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -190,7 +190,7 @@ void process_tree(owl_tree *const tree, bool from_expander) {
             const ConstExpression_ptr expression = compile_expression(statement.expression);
             static char buffer[256];
             expression->print_to_buffer(buffer, sizeof(buffer));
-            echo(buffer);
+            echo("%s", buffer);
         } else if (!statement.constructor.empty) {
             const struct parsed_constructor constructor = parsed_constructor_get(statement.constructor);
             if (constructor.expander_name.empty) {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -351,7 +351,7 @@ void process_line(const char *line, const int len) {
             process_lizard(line + 2);
             break;
         case '"':
-            echo(line + 2);
+            echo("%s", line + 2);
             break;
         default:
             throw std::runtime_error("unrecognized control command");

--- a/main/modules/can.cpp
+++ b/main/modules/can.cpp
@@ -132,7 +132,7 @@ bool Can::receive() {
                 pos += csprintf(&buffer[pos], sizeof(buffer) - pos, ",%02x", message.data[i]);
             }
         }
-        echo(buffer);
+        echo("%s", buffer);
     }
 
     return true;

--- a/main/modules/core.cpp
+++ b/main/modules/core.cpp
@@ -52,7 +52,7 @@ void Core::call(const std::string method_name, const std::vector<ConstExpression
             }
             pos += argument->print_to_buffer(&buffer[pos], sizeof(buffer) - pos);
         }
-        echo(buffer);
+        echo("%s", buffer);
     } else if (method_name == "output") {
         Module::expect(arguments, 1, string);
         this->output_list.clear();

--- a/main/modules/module.cpp
+++ b/main/modules/module.cpp
@@ -421,7 +421,7 @@ void Module::step() {
             pos += property->print_to_buffer(&buffer[pos], sizeof(buffer) - pos);
             pos += csprintf(&buffer[pos], sizeof(buffer) - pos, ";");
         }
-        echo(buffer);
+        echo("%s", buffer);
     }
 }
 

--- a/main/modules/serial_bus.cpp
+++ b/main/modules/serial_bus.cpp
@@ -151,8 +151,7 @@ void SerialBus::call(const std::string method_name, const std::vector<ConstExpre
 
 void SerialBus::process_uart() {
     static char buffer[FRAME_BUFFER_SIZE];
-    int remaining = 16;
-    while (remaining-- > 0 && this->serial->has_buffered_lines()) {
+    while (this->serial->has_buffered_lines()) {
         const int len = this->serial->read_line(buffer, sizeof(buffer));
         if (bool ok; (check(buffer, len, &ok), !ok)) {
             this->print_to_incoming_queue("warning: serial bus %s checksum mismatch: %s", this->name.c_str(), buffer);

--- a/main/modules/serial_bus.cpp
+++ b/main/modules/serial_bus.cpp
@@ -1,5 +1,6 @@
 #include "serial_bus.h"
 
+#include "../utils/format.h"
 #include "../utils/otb.h"
 #include "../utils/string_utils.h"
 #include "../utils/timing.h"
@@ -69,12 +70,22 @@ void SerialBus::step() {
 
 void SerialBus::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
     if (method_name == "send") {
-        Module::expect(arguments, 2, integer, string);
+        // bus.send(receiver, fmt[, args...]) — printf-style formatting.
+        // See utils/format.h for supported specifiers.
+        if (arguments.size() < 2) {
+            throw std::runtime_error("send expects at least 2 arguments (receiver, format[, args...])");
+        }
+        if ((arguments[0]->type & integer) == 0) {
+            throw std::runtime_error("receiver ID must be an integer");
+        }
+        if ((arguments[1]->type & string) == 0) {
+            throw std::runtime_error("format must be a string");
+        }
         const int receiver = arguments[0]->evaluate_integer();
         if (receiver <= 0 || receiver >= 255) {
             throw std::runtime_error("receiver ID must be between 0 and 255");
         }
-        const std::string payload = arguments[1]->evaluate_string();
+        const std::string payload = format_args(arguments[1]->evaluate_string(), arguments, 2);
         this->enqueue_outgoing_message(static_cast<uint8_t>(receiver), payload.c_str(), payload.size());
     } else if (method_name == "make_coordinator") {
         if (arguments.empty()) {
@@ -140,7 +151,8 @@ void SerialBus::call(const std::string method_name, const std::vector<ConstExpre
 
 void SerialBus::process_uart() {
     static char buffer[FRAME_BUFFER_SIZE];
-    while (this->serial->has_buffered_lines()) {
+    int remaining = 16;
+    while (remaining-- > 0 && this->serial->has_buffered_lines()) {
         const int len = this->serial->read_line(buffer, sizeof(buffer));
         if (bool ok; (check(buffer, len, &ok), !ok)) {
             this->print_to_incoming_queue("warning: serial bus %s checksum mismatch: %s", this->name.c_str(), buffer);

--- a/main/storage.cpp
+++ b/main/storage.cpp
@@ -105,7 +105,7 @@ void Storage::print_startup(const std::string substring) {
     while (!startup.empty()) {
         std::string line = cut_first_word(startup, '\n');
         if (starts_with(line, substring)) {
-            echo(line.c_str());
+            echo("%s", line.c_str());
         }
     }
 }

--- a/main/utils/format.cpp
+++ b/main/utils/format.cpp
@@ -2,39 +2,22 @@
 
 #include "../compilation/type.h"
 #include <cstdio>
+#include <cstring>
 #include <stdexcept>
-
-// Specifier letters we recognize. Flags / width / precision between '%' and
-// the letter are passed through to snprintf untouched, so all of printf's
-// knobs (e.g. "%.3f", "%-10s", "%5d", "%x") work for free.
-static bool is_specifier_end(char c) {
-    switch (c) {
-    case 'd':
-    case 'f':
-    case 's':
-    case 'b':
-    case '%':
-        return true;
-    default:
-        return false;
-    }
-}
 
 std::string format_args(const std::string &fmt,
                         const std::vector<ConstExpression_ptr> &arguments,
                         size_t args_start) {
     std::string out;
-    out.reserve(fmt.size());
     size_t arg_idx = args_start;
-    size_t i = 0;
     char buf[64];
-    while (i < fmt.size()) {
+    for (size_t i = 0; i < fmt.size();) {
         if (fmt[i] != '%') {
             out += fmt[i++];
             continue;
         }
         const size_t start = i++;
-        while (i < fmt.size() && !is_specifier_end(fmt[i])) {
+        while (i < fmt.size() && !std::strchr("dfs%", fmt[i])) {
             ++i;
         }
         if (i >= fmt.size()) {
@@ -46,50 +29,17 @@ std::string format_args(const std::string &fmt,
             continue;
         }
         const std::string sub = fmt.substr(start, i - start);
-        if (arg_idx >= arguments.size()) {
-            throw std::runtime_error("format: too few arguments for format string");
-        }
-        const auto &arg = arguments[arg_idx++];
-        switch (spec) {
-        case 'd':
-            if ((arg->type & integer) == 0) {
-                throw std::runtime_error("format: '%d' expects integer argument");
-            }
+        const auto &arg = arguments.at(arg_idx++);
+        if (spec == 'd') {
             std::snprintf(buf, sizeof(buf), sub.c_str(), static_cast<int>(arg->evaluate_integer()));
-            out += buf;
-            break;
-        case 'f':
-            // integer promotes to number
-            if ((arg->type & numbery) == 0) {
-                throw std::runtime_error("format: '%f' expects number/integer argument");
-            }
+        } else if (spec == 'f') {
             std::snprintf(buf, sizeof(buf), sub.c_str(), arg->evaluate_number());
-            out += buf;
-            break;
-        case 's': {
-            std::string s;
-            if ((arg->type & string) != 0) {
-                s = arg->evaluate_string();
-            } else if ((arg->type & boolean) != 0) {
-                s = arg->evaluate_boolean() ? "true" : "false";
-            } else {
-                throw std::runtime_error("format: '%s' expects string or boolean argument");
-            }
+        } else {
+            const std::string s = (arg->type & boolean) ? (arg->evaluate_boolean() ? "true" : "false")
+                                                        : arg->evaluate_string();
             std::snprintf(buf, sizeof(buf), sub.c_str(), s.c_str());
-            out += buf;
-            break;
         }
-        case 'b':
-            // printf has no %b; handle ourselves and ignore flags/width
-            if ((arg->type & boolean) == 0) {
-                throw std::runtime_error("format: '%b' expects boolean argument");
-            }
-            out += arg->evaluate_boolean() ? "true" : "false";
-            break;
-        default:
-            // unreachable given is_specifier_end
-            throw std::runtime_error("format: unknown specifier");
-        }
+        out += buf;
     }
     return out;
 }

--- a/main/utils/format.cpp
+++ b/main/utils/format.cpp
@@ -10,7 +10,7 @@ std::string format_args(const std::string &fmt,
                         size_t args_start) {
     std::string out;
     size_t arg_idx = args_start;
-    char buf[64];
+    char buf[256];
     for (size_t i = 0; i < fmt.size();) {
         if (fmt[i] != '%') {
             out += fmt[i++];

--- a/main/utils/format.cpp
+++ b/main/utils/format.cpp
@@ -34,10 +34,10 @@ std::string format_args(const std::string &fmt,
             std::snprintf(buf, sizeof(buf), sub.c_str(), static_cast<int>(arg->evaluate_integer()));
         } else if (spec == 'f') {
             std::snprintf(buf, sizeof(buf), sub.c_str(), arg->evaluate_number());
+        } else if (arg->type & boolean) {
+            std::snprintf(buf, sizeof(buf), sub.c_str(), arg->evaluate_boolean() ? "true" : "false");
         } else {
-            const std::string s = (arg->type & boolean) ? (arg->evaluate_boolean() ? "true" : "false")
-                                                        : arg->evaluate_string();
-            std::snprintf(buf, sizeof(buf), sub.c_str(), s.c_str());
+            std::snprintf(buf, sizeof(buf), sub.c_str(), arg->evaluate_string().c_str());
         }
         out += buf;
     }

--- a/main/utils/format.cpp
+++ b/main/utils/format.cpp
@@ -37,10 +37,16 @@ std::string format_args(const std::string &fmt,
             std::snprintf(buf, sizeof(buf), sub.c_str(), static_cast<int>(arg->evaluate_integer()));
         } else if (spec == 'f') {
             std::snprintf(buf, sizeof(buf), sub.c_str(), arg->evaluate_number());
-        } else if (arg->type & boolean) {
-            std::snprintf(buf, sizeof(buf), sub.c_str(), arg->evaluate_boolean() ? "true" : "false");
+        } else if (spec == 's') {
+            if (arg->type & boolean) {
+                std::snprintf(buf, sizeof(buf), sub.c_str(), arg->evaluate_boolean() ? "true" : "false");
+            } else if (arg->type & string) {
+                std::snprintf(buf, sizeof(buf), sub.c_str(), arg->evaluate_string().c_str());
+            } else {
+                throw std::runtime_error("format: '%s' expects a string or boolean argument");
+            }
         } else {
-            std::snprintf(buf, sizeof(buf), sub.c_str(), arg->evaluate_string().c_str());
+            throw std::runtime_error("format: unsupported specifier '" + sub + "'");
         }
         out += buf;
     }

--- a/main/utils/format.cpp
+++ b/main/utils/format.cpp
@@ -1,0 +1,95 @@
+#include "format.h"
+
+#include "../compilation/type.h"
+#include <cstdio>
+#include <stdexcept>
+
+// Specifier letters we recognize. Flags / width / precision between '%' and
+// the letter are passed through to snprintf untouched, so all of printf's
+// knobs (e.g. "%.3f", "%-10s", "%5d", "%x") work for free.
+static bool is_specifier_end(char c) {
+    switch (c) {
+    case 'd':
+    case 'f':
+    case 's':
+    case 'b':
+    case '%':
+        return true;
+    default:
+        return false;
+    }
+}
+
+std::string format_args(const std::string &fmt,
+                        const std::vector<ConstExpression_ptr> &arguments,
+                        size_t args_start) {
+    std::string out;
+    out.reserve(fmt.size());
+    size_t arg_idx = args_start;
+    size_t i = 0;
+    char buf[64];
+    while (i < fmt.size()) {
+        if (fmt[i] != '%') {
+            out += fmt[i++];
+            continue;
+        }
+        const size_t start = i++;
+        while (i < fmt.size() && !is_specifier_end(fmt[i])) {
+            ++i;
+        }
+        if (i >= fmt.size()) {
+            throw std::runtime_error("format: unterminated '%' in format string");
+        }
+        const char spec = fmt[i++];
+        if (spec == '%') {
+            out += '%';
+            continue;
+        }
+        const std::string sub = fmt.substr(start, i - start);
+        if (arg_idx >= arguments.size()) {
+            throw std::runtime_error("format: too few arguments for format string");
+        }
+        const auto &arg = arguments[arg_idx++];
+        switch (spec) {
+        case 'd':
+            if ((arg->type & integer) == 0) {
+                throw std::runtime_error("format: '%d' expects integer argument");
+            }
+            std::snprintf(buf, sizeof(buf), sub.c_str(), static_cast<int>(arg->evaluate_integer()));
+            out += buf;
+            break;
+        case 'f':
+            // integer promotes to number
+            if ((arg->type & numbery) == 0) {
+                throw std::runtime_error("format: '%f' expects number/integer argument");
+            }
+            std::snprintf(buf, sizeof(buf), sub.c_str(), arg->evaluate_number());
+            out += buf;
+            break;
+        case 's': {
+            std::string s;
+            if ((arg->type & string) != 0) {
+                s = arg->evaluate_string();
+            } else if ((arg->type & boolean) != 0) {
+                s = arg->evaluate_boolean() ? "true" : "false";
+            } else {
+                throw std::runtime_error("format: '%s' expects string or boolean argument");
+            }
+            std::snprintf(buf, sizeof(buf), sub.c_str(), s.c_str());
+            out += buf;
+            break;
+        }
+        case 'b':
+            // printf has no %b; handle ourselves and ignore flags/width
+            if ((arg->type & boolean) == 0) {
+                throw std::runtime_error("format: '%b' expects boolean argument");
+            }
+            out += arg->evaluate_boolean() ? "true" : "false";
+            break;
+        default:
+            // unreachable given is_specifier_end
+            throw std::runtime_error("format: unknown specifier");
+        }
+    }
+    return out;
+}

--- a/main/utils/format.cpp
+++ b/main/utils/format.cpp
@@ -29,7 +29,10 @@ std::string format_args(const std::string &fmt,
             continue;
         }
         const std::string sub = fmt.substr(start, i - start);
-        const auto &arg = arguments.at(arg_idx++);
+        if (arg_idx >= arguments.size()) {
+            throw std::runtime_error("format: '" + sub + "' has no matching argument");
+        }
+        const auto &arg = arguments[arg_idx++];
         if (spec == 'd') {
             std::snprintf(buf, sizeof(buf), sub.c_str(), static_cast<int>(arg->evaluate_integer()));
         } else if (spec == 'f') {

--- a/main/utils/format.h
+++ b/main/utils/format.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "../compilation/expression.h"
+#include <string>
+#include <vector>
+
+// Printf-style formatter for Lizard expressions.
+//
+// Walks `fmt` and replaces each specifier with the corresponding argument,
+// starting at `arguments[args_start]`. Flags, width, and precision between
+// '%' and the specifier letter are passed straight to snprintf, so the full
+// printf syntax works (e.g. "%.3f", "%-10s", "%5d"). Recognized specifier
+// letters:
+//   %d  — integer
+//   %f  — number (integer is promoted)
+//   %s  — string (also accepts bool as "true"/"false")
+//   %b  — bool → "true"/"false" (Lizard extension; flags ignored)
+//   %%  — literal %
+//
+// Throws std::runtime_error on type mismatch, unknown specifier, too few
+// arguments, or an unterminated % at the end of the format string.
+// Extra trailing arguments are ignored silently.
+std::string format_args(const std::string &fmt,
+                        const std::vector<ConstExpression_ptr> &arguments,
+                        size_t args_start = 0);

--- a/main/utils/format.h
+++ b/main/utils/format.h
@@ -6,18 +6,18 @@
 
 // Printf-style formatter for Lizard expressions.
 //
-// Walks `fmt` and replaces each specifier with the corresponding argument,
-// starting at `arguments[args_start]`. Flags, width, and precision between
-// '%' and the specifier letter are passed straight to snprintf, so the full
-// printf syntax works (e.g. "%.3f", "%-10s", "%5d"). Recognized specifiers:
+// Walks `fmt` and replaces each specifier with the corresponding argument, starting at `arguments[args_start]`.
+// Flags, width, and precision between '%' and the specifier letter are passed straight to snprintf,
+// so the full printf syntax works (e.g. "%.3f", "%-10s", "%5d").
+// Recognized specifiers:
 //   %d  — integer
 //   %f  — number (integer is promoted)
 //   %s  — string (bool is rendered as "true"/"false")
 //   %%  — literal %
 //
-// Throws on an unterminated '%' or too few arguments. Type mismatches fall
-// through to snprintf and may produce garbage output rather than a clean
-// error; extra trailing arguments are ignored silently.
+// Throws on an unterminated '%' or too few arguments.
+// Type mismatches fall through to snprintf and may produce garbage output rather than a clean error;
+// extra trailing arguments are ignored silently.
 std::string format_args(const std::string &fmt,
                         const std::vector<ConstExpression_ptr> &arguments,
                         size_t args_start = 0);

--- a/main/utils/format.h
+++ b/main/utils/format.h
@@ -9,17 +9,15 @@
 // Walks `fmt` and replaces each specifier with the corresponding argument,
 // starting at `arguments[args_start]`. Flags, width, and precision between
 // '%' and the specifier letter are passed straight to snprintf, so the full
-// printf syntax works (e.g. "%.3f", "%-10s", "%5d"). Recognized specifier
-// letters:
+// printf syntax works (e.g. "%.3f", "%-10s", "%5d"). Recognized specifiers:
 //   %d  — integer
 //   %f  — number (integer is promoted)
-//   %s  — string (also accepts bool as "true"/"false")
-//   %b  — bool → "true"/"false" (Lizard extension; flags ignored)
+//   %s  — string (bool is rendered as "true"/"false")
 //   %%  — literal %
 //
-// Throws std::runtime_error on type mismatch, unknown specifier, too few
-// arguments, or an unterminated % at the end of the format string.
-// Extra trailing arguments are ignored silently.
+// Throws on an unterminated '%' or too few arguments. Type mismatches fall
+// through to snprintf and may produce garbage output rather than a clean
+// error; extra trailing arguments are ignored silently.
 std::string format_args(const std::string &fmt,
                         const std::vector<ConstExpression_ptr> &arguments,
                         size_t args_start = 0);


### PR DESCRIPTION
### Motivation

`bus.send` accepted only a fixed `(receiver, payload)` pair, so producing a formatted line required string concatenation in Lizard scripts — which Lizard does not really offer. Common cases like sending a tracked variable as a `!!`-prefixed assignment to a peer therefore needed boilerplate or were not expressible at all.

This PR adds printf-style formatting to `bus.send` so that values can be embedded directly into the outgoing message, including multiple values per message (e.g. `"!!fmt_float=%f;fmt_prec=%.3f"`).

### Implementation

- New utility `main/utils/format.{h,cpp}` with a single `format_args()` function that walks a format string and consumes one argument per specifier from a `std::vector<ConstExpression_ptr>`, starting at a given offset.
- Specifiers are forwarded to `snprintf`, so the full printf syntax for flags, width, and precision works (`%.3f`, `%-10s`, `%5d`, …). Recognized: `%d` (int), `%f` (number, int auto-promoted), `%s` (string; bool rendered as `"true"`/`"false"`), `%%` (literal).
- `SerialBus::call("send", ...)` now requires at least `(receiver, format)` and forwards any further arguments through `format_args`. The receiver/format type checks are kept explicit so the error messages stay precise.
- A handful of `echo(buffer)` call sites in `main.cpp`, `can.cpp`, `core.cpp`, `module.cpp` and `storage.cpp` switched to `echo("%s", buffer)`. This prevents stray `%` characters in the buffer from being interpreted as format specifiers — defensive hardening that pairs with introducing more printf-style usage.
- `docs/module_reference.md`: `bus.send` row updated to the new `(receiver, fmt, args...)` signature with the supported specifiers.

Trade-offs:

- Type mismatches between specifier and argument fall through to `snprintf` and may produce garbage rather than a clean error. This matches C printf behavior and keeps the implementation small; we can tighten it later if it becomes a footgun.
- Extra trailing arguments are silently ignored.
- The internal `buf[64]` per-specifier limit caps a single formatted field at 63 characters; long strings get truncated.

### Test scripts

Two scripts running on a pair of nodes wired over the same UART. Node 1 (sender) bumps a few locally-tracked values every 500 ms and pushes them to node 2 (coordinator) as `!!`-prefixed assignments, exercising `%d`, `%f`, `%.3f`, `%s` (bool→`"true"`/`"false"`) and a multi-value message in one round.

<details>
<summary><code>bus_format_bus2.liz</code> — receiver / coordinator (node 2)</summary>

```
serial = Serial(26, 27, 115200, 1)
bus = SerialBus(serial, 2)
bus.make_coordinator(1)

# Slots filled by "!!"-prefixed assignments coming from bus_1.
int   fmt_int    = 0
float fmt_float  = 0.0
float fmt_prec   = 0.0
bool  fmt_bool   = false

core.output("core.millis fmt_int fmt_float fmt_prec:3 fmt_bool")
```

</details>

<details>
<summary><code>bus_format_bus1.liz</code> — sender (node 1)</summary>

```
serial = Serial(26, 27, 115200, 1)
bus = SerialBus(serial, 1)

# Locally-tracked values to format and push.
int   tick   = 0
float angle  = 0.0
bool  flag   = false
int   t_last = 0

# Every 500 ms: bump the values and send them via printf-style formatting.
# Exercises %d, %f, %.3f and %s (bool→"true"/"false") in one place.
when core.millis - t_last > 500 then
    tick  = tick + 1
    angle = angle + 0.1234
    flag  = not flag
    bus.send(2, "!!fmt_int=%d",     tick)
    bus.send(2, "!!fmt_float=%f;fmt_prec=%.3f", angle, angle)
    bus.send(2, "!!fmt_bool=%s",    flag)
    t_last = core.millis
end

core.output("core.millis tick angle:4 flag")
```

</details>

### Progress

- [x] The implementation is complete.
- [x] Tested on hardware
- [x] Documentation has been updated
