### PR TITLE
Add DualDriveMotor and DualDriveWheels modules

### DIFF
--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -1017,18 +1017,18 @@ Currently only the G350 motor (600 hall ticks per revolution) is supported in th
 | `motor.enabled`     | Whether the motor is enabled                      | `bool`    |
 | `motor.debug`       | Enable CAN debug output                           | `bool`    |
 
-| Methods                                       | Description                       | Arguments                     |
-| --------------------------------------------- | --------------------------------- | ----------------------------- |
-| `motor.speed(vel[, acc, jerk])`               | Set target angular velocity rad/s | `float`\[, `float`, `float`\] |
-| `motor.drive_ticks(vel, ticks)`               | Relative move in hall ticks       | `float`, `int`                |
-| `motor.switch_state(state)`                   | Set state: 1=off, 2=brake, 3=on   | `int`                         |
-| `motor.configure(setting_id, value1, value2)` | Send raw configure command        | `int`, `int`, `int`           |
-| `motor.configure_node_id(new_id)`             | Set CAN node ID                   | `int`                         |
-| `motor.on()`                                  | Turn motor on                     |                               |
-| `motor.off()`                                 | Turn motor off                    |                               |
-| `motor.stop()`                                | Brake the motor                   |                               |
-| `motor.enable()`                              | Enable the motor                  |                               |
-| `motor.disable()`                             | Disable the motor                 |                               |
+| Methods                                       | Description                       | Arguments           |
+| --------------------------------------------- | --------------------------------- | ------------------- |
+| `motor.speed(vel)`                            | Set target angular velocity rad/s | `float`             |
+| `motor.drive_ticks(vel, ticks)`               | Relative move in hall ticks       | `float`, `int`      |
+| `motor.switch_state(state)`                   | Set state: 1=off, 2=brake, 3=on   | `int`               |
+| `motor.configure(setting_id, value1, value2)` | Send raw configure command        | `int`, `int`, `int` |
+| `motor.configure_node_id(new_id)`             | Set CAN node ID                   | `int`               |
+| `motor.on()`                                  | Turn motor on                     |                     |
+| `motor.off()`                                 | Turn motor off                    |                     |
+| `motor.stop()`                                | Brake the motor                   |                     |
+| `motor.enable()`                              | Enable the motor                  |                     |
+| `motor.disable()`                             | Disable the motor                 |                     |
 
 ## Dual Drive Wheels
 
@@ -1048,6 +1048,7 @@ The DualDriveWheels module combines two DualDriveMotor modules for differential 
 | Methods                         | Description                                     | Arguments        |
 | ------------------------------- | ----------------------------------------------- | ---------------- |
 | `wheels.speed(linear, angular)` | Move with `linear`/`angular` speed (m/s, rad/s) | `float`, `float` |
+| `wheels.drive(speed, distance)` | Drive straight `distance` (m) at `speed` (m/s)  | `float`, `float` |
 | `wheels.off()`                  | Turn both motors off                            |                  |
 | `wheels.stop()`                 | Brake both motors                               |                  |
 | `wheels.enable()`               | Enable both motors                              |                  |

--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -991,6 +991,70 @@ The DunkerWheels module combines two DunkerMotor modules and provides odometry a
 
 When the wheels are disabled, they will freewheel and ignore movement commands.
 
+## Dual Drive Motor
+
+The DualDriveMotor module controls a Twin MC motor controller in track drive mode (speed control on motor 1).
+The constructor sends the firmware-mode-switch (`0xA5A5`) so the controller is in drive mode regardless of its previous state.
+Currently only the G350 motor (600 hall ticks per revolution) is supported in this mode.
+
+| Constructor                            | Description            | Arguments         |
+| -------------------------------------- | ---------------------- | ----------------- |
+| `motor = DualDriveMotor(can, node_id)` | CAN module and node ID | CAN module, `int` |
+
+| Properties          | Description                                       | Data type |
+| ------------------- | ------------------------------------------------- | --------- |
+| `motor.voltage`     | Board voltage (V)                                 | `float`   |
+| `motor.temperature` | Controller temperature (°C)                       | `int`     |
+| `motor.state`       | Current switch state                              | `int`     |
+| `motor.error_codes` | Error bitmask as hex string                       | `str`     |
+| `motor.version`     | Firmware version reported by controller           | `int`     |
+| `motor.speed`       | Current speed (m/s, sign- and `m_per_rad`-scaled) | `float`   |
+| `motor.current_m1`  | Motor 1 current (A)                               | `float`   |
+| `motor.current_m2`  | Motor 2 current (A)                               | `float`   |
+| `motor.m_per_rad`   | Meters per radian for speed conversion            | `float`   |
+| `motor.reversed`    | Reverse motor direction                           | `bool`    |
+| `motor.rad_limit`   | Maximum angular velocity limit (rad/s)            | `float`   |
+| `motor.enabled`     | Whether the motor is enabled                      | `bool`    |
+| `motor.debug`       | Enable CAN debug output                           | `bool`    |
+
+| Methods                                       | Description                       | Arguments                     |
+| --------------------------------------------- | --------------------------------- | ----------------------------- |
+| `motor.speed(vel[, acc, jerk])`               | Set target angular velocity rad/s | `float`\[, `float`, `float`\] |
+| `motor.drive_ticks(vel, ticks)`               | Relative move in hall ticks       | `float`, `int`                |
+| `motor.switch_state(state)`                   | Set state: 1=off, 2=brake, 3=on   | `int`                         |
+| `motor.configure(setting_id, value1, value2)` | Send raw configure command        | `int`, `int`, `int`           |
+| `motor.configure_node_id(new_id)`             | Set CAN node ID                   | `int`                         |
+| `motor.on()`                                  | Turn motor on                     |                               |
+| `motor.off()`                                 | Turn motor off                    |                               |
+| `motor.stop()`                                | Brake the motor                   |                               |
+| `motor.enable()`                              | Enable the motor                  |                               |
+| `motor.disable()`                             | Disable the motor                 |                               |
+
+## Dual Drive Wheels
+
+The DualDriveWheels module combines two DualDriveMotor modules for differential steering.
+
+| Constructor                                         | Description       | Arguments                  |
+| --------------------------------------------------- | ----------------- | -------------------------- |
+| `wheels = DualDriveWheels(left_motor, right_motor)` | Two motor modules | two DualDriveMotor modules |
+
+| Properties             | Description                    | Data type |
+| ---------------------- | ------------------------------ | --------- |
+| `wheels.width`         | Wheel distance (m)             | `float`   |
+| `wheels.linear_speed`  | Forward speed (m/s)            | `float`   |
+| `wheels.angular_speed` | Turning speed (rad/s)          | `float`   |
+| `wheels.enabled`       | Whether the wheels are enabled | `bool`    |
+
+| Methods                         | Description                                     | Arguments        |
+| ------------------------------- | ----------------------------------------------- | ---------------- |
+| `wheels.speed(linear, angular)` | Move with `linear`/`angular` speed (m/s, rad/s) | `float`, `float` |
+| `wheels.off()`                  | Turn both motors off                            |                  |
+| `wheels.stop()`                 | Brake both motors                               |                  |
+| `wheels.enable()`               | Enable both motors                              |                  |
+| `wheels.disable()`              | Disable both motors                             |                  |
+
+When the wheels are disabled, they will stop and ignore movement commands.
+
 ## Analog Unit
 
 The AnalogUnit module owns an ADC oneshot unit and is shared by one or more `Analog` or `TemperatureSensor` modules.

--- a/main/modules/dual_drive_motor.cpp
+++ b/main/modules/dual_drive_motor.cpp
@@ -112,9 +112,8 @@ void DualDriveMotor::send_drive_ticks_cmd(float angular_vel, int16_t ticks) {
     }
     const float rad_limit = this->properties.at("rad_limit")->number_value;
     angular_vel = std::clamp(angular_vel, -rad_limit, rad_limit);
-    const double s = this->sign();
-    int16_t raw_vel = static_cast<int16_t>(angular_vel * s / 0.01f);
-    int16_t raw_ticks = static_cast<int16_t>(ticks * s);
+    int16_t raw_vel = static_cast<int16_t>(angular_vel * this->sign() / 0.01f);
+    int16_t raw_ticks = static_cast<int16_t>(ticks * this->sign());
     uint8_t data[8] = {0, 0, 0, 0, 0, 0, 0, 0};
     std::memcpy(data, &raw_vel, 2);
     std::memcpy(data + 2, &raw_ticks, 2);

--- a/main/modules/dual_drive_motor.cpp
+++ b/main/modules/dual_drive_motor.cpp
@@ -1,0 +1,194 @@
+#include "dual_drive_motor.h"
+#include "../utils/timing.h"
+#include "../utils/uart.h"
+#include <cmath>
+#include <cstring>
+#include <stdexcept>
+
+REGISTER_MODULE_DEFAULTS(DualDriveMotor)
+
+const std::map<std::string, Variable_ptr> DualDriveMotor::get_defaults() {
+    auto defaults = DualDriveMotorBase::common_defaults();
+    defaults["speed"] = std::make_shared<NumberVariable>();
+    defaults["m_per_rad"] = std::make_shared<NumberVariable>(1.0);
+    defaults["reversed"] = std::make_shared<BooleanVariable>(false);
+    defaults["rad_limit"] = std::make_shared<NumberVariable>(7.8);
+    defaults["current_m1"] = std::make_shared<NumberVariable>();
+    defaults["current_m2"] = std::make_shared<NumberVariable>();
+    return defaults;
+}
+
+DualDriveMotor::DualDriveMotor(const std::string name, const Can_ptr can, const uint32_t node_id)
+    : DualDriveMotorBase(dual_drive_motor, name, can, node_id) {
+    this->properties = DualDriveMotor::get_defaults();
+    // Operating mode 0xA5A5 = drive mode (per firmware spec). Fire-and-forget at construction.
+    this->configure(0x02, 0xA5A5, 0);
+}
+
+bool DualDriveMotor::is_reversed() const {
+    return this->properties.at("reversed")->boolean_value;
+}
+
+double DualDriveMotor::sign() const {
+    return this->is_reversed() ? -1.0 : 1.0;
+}
+
+void DualDriveMotor::subscribe_to_can() {
+    auto self = std::static_pointer_cast<Module>(this->shared_from_this());
+    this->can->subscribe((this->node_id << 5) | 0x11, self);
+    this->can->subscribe((this->node_id << 5) | 0x12, self);
+}
+
+void DualDriveMotor::handle_can_msg(const uint32_t id, const int count, const uint8_t *const data) {
+    uint8_t cmd_id = id & 0x1F;
+    switch (cmd_id) {
+    case 0x11:
+        this->handle_status_msg(data);
+        break;
+    case 0x12: {
+        // DriveStatus (~100ms): motor 1 velocity, relative position counter, per-motor currents.
+        // Bytes: [0-1] vel_m1 int16 0.01 rad/s, [2-3] position int16 hall ticks (wraps at ±32768),
+        //        [4-5] current_m1 int16 mA, [6-7] current_m2 int16 mA
+        int16_t raw_vel_m1;
+        std::memcpy(&raw_vel_m1, data, 2);
+        const double m_per_rad = this->properties.at("m_per_rad")->number_value;
+        this->properties.at("speed")->number_value = raw_vel_m1 * 0.01 * m_per_rad * this->sign();
+
+        int16_t raw_position;
+        std::memcpy(&raw_position, data + 2, 2);
+        if (this->has_last_raw_position) {
+            int32_t delta = static_cast<int32_t>(raw_position) - static_cast<int32_t>(this->last_raw_position);
+            if (delta > 32767) {
+                delta -= 65536;
+            } else if (delta < -32768) {
+                delta += 65536;
+            }
+            this->accumulated_ticks += delta;
+        } else {
+            this->has_last_raw_position = true;
+        }
+        this->last_raw_position = raw_position;
+
+        int16_t raw_current_m1, raw_current_m2;
+        std::memcpy(&raw_current_m1, data + 4, 2);
+        std::memcpy(&raw_current_m2, data + 6, 2);
+        this->properties.at("current_m1")->number_value = raw_current_m1 * 0.001;
+        this->properties.at("current_m2")->number_value = raw_current_m2 * 0.001;
+
+        if (this->is_debug()) {
+            echo("[%lu] CAN RX [NodeID=%ld, CmdID=0x12]: speed %.2f m/s, position %d ticks, I_m1 %.3f A, I_m2 %.3f A",
+                 millis(), this->node_id,
+                 this->properties.at("speed")->number_value,
+                 raw_position,
+                 this->properties.at("current_m1")->number_value,
+                 this->properties.at("current_m2")->number_value);
+        }
+        break;
+    }
+    }
+}
+
+void DualDriveMotor::send_speed_cmd(float angular_vel, uint8_t acc_limit, int8_t jerk_limit_exp) {
+    // SpeedCmd 0x01: target speed.
+    // Bytes: [0-1] vel int16 0.01 rad/s, [2] acc_limit (0=default), [3] jerk_limit_exp (0=default)
+    if (!this->is_enabled()) {
+        return;
+    }
+    const float rad_limit = this->properties.at("rad_limit")->number_value;
+    if (angular_vel > rad_limit) {
+        angular_vel = rad_limit;
+    } else if (angular_vel < -rad_limit) {
+        angular_vel = -rad_limit;
+    }
+    int16_t raw_vel = static_cast<int16_t>(angular_vel * this->sign() / 0.01f);
+    uint8_t data[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    std::memcpy(data, &raw_vel, 2);
+    data[2] = acc_limit;
+    data[3] = static_cast<uint8_t>(jerk_limit_exp);
+    uint32_t can_id = (this->node_id << 5) | 0x01;
+    if (this->is_debug()) {
+        echo("[%lu] CAN TX [NodeID=%ld, CmdID=0x01]: speed %.2f rad/s, raw %d",
+             millis(), this->node_id, angular_vel, raw_vel);
+    }
+    this->can->send(can_id, data);
+}
+
+void DualDriveMotor::send_drive_ticks_cmd(float angular_vel, int16_t ticks) {
+    // DriveTicksCmd 0x04: relative move in hall ticks.
+    // Bytes: [0-1] vel int16 0.01 rad/s, [2-3] ticks int16
+    if (!this->is_enabled()) {
+        return;
+    }
+    const float rad_limit = this->properties.at("rad_limit")->number_value;
+    if (angular_vel > rad_limit) {
+        angular_vel = rad_limit;
+    } else if (angular_vel < -rad_limit) {
+        angular_vel = -rad_limit;
+    }
+    const double s = this->sign();
+    int16_t raw_vel = static_cast<int16_t>(angular_vel * s / 0.01f);
+    int16_t raw_ticks = static_cast<int16_t>(ticks * s);
+    uint8_t data[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    std::memcpy(data, &raw_vel, 2);
+    std::memcpy(data + 2, &raw_ticks, 2);
+    uint32_t can_id = (this->node_id << 5) | 0x04;
+    if (this->is_debug()) {
+        echo("[%lu] CAN TX [NodeID=%ld, CmdID=0x04]: speed %.2f rad/s, ticks %d",
+             millis(), this->node_id, angular_vel, raw_ticks);
+    }
+    this->can->send(can_id, data);
+}
+
+void DualDriveMotor::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
+    if (method_name == "speed") {
+        if (arguments.size() < 1 || arguments.size() > 3) {
+            throw std::runtime_error("unexpected number of arguments");
+        }
+        Module::expect(arguments, -1, numbery, numbery, numbery);
+        float angular_vel = arguments[0]->evaluate_number();
+        uint8_t acc_limit = arguments.size() > 1 ? static_cast<uint8_t>(arguments[1]->evaluate_number()) : 0x00;
+        int8_t jerk_limit_exp = arguments.size() > 2 ? static_cast<int8_t>(arguments[2]->evaluate_number()) : (int8_t)0x00;
+        this->send_speed_cmd(angular_vel, acc_limit, jerk_limit_exp);
+    } else if (method_name == "drive_ticks") {
+        Module::expect(arguments, 2, numbery, integer);
+        float angular_vel = arguments[0]->evaluate_number();
+        int16_t ticks = static_cast<int16_t>(arguments[1]->evaluate_integer());
+        this->send_drive_ticks_cmd(angular_vel, ticks);
+    } else {
+        DualDriveMotorBase::call(method_name, arguments);
+    }
+}
+
+void DualDriveMotor::stop() {
+    this->send_switch_state(2);
+}
+
+double DualDriveMotor::get_position() {
+    // The int16 hall counter from 0x12 wraps at ±32768; we unfold it into
+    // accumulated_ticks on each frame. Convert to meters via motor_ticks and m_per_rad.
+    const double m_per_rad = this->properties.at("m_per_rad")->number_value;
+    return static_cast<double>(this->accumulated_ticks) / MOTOR_TICKS * 2.0 * M_PI * m_per_rad * this->sign();
+}
+
+void DualDriveMotor::position(const double position, const double speed, const double acceleration) {
+    // Not supported: drive mode has no closed-loop position control.
+}
+
+double DualDriveMotor::get_speed() {
+    return this->properties.at("speed")->number_value;
+}
+
+void DualDriveMotor::speed(const double speed, const double acceleration) {
+    const double m_per_rad = this->properties.at("m_per_rad")->number_value;
+    float angular_vel = static_cast<float>(speed / m_per_rad);
+    uint8_t acc_limit = acceleration > 0 ? static_cast<uint8_t>(acceleration) : 0xFF;
+    this->send_speed_cmd(angular_vel, acc_limit);
+}
+
+void DualDriveMotor::enable() {
+    DualDriveMotorBase::enable();
+}
+
+void DualDriveMotor::disable() {
+    DualDriveMotorBase::disable();
+}

--- a/main/modules/dual_drive_motor.cpp
+++ b/main/modules/dual_drive_motor.cpp
@@ -88,9 +88,9 @@ void DualDriveMotor::handle_can_msg(const uint32_t id, const int count, const ui
     }
 }
 
-void DualDriveMotor::send_speed_cmd(float angular_vel, uint8_t acc_limit, int8_t jerk_limit_exp) {
+void DualDriveMotor::send_speed_cmd(float angular_vel) {
     // SpeedCmd 0x01: target speed.
-    // Bytes: [0-1] vel int16 0.01 rad/s, [2] acc_limit (0=default), [3] jerk_limit_exp (0=default)
+    // Bytes: [0-1] vel int16 0.01 rad/s, [2] acc_limit, [3] jerk_limit_exp (acceleration not yet supported by firmware)
     if (!this->is_enabled()) {
         return;
     }
@@ -103,8 +103,6 @@ void DualDriveMotor::send_speed_cmd(float angular_vel, uint8_t acc_limit, int8_t
     int16_t raw_vel = static_cast<int16_t>(angular_vel * this->sign() / 0.01f);
     uint8_t data[8] = {0, 0, 0, 0, 0, 0, 0, 0};
     std::memcpy(data, &raw_vel, 2);
-    data[2] = acc_limit;
-    data[3] = static_cast<uint8_t>(jerk_limit_exp);
     uint32_t can_id = (this->node_id << 5) | 0x01;
     if (this->is_debug()) {
         echo("[%lu] CAN TX [NodeID=%ld, CmdID=0x01]: speed %.2f rad/s, raw %d",
@@ -139,16 +137,18 @@ void DualDriveMotor::send_drive_ticks_cmd(float angular_vel, int16_t ticks) {
     this->can->send(can_id, data);
 }
 
+void DualDriveMotor::drive_meters(float linear_speed, float distance) {
+    const float m_per_rad = this->properties.at("m_per_rad")->number_value;
+    const float angular_vel = linear_speed / m_per_rad;
+    const int16_t ticks = static_cast<int16_t>(distance / m_per_rad * MOTOR_TICKS / (2.0f * M_PI));
+    this->send_drive_ticks_cmd(angular_vel, ticks);
+}
+
 void DualDriveMotor::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
     if (method_name == "speed") {
-        if (arguments.size() < 1 || arguments.size() > 3) {
-            throw std::runtime_error("unexpected number of arguments");
-        }
-        Module::expect(arguments, -1, numbery, numbery, numbery);
+        Module::expect(arguments, 1, numbery);
         float angular_vel = arguments[0]->evaluate_number();
-        uint8_t acc_limit = arguments.size() > 1 ? static_cast<uint8_t>(arguments[1]->evaluate_number()) : 0x00;
-        int8_t jerk_limit_exp = arguments.size() > 2 ? static_cast<int8_t>(arguments[2]->evaluate_number()) : (int8_t)0x00;
-        this->send_speed_cmd(angular_vel, acc_limit, jerk_limit_exp);
+        this->send_speed_cmd(angular_vel);
     } else if (method_name == "drive_ticks") {
         Module::expect(arguments, 2, numbery, integer);
         float angular_vel = arguments[0]->evaluate_number();
@@ -179,10 +179,10 @@ double DualDriveMotor::get_speed() {
 }
 
 void DualDriveMotor::speed(const double speed, const double acceleration) {
+    // acceleration parameter currently ignored: not yet supported by firmware.
     const double m_per_rad = this->properties.at("m_per_rad")->number_value;
     float angular_vel = static_cast<float>(speed / m_per_rad);
-    uint8_t acc_limit = acceleration > 0 ? static_cast<uint8_t>(acceleration) : 0xFF;
-    this->send_speed_cmd(angular_vel, acc_limit);
+    this->send_speed_cmd(angular_vel);
 }
 
 void DualDriveMotor::enable() {

--- a/main/modules/dual_drive_motor.cpp
+++ b/main/modules/dual_drive_motor.cpp
@@ -1,6 +1,7 @@
 #include "dual_drive_motor.h"
 #include "../utils/timing.h"
 #include "../utils/uart.h"
+#include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <stdexcept>
@@ -25,12 +26,8 @@ DualDriveMotor::DualDriveMotor(const std::string name, const Can_ptr can, const 
     this->configure(0x02, 0xA5A5, 0);
 }
 
-bool DualDriveMotor::is_reversed() const {
-    return this->properties.at("reversed")->boolean_value;
-}
-
 double DualDriveMotor::sign() const {
-    return this->is_reversed() ? -1.0 : 1.0;
+    return this->properties.at("reversed")->boolean_value ? -1.0 : 1.0;
 }
 
 void DualDriveMotor::subscribe_to_can() {
@@ -95,11 +92,7 @@ void DualDriveMotor::send_speed_cmd(float angular_vel) {
         return;
     }
     const float rad_limit = this->properties.at("rad_limit")->number_value;
-    if (angular_vel > rad_limit) {
-        angular_vel = rad_limit;
-    } else if (angular_vel < -rad_limit) {
-        angular_vel = -rad_limit;
-    }
+    angular_vel = std::clamp(angular_vel, -rad_limit, rad_limit);
     int16_t raw_vel = static_cast<int16_t>(angular_vel * this->sign() / 0.01f);
     uint8_t data[8] = {0, 0, 0, 0, 0, 0, 0, 0};
     std::memcpy(data, &raw_vel, 2);
@@ -118,11 +111,7 @@ void DualDriveMotor::send_drive_ticks_cmd(float angular_vel, int16_t ticks) {
         return;
     }
     const float rad_limit = this->properties.at("rad_limit")->number_value;
-    if (angular_vel > rad_limit) {
-        angular_vel = rad_limit;
-    } else if (angular_vel < -rad_limit) {
-        angular_vel = -rad_limit;
-    }
+    angular_vel = std::clamp(angular_vel, -rad_limit, rad_limit);
     const double s = this->sign();
     int16_t raw_vel = static_cast<int16_t>(angular_vel * s / 0.01f);
     int16_t raw_ticks = static_cast<int16_t>(ticks * s);
@@ -160,7 +149,7 @@ void DualDriveMotor::call(const std::string method_name, const std::vector<Const
 }
 
 void DualDriveMotor::stop() {
-    this->send_switch_state(2);
+    DualDriveMotorBase::stop();
 }
 
 double DualDriveMotor::get_position() {

--- a/main/modules/dual_drive_motor.h
+++ b/main/modules/dual_drive_motor.h
@@ -18,7 +18,7 @@ private:
     bool is_reversed() const;
     double sign() const;
 
-    void send_speed_cmd(float angular_vel, uint8_t acc_limit = 0x00, int8_t jerk_limit_exp = 0x00);
+    void send_speed_cmd(float angular_vel);
     void send_drive_ticks_cmd(float angular_vel, int16_t ticks);
 
 public:
@@ -27,6 +27,8 @@ public:
     void handle_can_msg(const uint32_t id, const int count, const uint8_t *const data) override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
+
+    void drive_meters(float linear_speed, float distance);
 
     void stop() override;
     double get_position() override;

--- a/main/modules/dual_drive_motor.h
+++ b/main/modules/dual_drive_motor.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "dual_drive_motor_base.h"
+#include "motor.h"
+
+class DualDriveMotor;
+using DualDriveMotor_ptr = std::shared_ptr<DualDriveMotor>;
+
+class DualDriveMotor : public DualDriveMotorBase, virtual public Motor {
+private:
+    // Only one drive motor type so far: g350 with 600 hall ticks per revolution.
+    static constexpr int MOTOR_TICKS = 600;
+
+    int16_t last_raw_position = 0;
+    bool has_last_raw_position = false;
+    int64_t accumulated_ticks = 0;
+
+    bool is_reversed() const;
+    double sign() const;
+
+    void send_speed_cmd(float angular_vel, uint8_t acc_limit = 0x00, int8_t jerk_limit_exp = 0x00);
+    void send_drive_ticks_cmd(float angular_vel, int16_t ticks);
+
+public:
+    DualDriveMotor(const std::string name, const Can_ptr can, const uint32_t node_id);
+    void subscribe_to_can();
+    void handle_can_msg(const uint32_t id, const int count, const uint8_t *const data) override;
+    void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    static const std::map<std::string, Variable_ptr> get_defaults();
+
+    void stop() override;
+    double get_position() override;
+    void position(const double position, const double speed, const double acceleration) override;
+    double get_speed() override;
+    void speed(const double speed, const double acceleration) override;
+    void enable() override;
+    void disable() override;
+};

--- a/main/modules/dual_drive_motor.h
+++ b/main/modules/dual_drive_motor.h
@@ -15,7 +15,6 @@ private:
     bool has_last_raw_position = false;
     int64_t accumulated_ticks = 0;
 
-    bool is_reversed() const;
     double sign() const;
 
     void send_speed_cmd(float angular_vel);

--- a/main/modules/dual_drive_motor_base.cpp
+++ b/main/modules/dual_drive_motor_base.cpp
@@ -59,6 +59,10 @@ void DualDriveMotorBase::send_switch_state(uint8_t state) {
     this->can->send(can_id, data);
 }
 
+void DualDriveMotorBase::stop() {
+    this->send_switch_state(2);
+}
+
 void DualDriveMotorBase::configure(uint8_t setting_id, uint16_t value1, int32_t value2) {
     // Configure 0x0B: Byte 0 = setting_id, Bytes 2-3 = value1 u16, Bytes 4-7 = value2 i32
     // setting_id: 0x00=ACK, 0x01=Set CanID, 0x02=Switch Operating Mode
@@ -81,7 +85,7 @@ void DualDriveMotorBase::call(const std::string method_name, const std::vector<C
         this->send_switch_state(1);
     } else if (method_name == "stop") {
         Module::expect(arguments, 0);
-        this->send_switch_state(2);
+        this->stop();
     } else if (method_name == "on") {
         Module::expect(arguments, 0);
         this->send_switch_state(3);

--- a/main/modules/dual_drive_motor_base.cpp
+++ b/main/modules/dual_drive_motor_base.cpp
@@ -1,0 +1,132 @@
+#include "dual_drive_motor_base.h"
+#include "../utils/timing.h"
+#include "../utils/uart.h"
+#include <cstring>
+
+const std::map<std::string, Variable_ptr> DualDriveMotorBase::common_defaults() {
+    return {
+        {"voltage", std::make_shared<NumberVariable>()},
+        {"temperature", std::make_shared<IntegerVariable>()},
+        {"state", std::make_shared<IntegerVariable>()},
+        {"error_codes", std::make_shared<StringVariable>("0x0000")},
+        {"version", std::make_shared<IntegerVariable>(0)},
+        {"enabled", std::make_shared<BooleanVariable>(true)},
+        {"debug", std::make_shared<BooleanVariable>(false)},
+    };
+}
+
+DualDriveMotorBase::DualDriveMotorBase(const ModuleType type, const std::string name, const Can_ptr can, const uint32_t node_id)
+    : Module(type, name), node_id(node_id), can(can) {
+}
+
+bool DualDriveMotorBase::is_enabled() const {
+    return this->properties.at("enabled")->boolean_value;
+}
+
+bool DualDriveMotorBase::is_debug() const {
+    return this->properties.at("debug")->boolean_value;
+}
+
+void DualDriveMotorBase::handle_status_msg(const uint8_t *data) {
+    // Status (cyclic): bus voltage, motor velocity (ignored at base level), temperature, state, error codes, fw version.
+    // Bytes: [0-1] vel int16 0.01 rad/s (subclass-specific use), [2-3] voltage int16 0.001 V,
+    //        [4] temp int8 °C, [5] state, [6] error mask, [7] fw version
+    int16_t raw_voltage;
+    std::memcpy(&raw_voltage, data + 2, 2);
+    this->properties.at("voltage")->number_value = raw_voltage * 0.001;
+    this->properties.at("temperature")->integer_value = static_cast<int8_t>(data[4]);
+    this->properties.at("state")->integer_value = data[5];
+    char hex_buf[7];
+    snprintf(hex_buf, sizeof(hex_buf), "0x%04x", data[6]);
+    this->properties.at("error_codes")->string_value = hex_buf;
+    this->properties.at("version")->integer_value = data[7];
+    if (this->is_debug()) {
+        echo("[%lu] CAN RX [NodeID=%ld, CmdID=0x11]: voltage %.2f V, temp %d C, state %d, error %s, version %d",
+             millis(), this->node_id,
+             this->properties.at("voltage")->number_value,
+             (int)this->properties.at("temperature")->integer_value,
+             (int)this->properties.at("state")->integer_value,
+             hex_buf,
+             (int)data[7]);
+    }
+}
+
+void DualDriveMotorBase::send_switch_state(uint8_t state) {
+    // SwitchState 0x0A: Byte 0 = state (1=off, 2=stop/brake, 3=on)
+    uint8_t data[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    data[0] = state;
+    uint32_t can_id = (this->node_id << 5) | 0x0A;
+    this->can->send(can_id, data);
+}
+
+void DualDriveMotorBase::configure(uint8_t setting_id, uint16_t value1, int32_t value2) {
+    // Configure 0x0B: Byte 0 = setting_id, Bytes 2-3 = value1 u16, Bytes 4-7 = value2 i32
+    // setting_id: 0x00=ACK, 0x01=Set CanID, 0x02=Switch Operating Mode
+    uint8_t data[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    data[0] = setting_id;
+    std::memcpy(data + 2, &value1, 2);
+    std::memcpy(data + 4, &value2, 4);
+    uint32_t can_id = (this->node_id << 5) | 0x0B;
+    this->can->send(can_id, data);
+}
+
+void DualDriveMotorBase::configure_node_id(uint8_t new_node_id) {
+    // new_node_id is left-shifted by 5 to form the CAN base address (e.g. 1 -> 0x020).
+    this->configure(0x01, static_cast<uint16_t>(new_node_id) << 5, 0);
+}
+
+void DualDriveMotorBase::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
+    if (method_name == "off") {
+        Module::expect(arguments, 0);
+        this->send_switch_state(1);
+    } else if (method_name == "stop") {
+        Module::expect(arguments, 0);
+        this->send_switch_state(2);
+    } else if (method_name == "on") {
+        Module::expect(arguments, 0);
+        this->send_switch_state(3);
+    } else if (method_name == "switch_state") {
+        Module::expect(arguments, 1, integer);
+        this->send_switch_state(static_cast<uint8_t>(arguments[0]->evaluate_integer()));
+    } else if (method_name == "configure") {
+        Module::expect(arguments, 3, integer, integer, integer);
+        this->configure(static_cast<uint8_t>(arguments[0]->evaluate_integer()),
+                        static_cast<uint16_t>(arguments[1]->evaluate_integer()),
+                        static_cast<int32_t>(arguments[2]->evaluate_integer()));
+    } else if (method_name == "configure_node_id") {
+        Module::expect(arguments, 1, integer);
+        this->configure_node_id(static_cast<uint8_t>(arguments[0]->evaluate_integer()));
+    } else if (method_name == "enable") {
+        Module::expect(arguments, 0);
+        this->enable();
+    } else if (method_name == "disable") {
+        Module::expect(arguments, 0);
+        this->disable();
+    } else {
+        Module::call(method_name, arguments);
+    }
+}
+
+void DualDriveMotorBase::step() {
+    bool desired = this->is_enabled();
+    if (desired != this->last_applied_enabled) {
+        if (desired) {
+            this->enable();
+        } else {
+            this->disable();
+        }
+    }
+    Module::step();
+}
+
+void DualDriveMotorBase::enable() {
+    this->properties.at("enabled")->boolean_value = true;
+    this->last_applied_enabled = true;
+    this->send_switch_state(3);
+}
+
+void DualDriveMotorBase::disable() {
+    this->send_switch_state(1);
+    this->properties.at("enabled")->boolean_value = false;
+    this->last_applied_enabled = false;
+}

--- a/main/modules/dual_drive_motor_base.h
+++ b/main/modules/dual_drive_motor_base.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "can.h"
+#include "module.h"
+#include <memory>
+#include <string>
+
+class DualDriveMotorBase;
+using DualDriveMotorBase_ptr = std::shared_ptr<DualDriveMotorBase>;
+
+class DualDriveMotorBase : public Module, public std::enable_shared_from_this<DualDriveMotorBase> {
+protected:
+    const uint32_t node_id;
+    const Can_ptr can;
+    bool last_applied_enabled = true;
+
+    bool is_enabled() const;
+    bool is_debug() const;
+
+    void send_switch_state(uint8_t state);
+    void handle_status_msg(const uint8_t *data);
+
+public:
+    DualDriveMotorBase(const ModuleType type, const std::string name, const Can_ptr can, const uint32_t node_id);
+
+    void configure(uint8_t setting_id, uint16_t value1, int32_t value2);
+    void configure_node_id(uint8_t new_node_id);
+
+    void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void step() override;
+
+    virtual void enable();
+    virtual void disable();
+
+    static const std::map<std::string, Variable_ptr> common_defaults();
+};

--- a/main/modules/dual_drive_motor_base.h
+++ b/main/modules/dual_drive_motor_base.h
@@ -23,6 +23,7 @@ protected:
 public:
     DualDriveMotorBase(const ModuleType type, const std::string name, const Can_ptr can, const uint32_t node_id);
 
+    void stop();
     void configure(uint8_t setting_id, uint16_t value1, int32_t value2);
     void configure_node_id(uint8_t new_node_id);
 

--- a/main/modules/dual_drive_wheels.cpp
+++ b/main/modules/dual_drive_wheels.cpp
@@ -50,6 +50,14 @@ void DualDriveWheels::call(const std::string method_name, const std::vector<Cons
             this->left_motor->speed(linear - angular * width / 2.0, 0);
             this->right_motor->speed(linear + angular * width / 2.0, 0);
         }
+    } else if (method_name == "drive") {
+        Module::expect(arguments, 2, numbery, numbery);
+        if (this->is_enabled()) {
+            const float linear_speed = arguments[0]->evaluate_number();
+            const float distance = arguments[1]->evaluate_number();
+            this->left_motor->drive_meters(linear_speed, distance);
+            this->right_motor->drive_meters(linear_speed, distance);
+        }
     } else if (method_name == "off") {
         Module::expect(arguments, 0);
         this->left_motor->disable();

--- a/main/modules/dual_drive_wheels.cpp
+++ b/main/modules/dual_drive_wheels.cpp
@@ -1,0 +1,84 @@
+#include "dual_drive_wheels.h"
+#include <memory>
+
+REGISTER_MODULE_DEFAULTS(DualDriveWheels)
+
+const std::map<std::string, Variable_ptr> DualDriveWheels::get_defaults() {
+    return {
+        {"width", std::make_shared<NumberVariable>(1.0)},
+        {"linear_speed", std::make_shared<NumberVariable>()},
+        {"angular_speed", std::make_shared<NumberVariable>()},
+        {"enabled", std::make_shared<BooleanVariable>(true)},
+    };
+}
+
+DualDriveWheels::DualDriveWheels(const std::string name, const DualDriveMotor_ptr left_motor, const DualDriveMotor_ptr right_motor)
+    : Module(dual_drive_wheels, name), left_motor(left_motor), right_motor(right_motor) {
+    this->properties = DualDriveWheels::get_defaults();
+}
+
+bool DualDriveWheels::is_enabled() const {
+    return this->properties.at("enabled")->boolean_value;
+}
+
+void DualDriveWheels::step() {
+    const double left_speed = this->left_motor->get_speed();
+    const double right_speed = this->right_motor->get_speed();
+    const double width = this->properties.at("width")->number_value;
+    this->properties.at("linear_speed")->number_value = (left_speed + right_speed) / 2;
+    this->properties.at("angular_speed")->number_value = (right_speed - left_speed) / width;
+
+    bool desired = this->is_enabled();
+    if (desired != this->last_applied_enabled) {
+        if (desired) {
+            this->enable();
+        } else {
+            this->disable();
+        }
+    }
+
+    Module::step();
+}
+
+void DualDriveWheels::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
+    if (method_name == "speed") {
+        Module::expect(arguments, 2, numbery, numbery);
+        if (this->is_enabled()) {
+            const double linear = arguments[0]->evaluate_number();
+            const double angular = arguments[1]->evaluate_number();
+            const double width = this->properties.at("width")->number_value;
+            this->left_motor->speed(linear - angular * width / 2.0, 0);
+            this->right_motor->speed(linear + angular * width / 2.0, 0);
+        }
+    } else if (method_name == "off") {
+        Module::expect(arguments, 0);
+        this->left_motor->disable();
+        this->right_motor->disable();
+    } else if (method_name == "stop") {
+        Module::expect(arguments, 0);
+        this->left_motor->stop();
+        this->right_motor->stop();
+    } else if (method_name == "enable") {
+        Module::expect(arguments, 0);
+        this->enable();
+    } else if (method_name == "disable") {
+        Module::expect(arguments, 0);
+        this->disable();
+    } else {
+        Module::call(method_name, arguments);
+    }
+}
+
+void DualDriveWheels::enable() {
+    this->properties.at("enabled")->boolean_value = true;
+    this->last_applied_enabled = true;
+    this->left_motor->enable();
+    this->right_motor->enable();
+}
+
+void DualDriveWheels::disable() {
+    this->left_motor->disable();
+    this->right_motor->disable();
+    this->properties.at("enabled")->boolean_value = false;
+    this->last_applied_enabled = false;
+}

--- a/main/modules/dual_drive_wheels.h
+++ b/main/modules/dual_drive_wheels.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "dual_drive_motor.h"
+#include "module.h"
+
+class DualDriveWheels : public Module {
+private:
+    const DualDriveMotor_ptr left_motor;
+    const DualDriveMotor_ptr right_motor;
+    bool last_applied_enabled = true;
+
+    bool is_enabled() const;
+
+public:
+    DualDriveWheels(const std::string name, const DualDriveMotor_ptr left_motor, const DualDriveMotor_ptr right_motor);
+    void step() override;
+    void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    static const std::map<std::string, Variable_ptr> get_defaults();
+    void enable();
+    void disable();
+};

--- a/main/modules/module.cpp
+++ b/main/modules/module.cpp
@@ -11,6 +11,8 @@
 #include "d1_motor.h"
 #include "driver/gpio.h"
 #include "driver/ledc.h"
+#include "dual_drive_motor.h"
+#include "dual_drive_wheels.h"
 #include "dunker_motor.h"
 #include "dunker_wheels.h"
 #include "expander.h"
@@ -356,6 +358,28 @@ Module_ptr Module::create(const std::string type,
         MksServoMotor_ptr module = std::make_shared<MksServoMotor>(name, can_module, motor_id);
         module->subscribe_to_can();
         return module;
+    } else if (type == "DualDriveMotor") {
+        Module::expect(arguments, 2, identifier, integer);
+        const Can_ptr can_module = get_module_paramter<Can>(arguments[0], can, "can connection");
+        const int64_t node_id = arguments[1]->evaluate_integer();
+        DualDriveMotor_ptr motor = std::make_shared<DualDriveMotor>(name, can_module, node_id);
+        motor->subscribe_to_can();
+        return motor;
+    } else if (type == "DualDriveWheels") {
+        Module::expect(arguments, 2, identifier, identifier);
+        std::string left_name = arguments[0]->evaluate_identifier();
+        std::string right_name = arguments[1]->evaluate_identifier();
+        Module_ptr left_module = Global::get_module(left_name);
+        Module_ptr right_module = Global::get_module(right_name);
+        if (left_module->type != dual_drive_motor) {
+            throw std::runtime_error("module \"" + left_name + "\" is no dual drive motor");
+        }
+        if (right_module->type != dual_drive_motor) {
+            throw std::runtime_error("module \"" + right_name + "\" is no dual drive motor");
+        }
+        const DualDriveMotor_ptr left_motor = std::static_pointer_cast<DualDriveMotor>(left_module);
+        const DualDriveMotor_ptr right_motor = std::static_pointer_cast<DualDriveMotor>(right_module);
+        return std::make_shared<DualDriveWheels>(name, left_motor, right_motor);
     } else if (type == "DunkerMotor") {
         Module::expect(arguments, 2, identifier, integer);
         const Can_ptr can_module = get_module_paramter<Can>(arguments[0], can, "can connection");

--- a/main/modules/module.h
+++ b/main/modules/module.h
@@ -50,6 +50,8 @@ enum ModuleType {
     temperature_sensor,
     proxy,
     serial_bus,
+    dual_drive_motor,
+    dual_drive_wheels,
 };
 
 class Module;


### PR DESCRIPTION
### Motivation

Add Lizard support for a CAN-based dual-track drive (two motors with hall feedback) so it can be used through the standard Lizard module interface.

This PR is a minimal slice with only the driving parts (base class, drive motor, wheels) and is part of the #194.

### Implementation

Three new modules under `main/modules/`:

- **`DualDriveMotorBase`** — shared base for the dual-track drive over CAN. Handles common state (voltage, temperature, error codes, switch state, firmware version), enable/disable, and the `Configure` (0x0B) and `SwitchState` (0x0A) CAN commands.
- **`DualDriveMotor`** — drive-mode specialization. Auto-switches the controller into drive mode (`Configure 0x02 / 0xA5A5`) on construction. Implements the `Motor` interface so it can be used in shared abstractions (e.g. odometry). Exposes:
  - `motor.speed(vel)` — target angular velocity (rad/s) via SpeedCmd 0x01
  - `motor.drive_ticks(vel, ticks)` — relative move via DriveTicksCmd 0x04
  - `motor.position` — accumulated position (m), derived from the wrapping int16 hall counter and the configurable `m_per_rad`
  - properties: `m_per_rad`, `reversed`, `rad_limit`, per-motor currents
- **`DualDriveWheels`** — combines two `DualDriveMotor` instances for differential steering. Provides `wheels.speed(linear, angular)` and a new `wheels.drive(speed, distance)` for straight-line relative moves (uses each motor's `m_per_rad` and the fixed 600 ticks/rev for tick conversion).

Notes on the firmware contract:

- Currently only the G350 motor (600 hall ticks/rev) is supported in drive mode; this is hardcoded as `MOTOR_TICKS = 600`.
- Acceleration / jerk parameters of SpeedCmd 0x01 are intentionally left out for now: the firmware does not evaluate them yet. Tracked in the Motortreiber TODO inbox so we can re-add them once the firmware catches up.
- `position(target, ...)` (closed-loop absolute position) is not supported in drive mode and is stubbed accordingly.

Module registration follows the same pattern as `DunkerMotor` / `DunkerWheels`.

### Progress

- [x] The implementation is complete.
- [x] Tested on hardware.
- [x] Documentation has been updated.