### PR TITLE
Escape '%' in configure.py payloads sent over the serial bus

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -19,7 +19,11 @@ args = parser.parse_args()
 
 def send(payload: str) -> None:
     """Send a payload string to the ESP32, optionally over a serial bus."""
-    line_ = f'{args.bus_name}.send({args.serial_bus}, {json.dumps(payload)})' if args.serial_bus else payload
+    if args.serial_bus:
+        escaped_ = payload.replace('%', '%%')
+        line_ = f'{args.bus_name}.send({args.serial_bus}, {json.dumps(escaped_)})'
+    else:
+        line_ = payload
     print(f'Sending: {line_}')
     checksum_ = 0
     for c in line_:


### PR DESCRIPTION
## Problem

When configuring a node over the serial bus (`configure.py <file> <port> --serial-bus <id>`), every config line is wrapped into a `bus.send(<id>, "<payload>")` call that is executed on the **coordinator**.

The coordinator's `bus.send` performs printf-style formatting (see `main/modules/serial_bus.cpp` → `format_args` in `main/utils/format.cpp`). The payload is used as the **format string**, but `configure.py` passes no additional arguments. As a result, any `%` in a config line is interpreted as a format specifier and aborts that line with:

```
format: '%.2f' has no matching argument
```

Concretely, this silently dropped **every** config line containing a format string, e.g.:

```
bus.send(1, "!!scissor_position=%.2f", lift.position)
bus.send(1, "!!scissor_enabled=%s", lift.enabled)
bus.send(1, "!!scissor_fault=%s", lift.fault)
```

Those lines never reached the target node, so the node booted with an incomplete startup script and stopped emitting the affected messages — while still appearing healthy and reachable, which made the failure hard to spot.

## Fix

When `--serial-bus` is used, escape `%` as `%%` in the payload before wrapping it in the `bus.send(...)` call. The coordinator's printf formatting collapses `%%` back into a literal `%`, so the original line is reconstructed verbatim and forwarded to the target node intact.

Direct (non-bus) configuration is unaffected — the escaping only applies on the `--serial-bus` path.

## Testing

Verified on hardware: configuring an ESP32-S3 scissor-lift node over the bus via the coordinator. Before the fix the `%`-containing `bus.send` lines were dropped and no position messages arrived; after the fix the full startup script is applied and the node resumes sending its messages.