### PR TITLE
Add DualDriveDeltaMotor and DualDriveDeltaArm modules

### DIFF
--- a/main/modules/dual_drive_delta_arm.cpp
+++ b/main/modules/dual_drive_delta_arm.cpp
@@ -1,0 +1,439 @@
+#include "dual_drive_delta_arm.h"
+#include "../utils/timing.h"
+#include "../utils/uart.h"
+#include <cmath>
+#include <stdexcept>
+
+// Detection-tuning constants — fixed enough that runtime tuning isn't needed.
+static constexpr double POSITION_TOL_DEG = 1.2;     // "target reached" tolerance
+static constexpr unsigned long STABLE_MS = 100;     // hold time inside tolerance before active=false
+static constexpr double STALL_POS_TOL_DEG = 2.4;    // position drift allowed within stall window
+static constexpr unsigned long STALL_MS = 200;      // overcurrent + no movement → stall
+static constexpr int16_t BACKOFF_STEP_TICKS = 10;
+static constexpr uint8_t BACKOFF_SPEED = 20;
+static constexpr unsigned long BACKOFF_INTERVAL_MS = 200;
+
+REGISTER_MODULE_DEFAULTS(DualDriveDeltaArm)
+
+const std::map<std::string, Variable_ptr> DualDriveDeltaArm::get_defaults() {
+    return {
+        {"enabled", std::make_shared<BooleanVariable>(true)},
+        {"calibrating", std::make_shared<BooleanVariable>(false)},
+        {"calibrated_left", std::make_shared<BooleanVariable>(false)},
+        {"calibrated_right", std::make_shared<BooleanVariable>(false)},
+        {"active", std::make_shared<BooleanVariable>(false)},
+        {"stalled", std::make_shared<BooleanVariable>(false)},
+        {"angle_left", std::make_shared<NumberVariable>()},
+        {"angle_right", std::make_shared<NumberVariable>()},
+        {"deg_limit", std::make_shared<NumberVariable>(60.0)},
+        {"cal_timeout", std::make_shared<NumberVariable>(10.0)},
+        {"stall_current", std::make_shared<NumberVariable>(3.0)},
+    };
+}
+
+DualDriveDeltaArm::DualDriveDeltaArm(const std::string name, const DualDriveDeltaMotor_ptr motor,
+                                     const Input_ptr left_endstop, const Input_ptr right_endstop)
+    : Module(dual_drive_delta_arm, name), motor(motor), left_endstop(left_endstop), right_endstop(right_endstop),
+      deg_per_tick(360.0 / motor->motor_ticks) {
+    this->properties = DualDriveDeltaArm::get_defaults();
+}
+
+bool DualDriveDeltaArm::is_enabled() const {
+    return this->properties.at("enabled")->boolean_value;
+}
+
+bool DualDriveDeltaArm::is_calibrated() const {
+    return this->properties.at("calibrated_left")->boolean_value &&
+           this->properties.at("calibrated_right")->boolean_value;
+}
+
+bool DualDriveDeltaArm::endstop_active(const Input_ptr &input) const {
+    return input && input->get_property("active")->boolean_value;
+}
+
+void DualDriveDeltaArm::move_to(double left_deg, double right_deg, uint8_t speed_left, uint8_t speed_right) {
+    if (!this->is_calibrated()) {
+        echo("%s: not calibrated, ignoring move command", this->name.c_str());
+        return;
+    }
+    if (!this->can_move(left_deg, right_deg)) {
+        return;
+    }
+    int16_t left_ticks = static_cast<int16_t>(left_deg / this->deg_per_tick);
+    int16_t right_ticks = static_cast<int16_t>(right_deg / this->deg_per_tick);
+    this->motor->send_delta_angle_cmd(0x30, left_ticks, speed_left, right_ticks, speed_right);
+    this->target_left_deg = left_deg;
+    this->target_right_deg = right_deg;
+    this->was_in_tol = false;
+    this->stable_since = 0;
+    this->was_stalling = false;
+    this->stall_since = 0;
+    this->properties.at("stalled")->boolean_value = false;
+    this->properties.at("active")->boolean_value = true;
+}
+
+bool DualDriveDeltaArm::can_move(double left_deg, double right_deg) const {
+    if (!this->is_enabled()) {
+        return false;
+    }
+    if (this->endstop_active(this->left_endstop) && left_deg > 0) {
+        echo("%s: left endstop triggered, blocking positive motion", this->name.c_str());
+        return false;
+    }
+    if (this->endstop_active(this->right_endstop) && right_deg < 0) {
+        echo("%s: right endstop triggered, blocking negative motion", this->name.c_str());
+        return false;
+    }
+    const double deg_limit = this->properties.at("deg_limit")->number_value;
+    if (deg_limit > 0) {
+        if (left_deg > 0 || left_deg < -deg_limit) {
+            echo("%s: left motor target %.2f° out of range [-%.2f, 0]",
+                 this->name.c_str(), left_deg, deg_limit);
+            return false;
+        }
+        if (right_deg < 0 || right_deg > deg_limit) {
+            echo("%s: right motor target %.2f° out of range [0, %.2f]",
+                 this->name.c_str(), right_deg, deg_limit);
+            return false;
+        }
+    }
+    return true;
+}
+
+void DualDriveDeltaArm::start_reference(const std::string &side) {
+    if (!this->is_enabled()) {
+        echo("%s: not enabled, ignoring reference(%s)", this->name.c_str(), side.c_str());
+        return;
+    }
+    if (this->cal_state != cal_idle) {
+        echo("%s: already calibrating, ignoring reference(%s)", this->name.c_str(), side.c_str());
+        return;
+    }
+    if (side != "left" && side != "right" && side != "both") {
+        throw std::runtime_error("reference side must be \"left\", \"right\" or \"both\"");
+    }
+    // Reset ref results so stale values from previous runs don't cause immediate abort.
+    this->motor->get_property("ref_result_m1")->integer_value = 0;
+    this->motor->get_property("ref_result_m2")->integer_value = 0;
+    this->last_ref_m1 = 0;
+    this->last_ref_m2 = 0;
+    this->m1_brake_sent = false;
+    this->m2_brake_sent = false;
+    this->cal_started_at = millis();
+    this->properties.at("active")->boolean_value = false;
+    this->properties.at("stalled")->boolean_value = false;
+    this->was_stalling = false;
+
+    // If the relevant endstop is already active, nudge the motor away first.
+    // The reference drive would otherwise immediately re-brake and fail (overcurrent).
+    bool left_active = this->endstop_active(this->left_endstop);
+    bool right_active = this->endstop_active(this->right_endstop);
+    bool needs_left_backoff = (side == "left" || side == "both") && left_active;
+    bool needs_right_backoff = (side == "right" || side == "both") && right_active;
+    if (needs_left_backoff || needs_right_backoff) {
+        this->cal_state = cal_backoff;
+        this->pending_ref_side = side;
+        this->last_backoff_at = 0;
+        this->properties.at("calibrating")->boolean_value = true;
+        echo("%s: endstop active, backing off before reference %s", this->name.c_str(), side.c_str());
+        return;
+    }
+
+    this->properties.at("calibrating")->boolean_value = true;
+    if (side == "left") {
+        this->cal_state = cal_left;
+        this->motor->reference_drive_start(1, true);
+        echo("%s: reference left started", this->name.c_str());
+    } else if (side == "right") {
+        this->cal_state = cal_right;
+        this->motor->reference_drive_start(2, false);
+        echo("%s: reference right started", this->name.c_str());
+    } else {
+        this->cal_state = cal_both;
+        this->both_left_done = false;
+        this->both_right_done = false;
+        // Combined frame instead of two separate sends — some firmware revisions only honor "both"
+        // when m1 and m2 commands arrive in the same 0x0C frame.
+        this->motor->send_single_motor_control(0x10, 0x20);
+        echo("%s: reference both started", this->name.c_str());
+    }
+}
+
+void DualDriveDeltaArm::step() {
+    bool desired = this->is_enabled();
+    if (desired != this->last_applied_enabled) {
+        if (desired) {
+            this->enable();
+        } else {
+            this->disable();
+        }
+    }
+
+    bool left_endstop_active = this->endstop_active(this->left_endstop);
+    bool right_endstop_active = this->endstop_active(this->right_endstop);
+
+    // Export current motor angles in degrees (delta mode: 0x15 reports angle_mX as int16 ticks).
+    double cur_m1 = this->motor->get_property("angle_m1")->number_value;
+    double cur_m2 = this->motor->get_property("angle_m2")->number_value;
+    double cur_l_deg = cur_m1 * this->deg_per_tick;
+    double cur_r_deg = cur_m2 * this->deg_per_tick;
+    this->properties.at("angle_left")->number_value = cur_l_deg;
+    this->properties.at("angle_right")->number_value = cur_r_deg;
+
+    // Active / target-reached tracking (no velocity feedback in delta mode).
+    if (this->properties.at("active")->boolean_value) {
+        bool in_tol = std::abs(cur_l_deg - this->target_left_deg) <= POSITION_TOL_DEG &&
+                      std::abs(cur_r_deg - this->target_right_deg) <= POSITION_TOL_DEG;
+        if (in_tol) {
+            if (!this->was_in_tol) {
+                this->stable_since = millis();
+                this->was_in_tol = true;
+            } else if (millis_since(this->stable_since) >= STABLE_MS) {
+                this->properties.at("active")->boolean_value = false;
+                this->was_in_tol = false;
+            }
+        } else {
+            this->was_in_tol = false;
+        }
+    }
+
+    // Endstop safety is handled at move start by can_move() (blocks moves that would
+    // drive past an already-active endstop) and physically by the motor firmware itself.
+    // No runtime brake here — it would interfere with normal home parking at (0,0).
+    this->left_endstop_prev = left_endstop_active;
+    this->right_endstop_prev = right_endstop_active;
+
+    // Stall guard: overcurrent AND position not moving.
+    // High current while moving = legitimate load; high current with no progress = real stall.
+    if (this->properties.at("active")->boolean_value && this->cal_state == cal_idle) {
+        const double i_max = this->properties.at("stall_current")->number_value;
+        const double i_m1 = this->motor->get_property("current_m1")->number_value;
+        const double i_m2 = this->motor->get_property("current_m2")->number_value;
+        const bool overcurrent = std::abs(i_m1) > i_max || std::abs(i_m2) > i_max;
+        if (overcurrent) {
+            if (!this->was_stalling) {
+                this->stall_since = millis();
+                this->stall_start_deg_m1 = cur_l_deg;
+                this->stall_start_deg_m2 = cur_r_deg;
+                this->was_stalling = true;
+            } else if (std::abs(cur_l_deg - this->stall_start_deg_m1) > STALL_POS_TOL_DEG ||
+                       std::abs(cur_r_deg - this->stall_start_deg_m2) > STALL_POS_TOL_DEG) {
+                // Motor still moving despite overcurrent — restart the window.
+                this->stall_since = millis();
+                this->stall_start_deg_m1 = cur_l_deg;
+                this->stall_start_deg_m2 = cur_r_deg;
+            } else if (millis_since(this->stall_since) >= STALL_MS) {
+                this->properties.at("stalled")->boolean_value = true;
+                // Position drifts on forced stop — invalidate calibration so a
+                // recovery requires an explicit reference drive.
+                this->properties.at("calibrated_left")->boolean_value = false;
+                this->properties.at("calibrated_right")->boolean_value = false;
+                this->was_stalling = false;
+                echo("%s: stall detected (i_m1=%.2fA i_m2=%.2fA > %.2fA, no position change) — motor off, recalibrate",
+                     this->name.c_str(), i_m1, i_m2, i_max);
+                this->disable();
+            }
+        } else {
+            this->was_stalling = false;
+        }
+    }
+
+    // Latch ref results: 0x14 arrives per-motor in separate messages, each only
+    // setting its own nibble (the other is NONE/0). Keep the highest non-zero seen.
+    int ref_m1 = this->motor->get_property("ref_result_m1")->integer_value;
+    int ref_m2 = this->motor->get_property("ref_result_m2")->integer_value;
+    if (ref_m1 != 0) {
+        this->last_ref_m1 = ref_m1;
+    }
+    if (ref_m2 != 0) {
+        this->last_ref_m2 = ref_m2;
+    }
+
+    // Calibration timeout: brake both motors and abort if too long.
+    if (this->cal_state != cal_idle) {
+        const double timeout_s = this->properties.at("cal_timeout")->number_value;
+        if (timeout_s > 0 && millis_since(this->cal_started_at) > static_cast<unsigned long>(timeout_s * 1000)) {
+            this->motor->reference_drive_stop(1);
+            this->motor->reference_drive_stop(2);
+            this->properties.at("calibrating")->boolean_value = false;
+            this->properties.at("calibrated_left")->boolean_value = false;
+            this->properties.at("calibrated_right")->boolean_value = false;
+            this->cal_state = cal_idle;
+            echo("%s: calibration timeout after %.1fs", this->name.c_str(), timeout_s);
+        }
+    }
+
+    // Calibration state machine — endstop only triggers the brake; "done" is driven
+    // by the motor's own 0x14 ReferenceFeedback (last_ref_mX becoming non-zero).
+    switch (this->cal_state) {
+    case cal_left:
+        if (this->last_ref_m1 != 0) {
+            if (this->last_ref_m1 == REF_OK) {
+                this->properties.at("calibrated_left")->boolean_value = true;
+                echo("%s: left endstop reached, calibration complete", this->name.c_str());
+            } else {
+                echo("%s: left reference failed (ref_result=%d)", this->name.c_str(), this->last_ref_m1);
+            }
+            this->properties.at("calibrating")->boolean_value = false;
+            this->cal_state = cal_idle;
+        } else if (left_endstop_active && !this->m1_brake_sent) {
+            this->motor->reference_drive_stop(1);
+            this->m1_brake_sent = true;
+            echo("%s: left endstop reached, waiting for motor confirmation", this->name.c_str());
+        }
+        break;
+    case cal_right:
+        if (this->last_ref_m2 != 0) {
+            if (this->last_ref_m2 == REF_OK) {
+                this->properties.at("calibrated_right")->boolean_value = true;
+                echo("%s: right endstop reached, calibration complete", this->name.c_str());
+            } else {
+                echo("%s: right reference failed (ref_result=%d)", this->name.c_str(), this->last_ref_m2);
+            }
+            this->properties.at("calibrating")->boolean_value = false;
+            this->cal_state = cal_idle;
+        } else if (right_endstop_active && !this->m2_brake_sent) {
+            this->motor->reference_drive_stop(2);
+            this->m2_brake_sent = true;
+            echo("%s: right endstop reached, waiting for motor confirmation", this->name.c_str());
+        }
+        break;
+    case cal_both:
+        if (!this->both_left_done) {
+            if (this->last_ref_m1 != 0) {
+                echo("%s: left endstop reached during both-reference (ref_result=%d)",
+                     this->name.c_str(), this->last_ref_m1);
+                this->both_left_done = true;
+            } else if (left_endstop_active && !this->m1_brake_sent) {
+                this->motor->reference_drive_stop(1);
+                this->m1_brake_sent = true;
+            }
+        }
+        if (!this->both_right_done) {
+            if (this->last_ref_m2 != 0) {
+                echo("%s: right endstop reached during both-reference (ref_result=%d)",
+                     this->name.c_str(), this->last_ref_m2);
+                this->both_right_done = true;
+            } else if (right_endstop_active && !this->m2_brake_sent) {
+                this->motor->reference_drive_stop(2);
+                this->m2_brake_sent = true;
+            }
+        }
+        if (this->both_left_done && this->both_right_done) {
+            if (this->last_ref_m1 == REF_OK) {
+                this->properties.at("calibrated_left")->boolean_value = true;
+            }
+            if (this->last_ref_m2 == REF_OK) {
+                this->properties.at("calibrated_right")->boolean_value = true;
+            }
+            this->properties.at("calibrating")->boolean_value = false;
+            this->cal_state = cal_idle;
+            echo("%s: both calibration done (m1=%d m2=%d)", this->name.c_str(), this->last_ref_m1, this->last_ref_m2);
+        }
+        break;
+    case cal_backoff: {
+        // Back off a few ticks in the operating-range direction (negative for m1, positive for m2).
+        bool need_left = (this->pending_ref_side == "left" || this->pending_ref_side == "both");
+        bool need_right = (this->pending_ref_side == "right" || this->pending_ref_side == "both");
+        bool left_clear = !need_left || !left_endstop_active;
+        bool right_clear = !need_right || !right_endstop_active;
+        if (left_clear && right_clear) {
+            std::string side = this->pending_ref_side;
+            this->pending_ref_side.clear();
+            this->cal_state = cal_idle;
+            this->properties.at("calibrating")->boolean_value = false;
+            echo("%s: endstops cleared, starting reference %s", this->name.c_str(), side.c_str());
+            this->start_reference(side);
+            break;
+        }
+        if (millis_since(this->last_backoff_at) >= BACKOFF_INTERVAL_MS) {
+            bool nudge_left = need_left && left_endstop_active;
+            bool nudge_right = need_right && right_endstop_active;
+            // Only one motor per tick — alternate when both endstops are still active.
+            bool pick_left = nudge_left && (!nudge_right || !this->backoff_last_was_left);
+            int16_t a1 = static_cast<int16_t>(cur_m1);
+            int16_t a2 = static_cast<int16_t>(cur_m2);
+            if (pick_left) {
+                int16_t target_m1 = a1 - BACKOFF_STEP_TICKS;
+                echo("%s: backoff left angle=%d -> %d", this->name.c_str(), a1, target_m1);
+                this->motor->send_delta_angle_cmd(0x10, target_m1, BACKOFF_SPEED);
+                this->backoff_last_was_left = true;
+            } else if (nudge_right) {
+                int16_t target_m2 = a2 + BACKOFF_STEP_TICKS;
+                echo("%s: backoff right angle=%d -> %d", this->name.c_str(), a2, target_m2);
+                this->motor->send_delta_angle_cmd(0x20, target_m2, BACKOFF_SPEED);
+                this->backoff_last_was_left = false;
+            }
+            this->last_backoff_at = millis();
+        }
+        break;
+    }
+    case cal_idle:
+        break;
+    }
+
+    Module::step();
+}
+
+void DualDriveDeltaArm::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
+    if (method_name == "position") {
+        if (arguments.size() < 2 || arguments.size() > 4) {
+            throw std::runtime_error("unexpected number of arguments");
+        }
+        double left_deg = arguments[0]->evaluate_number();
+        double right_deg = arguments[1]->evaluate_number();
+        uint8_t speed_left = arguments.size() > 2 ? static_cast<uint8_t>(arguments[2]->evaluate_integer()) : 10;
+        uint8_t speed_right = arguments.size() > 3 ? static_cast<uint8_t>(arguments[3]->evaluate_integer()) : 10;
+        this->move_to(left_deg, right_deg, speed_left, speed_right);
+    } else if (method_name == "reference") {
+        Module::expect(arguments, 1, string);
+        this->start_reference(arguments[0]->evaluate_string());
+    } else if (method_name == "stop") {
+        // stop() = stop both, stop(1) or stop(2) = brake individual motor
+        if (arguments.size() == 0) {
+            if (this->cal_state != cal_idle) {
+                this->cal_state = cal_idle;
+                this->properties.at("calibrating")->boolean_value = false;
+                echo("%s: calibration aborted", this->name.c_str());
+            }
+            this->motor->stop();
+            this->properties.at("active")->boolean_value = false;
+        } else {
+            Module::expect(arguments, 1, integer);
+            int motor_nr = arguments[0]->evaluate_integer();
+            if (motor_nr < 1 || motor_nr > 2) {
+                throw std::runtime_error("motor number must be 1 or 2");
+            }
+            this->motor->reference_drive_stop(motor_nr);
+            echo("%s: brake motor %d", this->name.c_str(), motor_nr);
+        }
+    } else if (method_name == "off") {
+        Module::expect(arguments, 0);
+        this->motor->disable();
+    } else if (method_name == "on") {
+        Module::expect(arguments, 0);
+        this->motor->enable();
+    } else if (method_name == "enable") {
+        Module::expect(arguments, 0);
+        this->enable();
+    } else if (method_name == "disable") {
+        Module::expect(arguments, 0);
+        this->disable();
+    } else {
+        Module::call(method_name, arguments);
+    }
+}
+
+void DualDriveDeltaArm::enable() {
+    this->properties.at("enabled")->boolean_value = true;
+    this->last_applied_enabled = true;
+    this->motor->enable();
+}
+
+void DualDriveDeltaArm::disable() {
+    this->motor->stop();
+    this->motor->disable();
+    this->properties.at("enabled")->boolean_value = false;
+    this->last_applied_enabled = false;
+    this->properties.at("active")->boolean_value = false;
+}

--- a/main/modules/dual_drive_delta_arm.h
+++ b/main/modules/dual_drive_delta_arm.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "dual_drive_delta_motor.h"
+#include "input.h"
+#include "module.h"
+
+class DualDriveDeltaArm : public Module {
+private:
+    const DualDriveDeltaMotor_ptr motor;
+    const Input_ptr left_endstop;
+    const Input_ptr right_endstop;
+    const double deg_per_tick;
+    bool last_applied_enabled = true;
+
+    enum CalibrationState { cal_idle, cal_left, cal_right, cal_both, cal_backoff };
+    CalibrationState cal_state = cal_idle;
+    bool both_left_done = false;
+    bool both_right_done = false;
+    bool m1_brake_sent = false;
+    bool m2_brake_sent = false;
+    int last_ref_m1 = 0;
+    int last_ref_m2 = 0;
+    unsigned long cal_started_at = 0;
+    std::string pending_ref_side;
+    unsigned long last_backoff_at = 0;
+    bool backoff_last_was_left = false;
+
+    double target_left_deg = 0.0;
+    double target_right_deg = 0.0;
+    bool was_in_tol = false;
+    unsigned long stable_since = 0;
+    bool left_endstop_prev = false;
+    bool right_endstop_prev = false;
+    unsigned long stall_since = 0;
+    bool was_stalling = false;
+    double stall_start_deg_m1 = 0.0;
+    double stall_start_deg_m2 = 0.0;
+
+    bool is_enabled() const;
+    bool is_calibrated() const;
+    bool endstop_active(const Input_ptr &input) const;
+    void move_to(double left_deg, double right_deg, uint8_t speed_left, uint8_t speed_right);
+    bool can_move(double left_deg, double right_deg) const;
+    void start_reference(const std::string &side);
+    void enable();
+    void disable();
+
+public:
+    DualDriveDeltaArm(const std::string name, const DualDriveDeltaMotor_ptr motor, const Input_ptr left_endstop, const Input_ptr right_endstop);
+    void step() override;
+    void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    static const std::map<std::string, Variable_ptr> get_defaults();
+};

--- a/main/modules/dual_drive_delta_motor.cpp
+++ b/main/modules/dual_drive_delta_motor.cpp
@@ -20,12 +20,12 @@ const std::map<std::string, Variable_ptr> DualDriveDeltaMotor::get_defaults() {
 
 DualDriveDeltaMotor::MotorConfig DualDriveDeltaMotor::config_for(const std::string &motor_type) {
     // Known delta arm motors and their firmware operating-mode words (Configure 0x0B / setting 0x02):
-    //   "windmeile"     — first delta arm,           300 ticks/rev, mode 0xB5B5
+    //   "windmeile"     — first delta arm,           266 ticks/rev, mode 0xB5B5
     //   "g350"          — drive motor used as delta, 600 ticks/rev, mode 0xD5D5
     //   "g250r-t"       — new delta arm 14.2:1 gear, 678 ticks/rev, currently mode 0xB5B5 (later 0xC5C5)
     // The 12.5:1 g250r-t variant is intentionally not listed — may never be implemented.
     if (motor_type == "windmeile") {
-        return {300, 0xB5B5};
+        return {266, 0xB5B5};
     }
     if (motor_type == "g350") {
         return {600, 0xD5D5};
@@ -76,10 +76,14 @@ void DualDriveDeltaMotor::handle_can_msg(const uint32_t id, const int count, con
         this->properties.at("ref_result_m2")->integer_value = ref_m2;
         auto ref_str = [](uint8_t v) -> const char * {
             switch (v) {
-            case REF_OK: return "OK";
-            case REF_OVERCURRENT: return "OVERCURRENT";
-            case REF_END: return "REF_END";
-            default: return "NONE";
+            case REF_OK:
+                return "OK";
+            case REF_OVERCURRENT:
+                return "OVERCURRENT";
+            case REF_END:
+                return "REF_END";
+            default:
+                return "NONE";
             }
         };
         echo("[%lu] CAN RX [NodeID=%ld, CmdID=0x14]: Reference Result Motor1: %s Motor2: %s",

--- a/main/modules/dual_drive_delta_motor.cpp
+++ b/main/modules/dual_drive_delta_motor.cpp
@@ -1,0 +1,223 @@
+#include "dual_drive_delta_motor.h"
+#include "../utils/timing.h"
+#include "../utils/uart.h"
+#include <cstring>
+#include <stdexcept>
+
+REGISTER_MODULE_DEFAULTS(DualDriveDeltaMotor)
+
+const std::map<std::string, Variable_ptr> DualDriveDeltaMotor::get_defaults() {
+    auto defaults = DualDriveMotorBase::common_defaults();
+    defaults["reversed"] = std::make_shared<BooleanVariable>(false);
+    defaults["angle_m1"] = std::make_shared<NumberVariable>();
+    defaults["angle_m2"] = std::make_shared<NumberVariable>();
+    defaults["current_m1"] = std::make_shared<NumberVariable>();
+    defaults["current_m2"] = std::make_shared<NumberVariable>();
+    defaults["ref_result_m1"] = std::make_shared<IntegerVariable>(0);
+    defaults["ref_result_m2"] = std::make_shared<IntegerVariable>(0);
+    return defaults;
+}
+
+DualDriveDeltaMotor::MotorConfig DualDriveDeltaMotor::config_for(const std::string &motor_type) {
+    // Known delta arm motors and their firmware operating-mode words (Configure 0x0B / setting 0x02):
+    //   "windmeile"     — first delta arm,           300 ticks/rev, mode 0xB5B5
+    //   "g350"          — drive motor used as delta, 600 ticks/rev, mode 0xD5D5
+    //   "g250r-t"       — new delta arm 14.2:1 gear, 678 ticks/rev, currently mode 0xB5B5 (later 0xC5C5)
+    // The 12.5:1 g250r-t variant is intentionally not listed — may never be implemented.
+    if (motor_type == "windmeile") {
+        return {300, 0xB5B5};
+    }
+    if (motor_type == "g350") {
+        return {600, 0xD5D5};
+    }
+    if (motor_type == "g250r-t") {
+        return {678, 0xB5B5};
+    }
+    throw std::runtime_error("unknown delta motor_type: " + motor_type);
+}
+
+DualDriveDeltaMotor::DualDriveDeltaMotor(const std::string name, const Can_ptr can, const uint32_t node_id,
+                                         const std::string motor_type)
+    : DualDriveMotorBase(dual_drive_delta_motor, name, can, node_id),
+      motor_ticks(config_for(motor_type).ticks) {
+    this->properties = DualDriveDeltaMotor::get_defaults();
+    // Switch firmware to the operating mode for this motor variant. Fire-and-forget at construction.
+    this->configure(0x02, config_for(motor_type).mode, 0);
+}
+
+bool DualDriveDeltaMotor::is_reversed() const {
+    return this->properties.at("reversed")->boolean_value;
+}
+
+double DualDriveDeltaMotor::sign() const {
+    return this->is_reversed() ? -1.0 : 1.0;
+}
+
+void DualDriveDeltaMotor::subscribe_to_can() {
+    auto self = std::static_pointer_cast<Module>(this->shared_from_this());
+    this->can->subscribe((this->node_id << 5) | 0x11, self);
+    this->can->subscribe((this->node_id << 5) | 0x14, self);
+    this->can->subscribe((this->node_id << 5) | 0x15, self);
+}
+
+void DualDriveDeltaMotor::handle_can_msg(const uint32_t id, const int count, const uint8_t *const data) {
+    uint8_t cmd_id = id & 0x1F;
+    switch (cmd_id) {
+    case 0x11:
+        this->handle_status_msg(data);
+        break;
+    case 0x14: {
+        // ReferenceFeedback: reference drive completion result.
+        // Byte 0: high nibble = motor 1 result, low nibble = motor 2 result.
+        // Values: 0=none, 1=OK, 2=overcurrent, 4=ref_end (motor keeps spinning)
+        uint8_t ref_m1 = (data[0] >> 4) & 0x0F;
+        uint8_t ref_m2 = data[0] & 0x0F;
+        this->properties.at("ref_result_m1")->integer_value = ref_m1;
+        this->properties.at("ref_result_m2")->integer_value = ref_m2;
+        auto ref_str = [](uint8_t v) -> const char * {
+            switch (v) {
+            case REF_OK: return "OK";
+            case REF_OVERCURRENT: return "OVERCURRENT";
+            case REF_END: return "REF_END";
+            default: return "NONE";
+            }
+        };
+        echo("[%lu] CAN RX [NodeID=%ld, CmdID=0x14]: Reference Result Motor1: %s Motor2: %s",
+             millis(), this->node_id, ref_str(ref_m1), ref_str(ref_m2));
+        break;
+    }
+    case 0x15: {
+        // CurrentAngleCurrent: per-motor angle and current in position-controller mode.
+        // Bytes: [0-1] angle_m1 int16 hall ticks, [2-3] angle_m2 int16 hall ticks,
+        //        [4-5] current_m1 int16 mA, [6-7] current_m2 int16 mA
+        int16_t raw_angle_m1, raw_angle_m2, raw_current_m1, raw_current_m2;
+        std::memcpy(&raw_angle_m1, data, 2);
+        std::memcpy(&raw_angle_m2, data + 2, 2);
+        std::memcpy(&raw_current_m1, data + 4, 2);
+        std::memcpy(&raw_current_m2, data + 6, 2);
+        this->properties.at("angle_m1")->number_value = raw_angle_m1;
+        this->properties.at("angle_m2")->number_value = raw_angle_m2;
+        this->properties.at("current_m1")->number_value = raw_current_m1 * 0.001;
+        this->properties.at("current_m2")->number_value = raw_current_m2 * 0.001;
+        if (this->is_debug()) {
+            echo("CAN RX [NodeID=%ld, CmdID=0x15]: angle_m1=%d angle_m2=%d current_m1=%.2fA current_m2=%.2fA",
+                 this->node_id, raw_angle_m1, raw_angle_m2,
+                 this->properties.at("current_m1")->number_value,
+                 this->properties.at("current_m2")->number_value);
+        }
+        break;
+    }
+    }
+}
+
+void DualDriveDeltaMotor::send_rel_angle_cmd(float angle, uint16_t vel_limit, uint8_t acc_limit, int8_t jerk_limit_exp) {
+    // RelAngleCmd 0x02: move by relative angle.
+    // Bytes: [0-1] angle int16 0.001 rad, [2-3] vel_limit uint16 0.01 rad/s (0xFFFF=none),
+    //        [4] acc_limit, [5] jerk_limit_exp
+    if (!this->is_enabled()) {
+        return;
+    }
+    int16_t raw_angle = static_cast<int16_t>(angle * this->sign() / 0.001f);
+    uint8_t data[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    std::memcpy(data, &raw_angle, 2);
+    std::memcpy(data + 2, &vel_limit, 2);
+    data[4] = acc_limit;
+    data[5] = static_cast<uint8_t>(jerk_limit_exp);
+    uint32_t can_id = (this->node_id << 5) | 0x02;
+    this->can->send(can_id, data);
+}
+
+void DualDriveDeltaMotor::send_delta_angle_cmd(uint8_t motor_select, int16_t pos1, uint8_t spd1, int16_t pos2, uint8_t spd2) {
+    // AngleCmd 0x03: per-motor position command.
+    // Byte 0: motor_select (0x10=left, 0x20=right, 0x30=both)
+    // Bytes 1-2: pos1 int16 hall ticks (±150 = ±180°), Byte 3: spd1 (1=fast..50=slow)
+    // Bytes 4-5: pos2 (only if 0x30), Byte 6: spd2
+    if (!this->is_enabled()) {
+        return;
+    }
+    uint8_t data[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    data[0] = motor_select;
+    std::memcpy(data + 1, &pos1, 2);
+    data[3] = spd1;
+    if (motor_select == 0x30) {
+        std::memcpy(data + 4, &pos2, 2);
+        data[6] = spd2;
+    }
+    uint32_t can_id = (this->node_id << 5) | 0x03;
+    this->can->send(can_id, data);
+}
+
+void DualDriveDeltaMotor::send_reference_drive(uint8_t motor, uint8_t cmd) {
+    // SingleMotorControl 0x0C used for reference drive.
+    // Byte 0: motor 1 cmd, Byte 1: motor 2 cmd
+    // 0x00=no action, 0x05=brake (stores current pos as 0-ref if ref drive active),
+    // 0x10=calibration CW, 0x20=calibration CCW
+    uint8_t data[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    data[0] = (motor == 1) ? cmd : 0x00;
+    data[1] = (motor == 2) ? cmd : 0x00;
+    uint32_t can_id = (this->node_id << 5) | 0x0C;
+    this->can->send(can_id, data);
+}
+
+void DualDriveDeltaMotor::reference_drive_start(uint8_t motor, bool clockwise) {
+    this->send_reference_drive(motor, clockwise ? 0x10 : 0x20);
+}
+
+void DualDriveDeltaMotor::reference_drive_stop(uint8_t motor) {
+    if (this->is_debug()) {
+        echo("%s: stopping reference drive on motor %d", this->name.c_str(), motor);
+    }
+    this->send_reference_drive(motor, 0x05);
+}
+
+void DualDriveDeltaMotor::send_single_motor_control(uint8_t cmd_motor1, uint8_t cmd_motor2) {
+    // SingleMotorControl 0x0C: arbitrary cmd combinations on both motor slots.
+    uint8_t data[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    data[0] = cmd_motor1;
+    data[1] = cmd_motor2;
+    uint32_t can_id = (this->node_id << 5) | 0x0C;
+    this->can->send(can_id, data);
+}
+
+void DualDriveDeltaMotor::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
+    if (method_name == "rel_angle") {
+        if (arguments.size() < 1 || arguments.size() > 4) {
+            throw std::runtime_error("unexpected number of arguments");
+        }
+        Module::expect(arguments, -1, numbery, numbery, numbery, numbery);
+        float angle = arguments[0]->evaluate_number();
+        uint16_t vel_limit = arguments.size() > 1 ? static_cast<uint16_t>(arguments[1]->evaluate_number() / 0.01) : 0xFFFF;
+        uint8_t acc_limit = arguments.size() > 2 ? static_cast<uint8_t>(arguments[2]->evaluate_number()) : 0x00;
+        int8_t jerk_limit_exp = arguments.size() > 3 ? static_cast<int8_t>(arguments[3]->evaluate_number()) : (int8_t)0x00;
+        this->send_rel_angle_cmd(angle, vel_limit, acc_limit, jerk_limit_exp);
+    } else if (method_name == "delta_angle") {
+        if (arguments.size() < 2 || arguments.size() > 5) {
+            throw std::runtime_error("unexpected number of arguments");
+        }
+        Module::expect(arguments, -1, integer, integer, integer, integer, integer);
+        uint8_t motor_select = static_cast<uint8_t>(arguments[0]->evaluate_integer());
+        int16_t pos1 = static_cast<int16_t>(arguments[1]->evaluate_integer());
+        uint8_t spd1 = arguments.size() > 2 ? static_cast<uint8_t>(arguments[2]->evaluate_integer()) : 10;
+        int16_t pos2 = arguments.size() > 3 ? static_cast<int16_t>(arguments[3]->evaluate_integer()) : 0;
+        uint8_t spd2 = arguments.size() > 4 ? static_cast<uint8_t>(arguments[4]->evaluate_integer()) : 10;
+        this->send_delta_angle_cmd(motor_select, pos1, spd1, pos2, spd2);
+    } else if (method_name == "reference_drive_start") {
+        if (arguments.size() < 1 || arguments.size() > 2) {
+            throw std::runtime_error("unexpected number of arguments");
+        }
+        Module::expect(arguments, -1, integer, boolean);
+        uint8_t motor = static_cast<uint8_t>(arguments[0]->evaluate_integer());
+        bool clockwise = arguments.size() > 1 ? arguments[1]->evaluate_boolean() : true;
+        this->reference_drive_start(motor, clockwise);
+    } else if (method_name == "reference_drive_stop") {
+        Module::expect(arguments, 1, integer);
+        this->reference_drive_stop(static_cast<uint8_t>(arguments[0]->evaluate_integer()));
+    } else if (method_name == "single_motor_control") {
+        Module::expect(arguments, 2, integer, integer);
+        uint8_t cmd_motor1 = static_cast<uint8_t>(arguments[0]->evaluate_integer());
+        uint8_t cmd_motor2 = static_cast<uint8_t>(arguments[1]->evaluate_integer());
+        this->send_single_motor_control(cmd_motor1, cmd_motor2);
+    } else {
+        DualDriveMotorBase::call(method_name, arguments);
+    }
+}

--- a/main/modules/dual_drive_delta_motor.h
+++ b/main/modules/dual_drive_delta_motor.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "dual_drive_motor_base.h"
+
+class DualDriveDeltaMotor;
+using DualDriveDeltaMotor_ptr = std::shared_ptr<DualDriveDeltaMotor>;
+
+static constexpr uint8_t REF_OK = 1;
+static constexpr uint8_t REF_OVERCURRENT = 2;
+static constexpr uint8_t REF_END = 4;
+
+class DualDriveDeltaMotor : public DualDriveMotorBase {
+public:
+    struct MotorConfig {
+        int ticks;
+        uint16_t mode; // operating mode word for Configure 0x0B / setting 0x02
+    };
+
+    const int motor_ticks;
+
+private:
+    bool is_reversed() const;
+    double sign() const;
+
+    void send_rel_angle_cmd(float angle, uint16_t vel_limit = 0xFFFF, uint8_t acc_limit = 0x00, int8_t jerk_limit_exp = 0x00);
+
+    static MotorConfig config_for(const std::string &motor_type);
+
+public:
+    DualDriveDeltaMotor(const std::string name, const Can_ptr can, const uint32_t node_id,
+                        const std::string motor_type);
+    void subscribe_to_can();
+    void handle_can_msg(const uint32_t id, const int count, const uint8_t *const data) override;
+    void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    static const std::map<std::string, Variable_ptr> get_defaults();
+
+    void send_delta_angle_cmd(uint8_t motor_select, int16_t pos1, uint8_t spd1 = 10, int16_t pos2 = 0, uint8_t spd2 = 10);
+    void send_single_motor_control(uint8_t cmd_motor1, uint8_t cmd_motor2);
+    void send_reference_drive(uint8_t motor, uint8_t cmd);
+    void reference_drive_start(uint8_t motor, bool clockwise = true);
+    void reference_drive_stop(uint8_t motor);
+};

--- a/main/modules/dual_drive_motor_base.cpp
+++ b/main/modules/dual_drive_motor_base.cpp
@@ -1,0 +1,136 @@
+#include "dual_drive_motor_base.h"
+#include "../utils/timing.h"
+#include "../utils/uart.h"
+#include <cstring>
+
+const std::map<std::string, Variable_ptr> DualDriveMotorBase::common_defaults() {
+    return {
+        {"voltage", std::make_shared<NumberVariable>()},
+        {"temperature", std::make_shared<IntegerVariable>()},
+        {"state", std::make_shared<IntegerVariable>()},
+        {"error_codes", std::make_shared<StringVariable>("0x0000")},
+        {"version", std::make_shared<IntegerVariable>(0)},
+        {"enabled", std::make_shared<BooleanVariable>(true)},
+        {"debug", std::make_shared<BooleanVariable>(false)},
+    };
+}
+
+DualDriveMotorBase::DualDriveMotorBase(const ModuleType type, const std::string name, const Can_ptr can, const uint32_t node_id)
+    : Module(type, name), node_id(node_id), can(can) {
+}
+
+bool DualDriveMotorBase::is_enabled() const {
+    return this->properties.at("enabled")->boolean_value;
+}
+
+bool DualDriveMotorBase::is_debug() const {
+    return this->properties.at("debug")->boolean_value;
+}
+
+void DualDriveMotorBase::handle_status_msg(const uint8_t *data) {
+    // Status (cyclic): bus voltage, motor velocity (ignored at base level), temperature, state, error codes, fw version.
+    // Bytes: [0-1] vel int16 0.01 rad/s (subclass-specific use), [2-3] voltage int16 0.001 V,
+    //        [4] temp int8 °C, [5] state, [6] error mask, [7] fw version
+    int16_t raw_voltage;
+    std::memcpy(&raw_voltage, data + 2, 2);
+    this->properties.at("voltage")->number_value = raw_voltage * 0.001;
+    this->properties.at("temperature")->integer_value = static_cast<int8_t>(data[4]);
+    this->properties.at("state")->integer_value = data[5];
+    char hex_buf[7];
+    snprintf(hex_buf, sizeof(hex_buf), "0x%04x", data[6]);
+    this->properties.at("error_codes")->string_value = hex_buf;
+    this->properties.at("version")->integer_value = data[7];
+    if (this->is_debug()) {
+        echo("[%lu] CAN RX [NodeID=%ld, CmdID=0x11]: voltage %.2f V, temp %d C, state %d, error %s, version %d",
+             millis(), this->node_id,
+             this->properties.at("voltage")->number_value,
+             (int)this->properties.at("temperature")->integer_value,
+             (int)this->properties.at("state")->integer_value,
+             hex_buf,
+             (int)data[7]);
+    }
+}
+
+void DualDriveMotorBase::send_switch_state(uint8_t state) {
+    // SwitchState 0x0A: Byte 0 = state (1=off, 2=stop/brake, 3=on)
+    uint8_t data[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    data[0] = state;
+    uint32_t can_id = (this->node_id << 5) | 0x0A;
+    this->can->send(can_id, data);
+}
+
+void DualDriveMotorBase::stop() {
+    this->send_switch_state(2);
+}
+
+void DualDriveMotorBase::configure(uint8_t setting_id, uint16_t value1, int32_t value2) {
+    // Configure 0x0B: Byte 0 = setting_id, Bytes 2-3 = value1 u16, Bytes 4-7 = value2 i32
+    // setting_id: 0x00=ACK, 0x01=Set CanID, 0x02=Switch Operating Mode
+    uint8_t data[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    data[0] = setting_id;
+    std::memcpy(data + 2, &value1, 2);
+    std::memcpy(data + 4, &value2, 4);
+    uint32_t can_id = (this->node_id << 5) | 0x0B;
+    this->can->send(can_id, data);
+}
+
+void DualDriveMotorBase::configure_node_id(uint8_t new_node_id) {
+    // new_node_id is left-shifted by 5 to form the CAN base address (e.g. 1 -> 0x020).
+    this->configure(0x01, static_cast<uint16_t>(new_node_id) << 5, 0);
+}
+
+void DualDriveMotorBase::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
+    if (method_name == "off") {
+        Module::expect(arguments, 0);
+        this->send_switch_state(1);
+    } else if (method_name == "stop") {
+        Module::expect(arguments, 0);
+        this->stop();
+    } else if (method_name == "on") {
+        Module::expect(arguments, 0);
+        this->send_switch_state(3);
+    } else if (method_name == "switch_state") {
+        Module::expect(arguments, 1, integer);
+        this->send_switch_state(static_cast<uint8_t>(arguments[0]->evaluate_integer()));
+    } else if (method_name == "configure") {
+        Module::expect(arguments, 3, integer, integer, integer);
+        this->configure(static_cast<uint8_t>(arguments[0]->evaluate_integer()),
+                        static_cast<uint16_t>(arguments[1]->evaluate_integer()),
+                        static_cast<int32_t>(arguments[2]->evaluate_integer()));
+    } else if (method_name == "configure_node_id") {
+        Module::expect(arguments, 1, integer);
+        this->configure_node_id(static_cast<uint8_t>(arguments[0]->evaluate_integer()));
+    } else if (method_name == "enable") {
+        Module::expect(arguments, 0);
+        this->enable();
+    } else if (method_name == "disable") {
+        Module::expect(arguments, 0);
+        this->disable();
+    } else {
+        Module::call(method_name, arguments);
+    }
+}
+
+void DualDriveMotorBase::step() {
+    bool desired = this->is_enabled();
+    if (desired != this->last_applied_enabled) {
+        if (desired) {
+            this->enable();
+        } else {
+            this->disable();
+        }
+    }
+    Module::step();
+}
+
+void DualDriveMotorBase::enable() {
+    this->properties.at("enabled")->boolean_value = true;
+    this->last_applied_enabled = true;
+    this->send_switch_state(3);
+}
+
+void DualDriveMotorBase::disable() {
+    this->send_switch_state(1);
+    this->properties.at("enabled")->boolean_value = false;
+    this->last_applied_enabled = false;
+}

--- a/main/modules/dual_drive_motor_base.h
+++ b/main/modules/dual_drive_motor_base.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "can.h"
+#include "module.h"
+#include <memory>
+#include <string>
+
+class DualDriveMotorBase;
+using DualDriveMotorBase_ptr = std::shared_ptr<DualDriveMotorBase>;
+
+class DualDriveMotorBase : public Module, public std::enable_shared_from_this<DualDriveMotorBase> {
+protected:
+    const uint32_t node_id;
+    const Can_ptr can;
+    bool last_applied_enabled = true;
+
+    bool is_enabled() const;
+    bool is_debug() const;
+
+    void send_switch_state(uint8_t state);
+    void handle_status_msg(const uint8_t *data);
+
+public:
+    DualDriveMotorBase(const ModuleType type, const std::string name, const Can_ptr can, const uint32_t node_id);
+
+    void stop();
+    void configure(uint8_t setting_id, uint16_t value1, int32_t value2);
+    void configure_node_id(uint8_t new_node_id);
+
+    void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void step() override;
+
+    virtual void enable();
+    virtual void disable();
+
+    static const std::map<std::string, Variable_ptr> common_defaults();
+};

--- a/main/modules/module.cpp
+++ b/main/modules/module.cpp
@@ -11,6 +11,8 @@
 #include "d1_motor.h"
 #include "driver/gpio.h"
 #include "driver/ledc.h"
+#include "dual_drive_delta_arm.h"
+#include "dual_drive_delta_motor.h"
 #include "dunker_motor.h"
 #include "dunker_wheels.h"
 #include "expander.h"
@@ -378,6 +380,23 @@ Module_ptr Module::create(const std::string type,
         const DunkerMotor_ptr left_motor = std::static_pointer_cast<DunkerMotor>(left_module);
         const DunkerMotor_ptr right_motor = std::static_pointer_cast<DunkerMotor>(right_module);
         return std::make_shared<DunkerWheels>(name, left_motor, right_motor);
+    } else if (type == "DualDriveDeltaMotor") {
+        Module::expect(arguments, 3, identifier, integer, string);
+        const Can_ptr can_module = get_module_paramter<Can>(arguments[0], can, "can connection");
+        const int64_t node_id = arguments[1]->evaluate_integer();
+        if (node_id < 0 || node_id > 0x3F) {
+            throw std::runtime_error("node ID must be between 0 and 63");
+        }
+        const std::string motor_type = arguments[2]->evaluate_string();
+        DualDriveDeltaMotor_ptr motor = std::make_shared<DualDriveDeltaMotor>(name, can_module, node_id, motor_type);
+        motor->subscribe_to_can();
+        return motor;
+    } else if (type == "DualDriveDeltaArm") {
+        Module::expect(arguments, 3, identifier, identifier, identifier);
+        const DualDriveDeltaMotor_ptr motor = get_module_paramter<DualDriveDeltaMotor>(arguments[0], dual_drive_delta_motor, "dual drive delta motor");
+        const Input_ptr left_endstop = get_module_paramter<Input>(arguments[1], input, "input");
+        const Input_ptr right_endstop = get_module_paramter<Input>(arguments[2], input, "input");
+        return std::make_shared<DualDriveDeltaArm>(name, motor, left_endstop, right_endstop);
     } else if (type == "Analog") {
         if (arguments.size() < 2 || arguments.size() > 3) {
             throw std::runtime_error("unexpected number of arguments");

--- a/main/modules/module.h
+++ b/main/modules/module.h
@@ -50,6 +50,8 @@ enum ModuleType {
     temperature_sensor,
     proxy,
     serial_bus,
+    dual_drive_delta_motor,
+    dual_drive_delta_arm,
 };
 
 class Module;


### PR DESCRIPTION
### Motivation

Add Lizard support for the CAN-based dual-drive delta arm (two-motor positioning arm with hall feedback and per-side endstops) so it can be used through the standard Lizard module interface.

This PR is the second slice of #194 and stacks on top of #209: it ships the delta-arm parts (delta motor + arm kinematics/calibration). The shared `DualDriveMotorBase` is duplicated here against `main` so the branch can be reviewed independently — once #209 merges, merging `main` back into this branch resolves the base class to a no-op.

### Implementation

Three new modules under `main/modules/`:

- **`DualDriveMotorBase`** — shared base, identical to the one in #209. Handles common state (voltage, temperature, error codes, switch state, firmware version), enable/disable, and the `Configure` (0x0B) / `SwitchState` (0x0A) / `stop` CAN commands.
- **`DualDriveDeltaMotor`** — delta-mode specialization. Auto-switches the controller into the operating mode for the configured motor variant (`Configure 0x02`) on construction. Variants currently supported:
  - `windmeile` — first delta arm, 300 ticks/rev, mode `0xB5B5`
  - `g350` — drive motor used as delta, 600 ticks/rev, mode `0xD5D5`
  - `g250r-t` — new delta arm 14.2:1 gear, 678 ticks/rev, mode `0xB5B5` (later `0xC5C5`)

  Exposes:
  - `motor.rel_angle(angle, vel_limit?, acc_limit?, jerk_limit_exp?)` — relative angle move via `RelAngleCmd 0x02`
  - `motor.delta_angle(motor_select, pos1, spd1?, pos2?, spd2?)` — per-motor or combined position command via `AngleCmd 0x03` (`0x10`=left, `0x20`=right, `0x30`=both)
  - `motor.reference_drive_start(motor, clockwise?)` / `motor.reference_drive_stop(motor)` — trigger and brake the firmware's reference drive via `SingleMotorControl 0x0C`
  - `motor.single_motor_control(cmd_motor1, cmd_motor2)` — raw `0x0C` for combined frames
  - properties: `reversed`, per-motor `angle_m{1,2}` (hall ticks), per-motor `current_m{1,2}` (A), `ref_result_m{1,2}`
- **`DualDriveDeltaArm`** — combines a `DualDriveDeltaMotor` with two `Input` endstops. Owns the calibration state machine and the high-level positioning interface:
  - `arm.position(left_deg, right_deg, speed_left?, speed_right?)` — move both arms in degrees, blocked unless calibrated and target inside `deg_limit`
  - `arm.reference("left" | "right" | "both")` — start a reference drive; if the relevant endstop is already active the arm first nudges the motor away in `BACKOFF_STEP_TICKS` increments, then issues the reference command. For `"both"` the calibration is sent as a single combined `0x0C` frame because some firmware revisions only honor "both" that way.
  - `arm.stop()` — abort calibration and brake both motors; `arm.stop(1|2)` brakes a single motor
  - `arm.on()` / `arm.off()` / `arm.enable()` / `arm.disable()` — power and module-level enable
  - properties: `enabled`, `calibrating`, `calibrated_left`, `calibrated_right`, `active`, `stalled`, `angle_left`, `angle_right`, `deg_limit`, `cal_timeout`, `stall_current`

  Detection logic in `step()`:
  - **Target reached:** `active` clears once both arms stay within `POSITION_TOL_DEG` (1.2°) for `STABLE_MS` (100 ms).
  - **Stall guard:** while `active`, overcurrent (`|i| > stall_current`) AND no position change beyond `STALL_POS_TOL_DEG` (2.4°) within `STALL_MS` (200 ms) marks the arm `stalled`, invalidates calibration, and disables the motor.
  - **Calibration timeout:** `cal_timeout` (default 10 s) brakes both motors and clears calibration if the firmware never reports a `ReferenceFeedback`.

Notes on the firmware contract:

- Reference completion is driven by the firmware's own `ReferenceFeedback 0x14` (`REF_OK` / `REF_OVERCURRENT` / `REF_END`); the endstop only triggers the brake, not the "done" transition.
- `0x14` arrives per-motor in separate frames (each only setting its own nibble), so the arm latches the highest non-zero value seen per motor across the calibration window.
- No runtime endstop brake during normal motion — endstop safety is enforced at move-start by `can_move()` and physically by the motor firmware.

Module registration follows the same pattern as `DualDriveMotor` / `DualDriveWheels`.

### Progress

- [ ] The implementation is complete.
- [x] Tested on hardware.
- [ ] Documentation has been updated (or is not necessary).
