### PR TITLE
espresso: flash from non-Jetson hosts even with gpiod installed

### DIFF
--- a/espresso.py
+++ b/espresso.py
@@ -38,6 +38,8 @@ class GpioControllerV1(GpioController):
             'en': chip.find_line(en),
             'g0': chip.find_line(g0),
         }
+        if None in self._lines.values():
+            raise RuntimeError(f'GPIO lines {en}/{g0} not found on gpiochip0')
 
     def request_outputs(self, consumer: str) -> None:
         for line in self._lines.values():
@@ -122,11 +124,17 @@ EN = 'PR.04'
 G0 = 'PAC.06'
 if SWAP:
     EN, G0 = G0, EN
-gpio = {
-    None: GpioController,
-    1: GpioControllerV1,
-    2: GpioControllerV2,
-}[GPIOD_VERSION](EN, G0)
+try:
+    gpio = {
+        None: GpioController,
+        1: GpioControllerV1,
+        2: GpioControllerV2,
+    }[GPIOD_VERSION](EN, G0)
+except Exception as error:  # noqa: BLE001 - any gpiod/hardware error means no controllable pins
+    # gpiod is installed but the EN/G0 pins are not available (e.g. not a Jetson):
+    # fall back to the no-op controller and rely on esptool's DTR/RTS reset for flashing.
+    print(f'No controllable EN/G0 pins ({error}); falling back to esptool reset only.')
+    gpio = GpioController(EN, G0)
 
 
 @contextmanager

--- a/espresso.py
+++ b/espresso.py
@@ -57,12 +57,11 @@ class GpioControllerV2(GpioController):
     CHIP_PATH = '/dev/gpiochip0'
 
     def __init__(self, en: str, g0: str) -> None:
-        chip = gpiod.Chip(self.CHIP_PATH)
-        self._offsets = {
-            'en': chip.line_offset_from_id(en),
-            'g0': chip.line_offset_from_id(g0),
-        }
-        chip.close()
+        with gpiod.Chip(self.CHIP_PATH) as chip:
+            self._offsets = {
+                'en': chip.line_offset_from_id(en),
+                'g0': chip.line_offset_from_id(g0),
+            }
         self._request = None
 
     def request_outputs(self, consumer: str) -> None:
@@ -83,7 +82,8 @@ class GpioControllerV2(GpioController):
 
 DEFAULT_DEVICE = '/dev/tty.SLAB_USBtoUART'
 path = Path('/etc/nv_tegra_release')
-if path.exists() and (match := re.search(r'R(\d+)', path.read_text(encoding='utf-8'))):
+IS_JETSON = path.exists()
+if IS_JETSON and (match := re.search(r'R(\d+)', path.read_text(encoding='utf-8'))):
     major = int(match.group(1))
     if major == 35:
         DEFAULT_DEVICE = '/dev/ttyTHS0'
@@ -131,6 +131,8 @@ try:
         2: GpioControllerV2,
     }[GPIOD_VERSION](EN, G0)
 except Exception as error:  # noqa: BLE001 - any gpiod/hardware error means no controllable pins
+    if IS_JETSON:
+        raise  # on a Jetson the EN/G0 lines must resolve; surface the real error instead of masking it
     # gpiod is installed but the EN/G0 pins are not available (e.g. not a Jetson):
     # fall back to the no-op controller and rely on esptool's DTR/RTS reset for flashing.
     print(f'No controllable EN/G0 pins ({error}); falling back to esptool reset only.')


### PR DESCRIPTION
### Motivation

`espresso.py` is meant to flash an ESP32 from a Jetson, where it drives the EN/G0 pins via `gpiod`. When `gpiod` is **not** installed it already degrades to a no-op pin controller and flashes fine via esptool's DTR/RTS auto-reset (e.g. on a developer machine with a USB-serial board).

But when `gpiod` **is** installed on a non-Jetson host, the EN/G0 lines (`PR.04` / `PAC.06`) do not exist, and espresso crashed at startup while constructing the `GpioController` — so you couldn't flash from such a machine without uninstalling `gpiod`.

### Implementation

- The GPIO controller setup now degrades gracefully: if instantiating the real controller fails (chip or lines unavailable), espresso prints a short notice and falls back to the no-op `GpioController`, flashing via esptool's DTR/RTS reset — exactly the path used when `gpiod` is absent.
- `GpioControllerV1` now raises when `find_line` returns `None`, so a missing line triggers the same fallback as `GpioControllerV2` (which already raises).

On a real Jetson, where the lines resolve, nothing changes — the real controller is used as before.

### Progress

- [x] The implementation is complete.
- [x] Tested on hardware (flashed an ESP32 over USB; with a stubbed `gpiod` for both the v1 and v2 APIs: missing lines → fallback + successful flash; resolvable lines → real controller path unchanged; `gpiod` absent → unchanged).
- [x] Documentation has been updated (or is not necessary).
