### PR TITLE
Add a shared Wheels base class with a drivable gate

### DIFF
--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -524,12 +524,13 @@ The ODrive wheels module combines two ODrive motors and provides odometry and st
 | ----------------------------------------------- | ------------------------ | ------------------------ |
 | `wheels = ODriveWheels(left_motor, left_motor)` | Two ODrive motor modules | two ODrive motor modules |
 
-| Properties             | Description                    | Data type |
-| ---------------------- | ------------------------------ | --------- |
-| `wheels.width`         | Wheel distance (m)             | `float`   |
-| `wheels.linear_speed`  | Forward speed (m/s)            | `float`   |
-| `wheels.angular_speed` | Turning speed (rad/s)          | `float`   |
-| `wheels.enabled`       | Whether the wheels are enabled | `bool`    |
+| Properties             | Description                                                                                                | Data type |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------- | --------- |
+| `wheels.width`         | Wheel distance (m)                                                                                         | `float`   |
+| `wheels.linear_speed`  | Forward speed (m/s)                                                                                        | `float`   |
+| `wheels.angular_speed` | Turning speed (rad/s)                                                                                      | `float`   |
+| `wheels.enabled`       | Whether the wheels are enabled                                                                             | `bool`    |
+| `wheels.drivable`      | Whether driving is currently allowed; set to `false` to ignore drive commands without disabling the motors | `bool`    |
 
 | Methods                         | Description                                     | Arguments        |
 | ------------------------------- | ----------------------------------------------- | ---------------- |
@@ -663,13 +664,14 @@ The RoboClaw wheels module combines two RoboClaw motors and provides odometry an
 | ------------------------------------------------- | --------------------- | -------------------------- |
 | `wheels = RoboClawWheels(left_motor, left_motor)` | left and right motors | two RoboClaw motor modules |
 
-| Properties             | Description                      | Data type |
-| ---------------------- | -------------------------------- | --------- |
-| `wheels.width`         | Wheel distance (m)               | `float`   |
-| `wheels.linear_speed`  | Forward speed (m/s)              | `float`   |
-| `wheels.angular_speed` | Turning speed (rad/s)            | `float`   |
-| `wheels.m_per_tick`    | Meters per encoder tick          | `float`   |
-| `wheels.enabled`       | Whether motors react to commands | `bool`    |
+| Properties             | Description                                                                                                | Data type |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------- | --------- |
+| `wheels.width`         | Wheel distance (m)                                                                                         | `float`   |
+| `wheels.linear_speed`  | Forward speed (m/s)                                                                                        | `float`   |
+| `wheels.angular_speed` | Turning speed (rad/s)                                                                                      | `float`   |
+| `wheels.m_per_tick`    | Meters per encoder tick                                                                                    | `float`   |
+| `wheels.enabled`       | Whether motors react to commands                                                                           | `bool`    |
+| `wheels.drivable`      | Whether driving is currently allowed; set to `false` to ignore drive commands without disabling the motors | `bool`    |
 
 | Methods                         | Description                                     | Arguments        |
 | ------------------------------- | ----------------------------------------------- | ---------------- |
@@ -992,12 +994,13 @@ The DunkerWheels module combines two DunkerMotor modules and provides odometry a
 | ------------------------------------------------ | --------------------- | ----------------------- |
 | `wheels = DunkerWheels(left_motor, right_motor)` | left and right motors | two DunkerMotor modules |
 
-| Properties             | Description                    | Data type |
-| ---------------------- | ------------------------------ | --------- |
-| `wheels.width`         | Wheel distance (m)             | `float`   |
-| `wheels.linear_speed`  | Forward speed (m/s)            | `float`   |
-| `wheels.angular_speed` | Turning speed (rad/s)          | `float`   |
-| `wheels.enabled`       | Whether the wheels are enabled | `bool`    |
+| Properties             | Description                                                                                                | Data type |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------- | --------- |
+| `wheels.width`         | Wheel distance (m)                                                                                         | `float`   |
+| `wheels.linear_speed`  | Forward speed (m/s)                                                                                        | `float`   |
+| `wheels.angular_speed` | Turning speed (rad/s)                                                                                      | `float`   |
+| `wheels.enabled`       | Whether the wheels are enabled                                                                             | `bool`    |
+| `wheels.drivable`      | Whether driving is currently allowed; set to `false` to ignore drive commands without disabling the motors | `bool`    |
 
 | Methods                         | Description                                     | Arguments        |
 | ------------------------------- | ----------------------------------------------- | ---------------- |

--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -524,13 +524,13 @@ The ODrive wheels module combines two ODrive motors and provides odometry and st
 | ----------------------------------------------- | ------------------------ | ------------------------ |
 | `wheels = ODriveWheels(left_motor, left_motor)` | Two ODrive motor modules | two ODrive motor modules |
 
-| Properties             | Description                                                                                                | Data type |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------- | --------- |
-| `wheels.width`         | Wheel distance (m)                                                                                         | `float`   |
-| `wheels.linear_speed`  | Forward speed (m/s)                                                                                        | `float`   |
-| `wheels.angular_speed` | Turning speed (rad/s)                                                                                      | `float`   |
-| `wheels.enabled`       | Whether the wheels are enabled                                                                             | `bool`    |
-| `wheels.drivable`      | Whether driving is currently allowed; set to `false` to ignore drive commands without disabling the motors | `bool`    |
+| Properties             | Description                                                                                                              | Data type |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------- |
+| `wheels.width`         | Wheel distance (m)                                                                                                       | `float`   |
+| `wheels.linear_speed`  | Forward speed (m/s)                                                                                                      | `float`   |
+| `wheels.angular_speed` | Turning speed (rad/s)                                                                                                    | `float`   |
+| `wheels.enabled`       | Whether the wheels are enabled                                                                                           | `bool`    |
+| `wheels.drivable`      | Whether driving is currently allowed; set to `false` to brake (drive commands force a stop) without disabling the motors | `bool`    |
 
 | Methods                         | Description                                     | Arguments        |
 | ------------------------------- | ----------------------------------------------- | ---------------- |
@@ -664,14 +664,14 @@ The RoboClaw wheels module combines two RoboClaw motors and provides odometry an
 | ------------------------------------------------- | --------------------- | -------------------------- |
 | `wheels = RoboClawWheels(left_motor, left_motor)` | left and right motors | two RoboClaw motor modules |
 
-| Properties             | Description                                                                                                | Data type |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------- | --------- |
-| `wheels.width`         | Wheel distance (m)                                                                                         | `float`   |
-| `wheels.linear_speed`  | Forward speed (m/s)                                                                                        | `float`   |
-| `wheels.angular_speed` | Turning speed (rad/s)                                                                                      | `float`   |
-| `wheels.m_per_tick`    | Meters per encoder tick                                                                                    | `float`   |
-| `wheels.enabled`       | Whether motors react to commands                                                                           | `bool`    |
-| `wheels.drivable`      | Whether driving is currently allowed; set to `false` to ignore drive commands without disabling the motors | `bool`    |
+| Properties             | Description                                                                                                              | Data type |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------- |
+| `wheels.width`         | Wheel distance (m)                                                                                                       | `float`   |
+| `wheels.linear_speed`  | Forward speed (m/s)                                                                                                      | `float`   |
+| `wheels.angular_speed` | Turning speed (rad/s)                                                                                                    | `float`   |
+| `wheels.m_per_tick`    | Meters per encoder tick                                                                                                  | `float`   |
+| `wheels.enabled`       | Whether motors react to commands                                                                                         | `bool`    |
+| `wheels.drivable`      | Whether driving is currently allowed; set to `false` to brake (drive commands force a stop) without disabling the motors | `bool`    |
 
 | Methods                         | Description                                     | Arguments        |
 | ------------------------------- | ----------------------------------------------- | ---------------- |
@@ -994,13 +994,13 @@ The DunkerWheels module combines two DunkerMotor modules and provides odometry a
 | ------------------------------------------------ | --------------------- | ----------------------- |
 | `wheels = DunkerWheels(left_motor, right_motor)` | left and right motors | two DunkerMotor modules |
 
-| Properties             | Description                                                                                                | Data type |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------- | --------- |
-| `wheels.width`         | Wheel distance (m)                                                                                         | `float`   |
-| `wheels.linear_speed`  | Forward speed (m/s)                                                                                        | `float`   |
-| `wheels.angular_speed` | Turning speed (rad/s)                                                                                      | `float`   |
-| `wheels.enabled`       | Whether the wheels are enabled                                                                             | `bool`    |
-| `wheels.drivable`      | Whether driving is currently allowed; set to `false` to ignore drive commands without disabling the motors | `bool`    |
+| Properties             | Description                                                                                                              | Data type |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------- |
+| `wheels.width`         | Wheel distance (m)                                                                                                       | `float`   |
+| `wheels.linear_speed`  | Forward speed (m/s)                                                                                                      | `float`   |
+| `wheels.angular_speed` | Turning speed (rad/s)                                                                                                    | `float`   |
+| `wheels.enabled`       | Whether the wheels are enabled                                                                                           | `bool`    |
+| `wheels.drivable`      | Whether driving is currently allowed; set to `false` to brake (drive commands force a stop) without disabling the motors | `bool`    |
 
 | Methods                         | Description                                     | Arguments        |
 | ------------------------------- | ----------------------------------------------- | ---------------- |

--- a/main/modules/dunker_wheels.cpp
+++ b/main/modules/dunker_wheels.cpp
@@ -12,68 +12,32 @@ static Module_ptr create_dunker_wheels(const std::string &name, const std::vecto
 REGISTER_MODULE(DunkerWheels, &create_dunker_wheels)
 
 const std::map<std::string, Variable_ptr> DunkerWheels::get_defaults() {
-    return {
-        {"width", std::make_shared<NumberVariable>(1.0)},
-        {"linear_speed", std::make_shared<NumberVariable>()},
-        {"angular_speed", std::make_shared<NumberVariable>()},
-        {"enabled", std::make_shared<BooleanVariable>(true)},
-    };
+    return Wheels::get_wheels_defaults();
 }
 
 DunkerWheels::DunkerWheels(const std::string name, const DunkerMotor_ptr left_motor, const DunkerMotor_ptr right_motor)
-    : Module(name), left_motor(left_motor), right_motor(right_motor) {
+    : Wheels(name), left_motor(left_motor), right_motor(right_motor) {
     this->properties = DunkerWheels::get_defaults();
 }
 
-void DunkerWheels::step() {
+void DunkerWheels::update_odometry() {
     const double left_speed = this->left_motor->get_speed();
     const double right_speed = this->right_motor->get_speed();
-
     this->properties.at("linear_speed")->number_value = (left_speed + right_speed) / 2;
     this->properties.at("angular_speed")->number_value = (right_speed - left_speed) / this->properties.at("width")->number_value;
-
-    if (this->properties.at("enabled")->boolean_value != this->enabled) {
-        if (this->properties.at("enabled")->boolean_value) {
-            this->enable();
-        } else {
-            this->disable();
-        }
-    }
-
-    Module::step();
 }
 
-void DunkerWheels::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
-    if (method_name == "speed") {
-        Module::expect(arguments, 2, numbery, numbery);
-        if (!this->enabled)
-            return;
-        double linear = arguments[0]->evaluate_number();
-        double angular = arguments[1]->evaluate_number();
-        double width = this->properties.at("width")->number_value;
-        this->left_motor->speed(linear - angular * width / 2.0);
-        this->right_motor->speed(linear + angular * width / 2.0);
-    } else if (method_name == "enable") {
-        Module::expect(arguments, 0);
-        this->enable();
-    } else if (method_name == "disable") {
-        Module::expect(arguments, 0);
-        this->disable();
-    } else {
-        Module::call(method_name, arguments);
-    }
+void DunkerWheels::do_wheel_speeds(double left, double right) {
+    this->left_motor->speed(left);
+    this->right_motor->speed(right);
 }
 
-void DunkerWheels::enable() {
-    this->enabled = true;
-    this->properties.at("enabled")->boolean_value = true;
+void DunkerWheels::do_enable() {
     this->left_motor->enable();
     this->right_motor->enable();
 }
 
-void DunkerWheels::disable() {
+void DunkerWheels::do_disable() {
     this->left_motor->disable();
     this->right_motor->disable();
-    this->enabled = false;
-    this->properties.at("enabled")->boolean_value = false;
 }

--- a/main/modules/dunker_wheels.h
+++ b/main/modules/dunker_wheels.h
@@ -1,21 +1,22 @@
 #pragma once
 
 #include "dunker_motor.h"
-#include "module.h"
+#include "wheels.h"
 
-class DunkerWheels : public Module {
+class DunkerWheels : public Wheels {
 private:
     const DunkerMotor_ptr left_motor;
     const DunkerMotor_ptr right_motor;
-    bool enabled = true;
+
+protected:
+    void do_wheel_speeds(double left, double right) override;
+    void do_enable() override;
+    void do_disable() override;
+    void update_odometry() override;
 
 public:
     static inline constexpr const char *TYPE = "DunkerWheels";
 
     DunkerWheels(const std::string name, const DunkerMotor_ptr left_motor, const DunkerMotor_ptr right_motor);
-    void step() override;
-    void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
-    void enable();
-    void disable();
 };

--- a/main/modules/module.h
+++ b/main/modules/module.h
@@ -28,10 +28,8 @@ using DefaultsFunction = std::function<std::map<std::string, Variable_ptr>()>;
     } // namespace
 
 class Module {
-private:
-    std::list<Module_ptr> shadow_modules;
-
 protected:
+    std::list<Module_ptr> shadow_modules;
     std::map<std::string, Variable_ptr> properties;
     bool output_on = false;
     bool broadcast = false;

--- a/main/modules/odrive_wheels.cpp
+++ b/main/modules/odrive_wheels.cpp
@@ -57,10 +57,16 @@ void ODriveWheels::do_disable() {
 void ODriveWheels::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
     if (method_name == "power") {
         Module::expect(arguments, 2, numbery, numbery);
-        if (this->can_drive()) {
-            this->left_motor->power(arguments[0]->evaluate_number());
-            this->right_motor->power(arguments[1]->evaluate_number());
+        if (!this->enabled) {
+            return;
         }
+        if (!this->is_drivable()) {
+            this->left_motor->power(0);
+            this->right_motor->power(0);
+            return;
+        }
+        this->left_motor->power(arguments[0]->evaluate_number());
+        this->right_motor->power(arguments[1]->evaluate_number());
     } else if (method_name == "off") {
         Module::expect(arguments, 0);
         this->left_motor->off();

--- a/main/modules/odrive_wheels.cpp
+++ b/main/modules/odrive_wheels.cpp
@@ -13,20 +13,15 @@ static Module_ptr create_odrive_wheels(const std::string &name, const std::vecto
 REGISTER_MODULE(ODriveWheels, &create_odrive_wheels)
 
 const std::map<std::string, Variable_ptr> ODriveWheels::get_defaults() {
-    return {
-        {"width", std::make_shared<NumberVariable>(1.0)},
-        {"linear_speed", std::make_shared<NumberVariable>()},
-        {"angular_speed", std::make_shared<NumberVariable>()},
-        {"enabled", std::make_shared<BooleanVariable>(true)},
-    };
+    return Wheels::get_wheels_defaults();
 }
 
 ODriveWheels::ODriveWheels(const std::string name, const ODriveMotor_ptr left_motor, const ODriveMotor_ptr right_motor)
-    : Module(name), left_motor(left_motor), right_motor(right_motor) {
+    : Wheels(name), left_motor(left_motor), right_motor(right_motor) {
     this->properties = ODriveWheels::get_defaults();
 }
 
-void ODriveWheels::step() {
+void ODriveWheels::update_odometry() {
     double left_position = this->left_motor->get_position();
     double right_position = this->right_motor->get_position();
 
@@ -42,59 +37,35 @@ void ODriveWheels::step() {
     this->last_left_position = left_position;
     this->last_right_position = right_position;
     this->initialized = true;
+}
 
-    if (this->properties.at("enabled")->boolean_value != this->enabled) {
-        if (this->properties.at("enabled")->boolean_value) {
-            this->enable();
-        } else {
-            this->disable();
-        }
-    }
+void ODriveWheels::do_wheel_speeds(double left, double right) {
+    this->left_motor->speed(left);
+    this->right_motor->speed(right);
+}
 
-    Module::step();
+void ODriveWheels::do_enable() {
+    this->left_motor->enable();
+    this->right_motor->enable();
+}
+
+void ODriveWheels::do_disable() {
+    this->left_motor->disable();
+    this->right_motor->disable();
 }
 
 void ODriveWheels::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
     if (method_name == "power") {
         Module::expect(arguments, 2, numbery, numbery);
-        if (this->properties.at("enabled")->boolean_value) {
+        if (this->can_drive()) {
             this->left_motor->power(arguments[0]->evaluate_number());
             this->right_motor->power(arguments[1]->evaluate_number());
-        }
-    } else if (method_name == "speed") {
-        Module::expect(arguments, 2, numbery, numbery);
-        if (this->properties.at("enabled")->boolean_value) {
-            double linear = arguments[0]->evaluate_number();
-            double angular = arguments[1]->evaluate_number();
-            double width = this->properties.at("width")->number_value;
-            this->left_motor->speed(linear - angular * width / 2.0);
-            this->right_motor->speed(linear + angular * width / 2.0);
         }
     } else if (method_name == "off") {
         Module::expect(arguments, 0);
         this->left_motor->off();
         this->right_motor->off();
-    } else if (method_name == "enable") {
-        Module::expect(arguments, 0);
-        this->enable();
-    } else if (method_name == "disable") {
-        Module::expect(arguments, 0);
-        this->disable();
     } else {
-        Module::call(method_name, arguments);
+        Wheels::call(method_name, arguments);
     }
-}
-
-void ODriveWheels::enable() {
-    this->enabled = true;
-    this->properties.at("enabled")->boolean_value = true;
-    this->left_motor->enable();
-    this->right_motor->enable();
-}
-
-void ODriveWheels::disable() {
-    this->left_motor->disable();
-    this->right_motor->disable();
-    this->enabled = false;
-    this->properties.at("enabled")->boolean_value = false;
 }

--- a/main/modules/odrive_wheels.h
+++ b/main/modules/odrive_wheels.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "module.h"
 #include "odrive_motor.h"
+#include "wheels.h"
 
-class ODriveWheels : public Module {
+class ODriveWheels : public Wheels {
 private:
     const ODriveMotor_ptr left_motor;
     const ODriveMotor_ptr right_motor;
@@ -12,15 +12,17 @@ private:
     unsigned long int last_micros;
     double last_left_position;
     double last_right_position;
-    bool enabled = true;
+
+protected:
+    void do_wheel_speeds(double left, double right) override;
+    void do_enable() override;
+    void do_disable() override;
+    void update_odometry() override;
 
 public:
     static inline constexpr const char *TYPE = "ODriveWheels";
 
     ODriveWheels(const std::string name, const ODriveMotor_ptr left_motor, const ODriveMotor_ptr right_motor);
-    void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
-    void enable();
-    void disable();
 };

--- a/main/modules/roboclaw_wheels.cpp
+++ b/main/modules/roboclaw_wheels.cpp
@@ -74,10 +74,16 @@ void RoboClawWheels::do_disable() {
 void RoboClawWheels::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
     if (method_name == "power") {
         Module::expect(arguments, 2, numbery, numbery);
-        if (this->can_drive()) {
-            this->left_motor->power(arguments[0]->evaluate_number());
-            this->right_motor->power(arguments[1]->evaluate_number());
+        if (!this->enabled) {
+            return;
         }
+        if (!this->is_drivable()) {
+            this->left_motor->power(0);
+            this->right_motor->power(0);
+            return;
+        }
+        this->left_motor->power(arguments[0]->evaluate_number());
+        this->right_motor->power(arguments[1]->evaluate_number());
     } else if (method_name == "off") {
         Module::expect(arguments, 0);
         this->left_motor->power(0);

--- a/main/modules/roboclaw_wheels.cpp
+++ b/main/modules/roboclaw_wheels.cpp
@@ -13,17 +13,13 @@ static Module_ptr create_roboclaw_wheels(const std::string &name, const std::vec
 REGISTER_MODULE(RoboClawWheels, &create_roboclaw_wheels)
 
 const std::map<std::string, Variable_ptr> RoboClawWheels::get_defaults() {
-    return {
-        {"width", std::make_shared<NumberVariable>(1)},
-        {"linear_speed", std::make_shared<NumberVariable>()},
-        {"angular_speed", std::make_shared<NumberVariable>()},
-        {"enabled", std::make_shared<BooleanVariable>(true)},
-        {"m_per_tick", std::make_shared<NumberVariable>(1)},
-    };
+    auto defaults = Wheels::get_wheels_defaults();
+    defaults["m_per_tick"] = std::make_shared<NumberVariable>(1);
+    return defaults;
 }
 
 RoboClawWheels::RoboClawWheels(const std::string name, const RoboClawMotor_ptr left_motor, const RoboClawMotor_ptr right_motor)
-    : Module(name), left_motor(left_motor), right_motor(right_motor) {
+    : Wheels(name), left_motor(left_motor), right_motor(right_motor) {
     this->properties = RoboClawWheels::get_defaults();
 }
 
@@ -37,15 +33,15 @@ static double difference_wrapped_u32(double current_value, double last_value) {
     return diff;
 }
 
-void RoboClawWheels::step() {
+void RoboClawWheels::update_odometry() {
     double left_position = this->left_motor->get_position();
     double right_position = this->right_motor->get_position();
 
-    if (initialized) {
-        double d_left_position = difference_wrapped_u32(left_position, last_left_position);
-        double d_right_position = difference_wrapped_u32(right_position, last_right_position);
+    if (this->initialized) {
+        double d_left_position = difference_wrapped_u32(left_position, this->last_left_position);
+        double d_right_position = difference_wrapped_u32(right_position, this->last_right_position);
 
-        unsigned long int d_micros = micros_since(last_micros);
+        unsigned long int d_micros = micros_since(this->last_micros);
         const double m_per_tick = this->properties.at("m_per_tick")->number_value;
         double left_speed = (d_left_position * m_per_tick) / d_micros * 1000000;
         double right_speed = (d_right_position * m_per_tick) / d_micros * 1000000;
@@ -53,64 +49,40 @@ void RoboClawWheels::step() {
         this->properties.at("angular_speed")->number_value = (right_speed - left_speed) / this->properties.at("width")->number_value;
     }
 
-    last_micros = micros();
-    last_left_position = left_position;
-    last_right_position = right_position;
-    initialized = true;
+    this->last_micros = micros();
+    this->last_left_position = left_position;
+    this->last_right_position = right_position;
+    this->initialized = true;
+}
 
-    if (this->properties.at("enabled")->boolean_value != this->enabled) {
-        if (this->properties.at("enabled")->boolean_value) {
-            this->enable();
-        } else {
-            this->disable();
-        }
-    }
+void RoboClawWheels::do_wheel_speeds(double left, double right) {
+    const double m_per_tick = this->properties.at("m_per_tick")->number_value;
+    this->left_motor->speed(left / m_per_tick);
+    this->right_motor->speed(right / m_per_tick);
+}
 
-    Module::step();
+void RoboClawWheels::do_enable() {
+    this->left_motor->enable();
+    this->right_motor->enable();
+}
+
+void RoboClawWheels::do_disable() {
+    this->left_motor->disable();
+    this->right_motor->disable();
 }
 
 void RoboClawWheels::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
     if (method_name == "power") {
         Module::expect(arguments, 2, numbery, numbery);
-        if (this->properties.at("enabled")->boolean_value) {
+        if (this->can_drive()) {
             this->left_motor->power(arguments[0]->evaluate_number());
             this->right_motor->power(arguments[1]->evaluate_number());
-        }
-    } else if (method_name == "speed") {
-        Module::expect(arguments, 2, numbery, numbery);
-        if (this->properties.at("enabled")->boolean_value) {
-            double linear = arguments[0]->evaluate_number();
-            double angular = arguments[1]->evaluate_number();
-            const double half_width = this->properties.at("width")->number_value / 2.0;
-            const double m_per_tick = this->properties.at("m_per_tick")->number_value;
-            this->left_motor->speed((linear - angular * half_width) / m_per_tick);
-            this->right_motor->speed((linear + angular * half_width) / m_per_tick);
         }
     } else if (method_name == "off") {
         Module::expect(arguments, 0);
         this->left_motor->power(0);
         this->right_motor->power(0);
-    } else if (method_name == "enable") {
-        Module::expect(arguments, 0);
-        this->enable();
-    } else if (method_name == "disable") {
-        Module::expect(arguments, 0);
-        this->disable();
     } else {
-        Module::call(method_name, arguments);
+        Wheels::call(method_name, arguments);
     }
-}
-
-void RoboClawWheels::enable() {
-    this->enabled = true;
-    this->properties.at("enabled")->boolean_value = true;
-    this->left_motor->enable();
-    this->right_motor->enable();
-}
-
-void RoboClawWheels::disable() {
-    this->left_motor->disable();
-    this->right_motor->disable();
-    this->enabled = false;
-    this->properties.at("enabled")->boolean_value = false;
 }

--- a/main/modules/roboclaw_wheels.h
+++ b/main/modules/roboclaw_wheels.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "roboclaw_motor.h"
+#include "wheels.h"
 
-class RoboClawWheels : public Module {
+class RoboClawWheels : public Wheels {
 private:
     const RoboClawMotor_ptr left_motor;
     const RoboClawMotor_ptr right_motor;
@@ -11,16 +12,17 @@ private:
     int64_t last_left_position;
     int64_t last_right_position;
     bool initialized = false;
-    bool enabled = true;
 
-    void enable();
-    void disable();
+protected:
+    void do_wheel_speeds(double left, double right) override;
+    void do_enable() override;
+    void do_disable() override;
+    void update_odometry() override;
 
 public:
     static inline constexpr const char *TYPE = "RoboClawWheels";
 
     RoboClawWheels(const std::string name, const RoboClawMotor_ptr left_motor, const RoboClawMotor_ptr right_motor);
-    void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/wheels.cpp
+++ b/main/modules/wheels.cpp
@@ -1,0 +1,77 @@
+#include "wheels.h"
+
+std::map<std::string, Variable_ptr> Wheels::get_wheels_defaults() {
+    return {
+        {"width", std::make_shared<NumberVariable>(1.0)},
+        {"linear_speed", std::make_shared<NumberVariable>()},
+        {"angular_speed", std::make_shared<NumberVariable>()},
+        {"enabled", std::make_shared<BooleanVariable>(true)},
+        {"drivable", std::make_shared<BooleanVariable>(true)},
+    };
+}
+
+Wheels::Wheels(const std::string name)
+    : Module(name) {
+}
+
+bool Wheels::can_drive() const {
+    return this->enabled && this->properties.at("drivable")->boolean_value;
+}
+
+void Wheels::step() {
+    this->update_odometry();
+
+    if (this->properties.at("enabled")->boolean_value != this->enabled) {
+        if (this->properties.at("enabled")->boolean_value) {
+            this->enable();
+        } else {
+            this->disable();
+        }
+    }
+
+    Module::step();
+}
+
+void Wheels::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
+    if (method_name == "speed") {
+        Module::expect(arguments, 2, numbery, numbery);
+        if (!this->can_drive()) {
+            return;
+        }
+        const double linear = arguments[0]->evaluate_number();
+        const double angular = arguments[1]->evaluate_number();
+        const double width = this->properties.at("width")->number_value;
+        this->do_wheel_speeds(linear - angular * width / 2.0, linear + angular * width / 2.0);
+    } else if (method_name == "enable") {
+        Module::expect(arguments, 0);
+        this->enable();
+    } else if (method_name == "disable") {
+        Module::expect(arguments, 0);
+        this->disable();
+    } else {
+        Module::call(method_name, arguments);
+    }
+}
+
+void Wheels::write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander) {
+    Module::write_property(property_name, expression, from_expander);
+    // Shadowed wheels (e.g. front tracks) mirror method calls, but not property writes. Forward the
+    // drivable gate so shadows stop driving together with their master.
+    if (property_name == "drivable") {
+        for (auto const &module : this->shadow_modules) {
+            module->write_property(property_name, expression, from_expander);
+        }
+    }
+}
+
+void Wheels::enable() {
+    this->enabled = true;
+    this->properties.at("enabled")->boolean_value = true;
+    this->do_enable();
+}
+
+void Wheels::disable() {
+    this->do_disable();
+    this->enabled = false;
+    this->properties.at("enabled")->boolean_value = false;
+}

--- a/main/modules/wheels.cpp
+++ b/main/modules/wheels.cpp
@@ -18,6 +18,19 @@ bool Wheels::is_drivable() const {
     return this->properties.at("drivable")->boolean_value;
 }
 
+bool Wheels::gate_or_brake() {
+    if (!this->enabled) {
+        return false;
+    }
+    if (!this->is_drivable()) {
+        // Not drivable: brake instead of ignoring, so the continuous speed-command stream
+        // stops the robot rather than holding the last commanded speed.
+        this->do_wheel_speeds(0.0, 0.0);
+        return false;
+    }
+    return true;
+}
+
 void Wheels::step() {
     this->update_odometry();
 
@@ -35,13 +48,7 @@ void Wheels::step() {
 void Wheels::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
     if (method_name == "speed") {
         Module::expect(arguments, 2, numbery, numbery);
-        if (!this->enabled) {
-            return;
-        }
-        if (!this->is_drivable()) {
-            // Not drivable: brake instead of ignoring, so the continuous speed-command stream
-            // stops the robot rather than holding the last commanded speed.
-            this->do_wheel_speeds(0.0, 0.0);
+        if (!this->gate_or_brake()) {
             return;
         }
         const double linear = arguments[0]->evaluate_number();

--- a/main/modules/wheels.cpp
+++ b/main/modules/wheels.cpp
@@ -14,8 +14,8 @@ Wheels::Wheels(const std::string name)
     : Module(name) {
 }
 
-bool Wheels::can_drive() const {
-    return this->enabled && this->properties.at("drivable")->boolean_value;
+bool Wheels::is_drivable() const {
+    return this->properties.at("drivable")->boolean_value;
 }
 
 void Wheels::step() {
@@ -35,7 +35,13 @@ void Wheels::step() {
 void Wheels::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
     if (method_name == "speed") {
         Module::expect(arguments, 2, numbery, numbery);
-        if (!this->can_drive()) {
+        if (!this->enabled) {
+            return;
+        }
+        if (!this->is_drivable()) {
+            // Not drivable: brake instead of ignoring, so the continuous speed-command stream
+            // stops the robot rather than holding the last commanded speed.
+            this->do_wheel_speeds(0.0, 0.0);
             return;
         }
         const double linear = arguments[0]->evaluate_number();

--- a/main/modules/wheels.h
+++ b/main/modules/wheels.h
@@ -23,6 +23,10 @@ protected:
     /// Value of the `drivable` gate property.
     bool is_drivable() const;
 
+    /// Speed gate shared by all drive commands: returns true if driving is allowed.
+    /// If disabled it returns false silently; if not drivable it brakes and returns false.
+    bool gate_or_brake();
+
     /// Apply per-wheel target speeds (already split from linear/angular via `width`).
     virtual void do_wheel_speeds(double left, double right) = 0;
     virtual void do_enable() = 0;

--- a/main/modules/wheels.h
+++ b/main/modules/wheels.h
@@ -20,8 +20,8 @@ protected:
     /// Common property defaults; concrete modules extend this in their own `get_defaults()`.
     static std::map<std::string, Variable_ptr> get_wheels_defaults();
 
-    /// True while drive commands are allowed (both `enabled` and the `drivable` property set).
-    bool can_drive() const;
+    /// Value of the `drivable` gate property.
+    bool is_drivable() const;
 
     /// Apply per-wheel target speeds (already split from linear/angular via `width`).
     virtual void do_wheel_speeds(double left, double right) = 0;

--- a/main/modules/wheels.h
+++ b/main/modules/wheels.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "module.h"
+
+class Wheels;
+using Wheels_ptr = std::shared_ptr<Wheels>;
+
+/**
+ * Shared base for differential-drive wheels modules.
+ *
+ * Owns the common properties (`width`, `linear_speed`, `angular_speed`, `enabled`, `drivable`),
+ * the enabled-sync in `step()` and the `speed`/`enable`/`disable` command flow. Concrete
+ * drivetrains provide the motor-specific parts through the protected hooks. `drivable` is a gate
+ * that external rules can toggle to (dis)allow driving without disabling the motors.
+ */
+class Wheels : public Module {
+protected:
+    bool enabled = true;
+
+    /// Common property defaults; concrete modules extend this in their own `get_defaults()`.
+    static std::map<std::string, Variable_ptr> get_wheels_defaults();
+
+    /// True while drive commands are allowed (both `enabled` and the `drivable` property set).
+    bool can_drive() const;
+
+    /// Apply per-wheel target speeds (already split from linear/angular via `width`).
+    virtual void do_wheel_speeds(double left, double right) = 0;
+    virtual void do_enable() = 0;
+    virtual void do_disable() = 0;
+    /// Update `linear_speed`/`angular_speed` from the motors; called every `step()`.
+    virtual void update_odometry() = 0;
+
+public:
+    Wheels(const std::string name);
+    void step() override;
+    void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void write_property(const std::string property_name, const ConstExpression_ptr expression, const bool from_expander = false) override;
+    void enable();
+    void disable();
+};


### PR DESCRIPTION
### Motivation

The three wheels modules (`DunkerWheels`, `ODriveWheels`, `RoboClawWheels`) each inherited directly from `Module` and duplicated the same scaffolding: the `width`/`linear_speed`/`angular_speed`/`enabled` properties, the enabled-sync in `step()` and `enable()`/`disable()`. There was no common place to add cross-cutting behaviour — in particular a way to gate driving without disabling the motors.

### Implementation

- **Shared base.** A new abstract `Wheels : public Module` (`wheels.h`/`wheels.cpp`) owns the common properties, the `step()` enabled-sync and the `speed`/`enable`/`disable` command flow. The concrete drivetrains only implement the motor-specific hooks: `do_wheel_speeds`, `do_enable`, `do_disable`, `update_odometry`. Behaviour is unchanged for all three (net **−85 lines** in the refactor commit).
- **New `drivable` property.** A gate that external rules can toggle to (dis)allow driving without disabling the motors. While enabled but not drivable, `speed()`/`power()` **brake the motors to 0** rather than being ignored — the drive loop streams commands continuously, so merely ignoring them would hold the last commanded speed and keep the robot moving. The motors stay enabled and resume as soon as `drivable` is `true` again.
- **Shadow-aware gate.** Shadows mirror method calls but not property writes, so `Wheels::write_property` forwards the `drivable` write to its shadow modules. This keeps shadowed setups (e.g. front/back tracks where `wheels.shadow(wheels_front)`) gated together instead of leaving the shadow driving. (`Module::shadow_modules` is now `protected` for this.)

### Usage

Our new delta-arm drivetrain already relies on this: a brain-side rule sets `wheels.drivable = false` while the arm is not parked (both endstops inactive), so the robot can only drive once the arm is raised — and thanks to the shadow forwarding both track modules are gated at once.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] It builds (`python build.py esp32 --clean`).
- [x] Tests with real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (the `drivable` property is listed for each wheels module).