### PR TITLE
Deadline-based main loop (sleep the remainder of the 10 ms budget)

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -426,6 +426,7 @@ void app_main() {
     printf("\nReady.\n");
 
     while (true) {
+        const unsigned long loop_start = millis();
         try {
             process_uart();
         } catch (const std::runtime_error &e) {
@@ -458,6 +459,9 @@ void app_main() {
             }
         }
 
-        delay(10);
+        // sleep the remainder of the 10 ms budget, not a full vTaskDelay(10) after work (#213).
+        // 1-tick floor: vTaskDelay(0) only yields to equal prio, so idle (WDT) needs a real block.
+        const unsigned long elapsed = millis_since(loop_start);
+        delay(elapsed < 10 ? 10 - elapsed : 1);
     }
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -425,8 +425,11 @@ void app_main() {
 
     printf("\nReady.\n");
 
+    // Anchor for the deadline loop below: xTaskDelayUntil advances this by one period
+    // each iteration, giving a drift-free 10 ms cadence (no millis() re-read per loop).
+    TickType_t last_wake = xTaskGetTickCount();
+
     while (true) {
-        const unsigned long loop_start = millis();
         try {
             process_uart();
         } catch (const std::runtime_error &e) {
@@ -459,9 +462,13 @@ void app_main() {
             }
         }
 
-        // sleep the remainder of the 10 ms budget, not a full vTaskDelay(10) after work (#213).
-        // 1-tick floor: vTaskDelay(0) only yields to equal prio, so idle (WDT) needs a real block.
-        const unsigned long elapsed = millis_since(loop_start);
-        delay(elapsed < 10 ? 10 - elapsed : 1);
+        // Sleep until the next 10 ms period boundary instead of a full vTaskDelay(10) after
+        // work, so the period is max(10 ms, work) and drift-free (#213). On overrun
+        // xTaskDelayUntil returns pdFALSE without blocking; floor at 1 tick so the idle task
+        // still runs to feed the watchdog (vTaskDelay(0) only yields to equal-prio tasks).
+        if (xTaskDelayUntil(&last_wake, pdMS_TO_TICKS(10)) == pdFALSE) {
+            last_wake = xTaskGetTickCount();
+            delay(1);
+        }
     }
 }


### PR DESCRIPTION
*Authored with Claude Code, on @evnchn's behalf.*

**TL;DR:** The main loop ends each iteration with an unconditional `vTaskDelay(10)`, so per-loop work is stacked on top of a full 10 ms sleep — loop period becomes `work + 10 ms`. This sleeps to a fixed 10 ms deadline instead, so the period is `max(10 ms, work)`: work up to the budget is absorbed for free, and beyond it the redundant sleep is dropped. Uses `xTaskDelayUntil` (absolute phase reference) so the cadence is drift-free. Baud-agnostic, no protocol change. Implements mitigation #2 from #213. One file, +12/−1.

```cpp
TickType_t last_wake = xTaskGetTickCount();          // before the loop
while (true) {
    // ... loop work ...
    // sleep to the next 10 ms boundary; on overrun xTaskDelayUntil returns pdFALSE
    // without blocking, so yield 1 tick to let the idle task feed the watchdog
    if (xTaskDelayUntil(&last_wake, pdMS_TO_TICKS(10)) == pdFALSE) {
        last_wake = xTaskGetTickCount();
        delay(1);
    }
}
```

> **Update:** switched from a `millis()`-subtraction tail to `xTaskDelayUntil` after @JensOgorek's review — the relative variant drifted ~1 ms fast per loop (tick quantization), the absolute-phase version holds a true 10 ms. Numbers below re-measured on hardware accordingly.

<details>
<summary><b>Measured on hardware (ESP32-classic, ESP-IDF v5.3.1)</b></summary>

Injected per-loop CPU work, light output (so the wire isn't the bottleneck), 115200:

| per-loop work | 0 | 4 | 8 | 12 | 18 ms |
|---|---|---|---|---|---|
| `delay(10)` (before) | 100 | 71 | 56 | 45 | 36 Hz |
| `millis()` deadline (prev revision) | 111 | 111 | 111 | 77 | 53 Hz |
| `xTaskDelayUntil` deadline (this revision) | 100 | 100 | **100** | 77 | 53 Hz |

The loop holds a clean **10.0 ms** period through 8 ms of control work (idle period measured dead-on 10.00 ms), versus 56 Hz before. Beyond the budget the period tracks the work (12 ms → 13 ms, 18 ms → 19 ms), shedding the redundant trailing sleep. The previous `millis()` revision read 111 Hz ≈ 9 ms at low work — running ~1 ms/loop *fast* from per-loop tick quantization; `xTaskDelayUntil` removes that drift and hits the true 10 ms target (correct for a control loop). This recovers control-loop rate without touching baud; it does nothing for *output* throttling (that's wire-bound, per #213) — its job is to stop per-loop work stacking on the trailing sleep.
</details>

<details>
<summary><b>Why the 1-tick floor (not 0)</b></summary>

When the work overruns the 10 ms budget, `xTaskDelayUntil` returns `pdFALSE` without blocking. Rather than spin straight into the next iteration, the overrun branch re-anchors `last_wake` and yields 1 tick. The reason for 1 and not 0: `vTaskDelay(0)` only yields to equal-or-higher-priority ready tasks, so it never lets the priority-0 idle task run — which on ESP-IDF feeds the task watchdog and frees deleted-task memory. A real 1-tick block does. Verified on hardware: with the floor at 0 and 15 ms/loop of work, the TWDT fires on `IDLE0 (CPU 0)` in ~5 s; at 1 it runs stably (15 ms sustained work for 8 s → 0 resets, no TWDT).
</details>
