### PR TITLE
Fix configure.py timeout on the un-checksummed "Ready." banner

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -36,7 +36,8 @@ def read(*, timeout: float) -> Iterator[str]:
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
-            yield port.read_until(b'\r\n').decode().rsplit('@', 1)[0]
+            # strip() so the match also catches the un-checksummed boot banner "Ready.\r\n"
+            yield port.read_until(b'\r\n').decode().rsplit('@', 1)[0].strip()
         except UnicodeDecodeError:
             continue
 


### PR DESCRIPTION
## Problem

`configure.py` often times out with `Timeout waiting for device to restart!` even though the startup script was written correctly (the board is configured fine after `!.`). It happens reliably for plain configs and only *usually* works for configs containing an `Expander`.

## Cause

`read()` removes a trailing `@checksum` with `rsplit('@', 1)[0]`, which also drops the line's `\r\n` — but only when a checksum is actually present:

```python
yield port.read_until(b'\r\n').decode().rsplit('@', 1)[0]
```

The autonomous boot/restart banner is printed **without** a checksum (`"Ready.\r\n"`). With no `@`, `rsplit` leaves the line as `"Ready.\r\n"`, so `line.endswith('Ready.')` never matches and the restart wait runs out.

Configs with an `Expander` often slip through because the Expander boots its own Lizard and its relayed, checksummed `Ready.@xx\r\n` *does* match — plus each `Expander` adds `+3 s` of timeout budget. Plain configs only have the un-checksummed banner, so they time out consistently.

## Fix

Strip whitespace from each read line so the match works whether or not a checksum is present:

```python
yield port.read_until(b'\r\n').decode().rsplit('@', 1)[0].strip()
```

`.strip()` is harmless for the checksum-verification path too (it uses `line.split()`).

## Testing

Verified against an ESP32-S3 running Lizard: a plain 7-line startup script that previously timed out now reports `ESP booted and sent "Ready."` followed by `Checksum matches.`