### PR TITLE
Extract a shared Wheels base class from the three wheels modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,7 +330,7 @@ The main loop runs every **10ms** (`delay(10)` in `app_main`). Any operation tha
 
 Modules self-register via `REGISTER_MODULE(ClassName, &create_X)` in their own `.cpp`. The macro keys off the class's `static constexpr const char *TYPE` constant — both the factory and the static `ClassName::get_defaults()` method are registered under that string. Forgetting either the macro or the `TYPE` constant causes the DSL to report `unknown module type "ClassName"`. Two modules trying to register under the same `TYPE` throw a hard error at static-init time, so collisions are caught at first boot rather than silently shadowing.
 
-The class must define `static const std::map<std::string, Variable_ptr> get_defaults()` (return an empty map if there are no defaults) and pass only the instance name to the `Module(name)` base constructor — the runtime type identity comes from RTTI on the polymorphic `Module`.
+The class must define `static const std::map<std::string, Variable_ptr> get_defaults()` (return an empty map if there are no defaults) and pass only the instance name to the `Module(name)` base constructor — the runtime type identity comes from RTTI on the polymorphic `Module`. Inheriting `get_defaults()` from an intermediate base class (e.g. `Wheels`) is fine; a subclass that adds properties must shadow `get_defaults()` and pass its result to the base constructor, so that the registered defaults always equal the constructed properties — expander proxies seed their properties exclusively from the registered `get_defaults()`, so a property that exists only in a constructor breaks proxied instances at runtime.
 
 #### `WHOLE_ARCHIVE` is mandatory
 

--- a/main/modules/dunker_wheels.cpp
+++ b/main/modules/dunker_wheels.cpp
@@ -12,68 +12,32 @@ static Module_ptr create_dunker_wheels(const std::string &name, const std::vecto
 REGISTER_MODULE(DunkerWheels, &create_dunker_wheels)
 
 const std::map<std::string, Variable_ptr> DunkerWheels::get_defaults() {
-    return {
-        {"width", std::make_shared<NumberVariable>(1.0)},
-        {"linear_speed", std::make_shared<NumberVariable>()},
-        {"angular_speed", std::make_shared<NumberVariable>()},
-        {"enabled", std::make_shared<BooleanVariable>(true)},
-    };
+    return Wheels::get_wheels_defaults();
 }
 
 DunkerWheels::DunkerWheels(const std::string name, const DunkerMotor_ptr left_motor, const DunkerMotor_ptr right_motor)
-    : Module(name), left_motor(left_motor), right_motor(right_motor) {
+    : Wheels(name), left_motor(left_motor), right_motor(right_motor) {
     this->properties = DunkerWheels::get_defaults();
 }
 
-void DunkerWheels::step() {
+void DunkerWheels::update_odometry() {
     const double left_speed = this->left_motor->get_speed();
     const double right_speed = this->right_motor->get_speed();
-
     this->properties.at("linear_speed")->number_value = (left_speed + right_speed) / 2;
     this->properties.at("angular_speed")->number_value = (right_speed - left_speed) / this->properties.at("width")->number_value;
-
-    if (this->properties.at("enabled")->boolean_value != this->enabled) {
-        if (this->properties.at("enabled")->boolean_value) {
-            this->enable();
-        } else {
-            this->disable();
-        }
-    }
-
-    Module::step();
 }
 
-void DunkerWheels::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
-    if (method_name == "speed") {
-        Module::expect(arguments, 2, numbery, numbery);
-        if (!this->enabled)
-            return;
-        double linear = arguments[0]->evaluate_number();
-        double angular = arguments[1]->evaluate_number();
-        double width = this->properties.at("width")->number_value;
-        this->left_motor->speed(linear - angular * width / 2.0);
-        this->right_motor->speed(linear + angular * width / 2.0);
-    } else if (method_name == "enable") {
-        Module::expect(arguments, 0);
-        this->enable();
-    } else if (method_name == "disable") {
-        Module::expect(arguments, 0);
-        this->disable();
-    } else {
-        Module::call(method_name, arguments);
-    }
+void DunkerWheels::do_wheel_speeds(double left, double right) {
+    this->left_motor->speed(left);
+    this->right_motor->speed(right);
 }
 
-void DunkerWheels::enable() {
-    this->enabled = true;
-    this->properties.at("enabled")->boolean_value = true;
+void DunkerWheels::do_enable() {
     this->left_motor->enable();
     this->right_motor->enable();
 }
 
-void DunkerWheels::disable() {
+void DunkerWheels::do_disable() {
     this->left_motor->disable();
     this->right_motor->disable();
-    this->enabled = false;
-    this->properties.at("enabled")->boolean_value = false;
 }

--- a/main/modules/dunker_wheels.cpp
+++ b/main/modules/dunker_wheels.cpp
@@ -11,13 +11,8 @@ static Module_ptr create_dunker_wheels(const std::string &name, const std::vecto
 }
 REGISTER_MODULE(DunkerWheels, &create_dunker_wheels)
 
-const std::map<std::string, Variable_ptr> DunkerWheels::get_defaults() {
-    return Wheels::get_wheels_defaults();
-}
-
 DunkerWheels::DunkerWheels(const std::string name, const DunkerMotor_ptr left_motor, const DunkerMotor_ptr right_motor)
     : Wheels(name), left_motor(left_motor), right_motor(right_motor) {
-    this->properties = DunkerWheels::get_defaults();
 }
 
 void DunkerWheels::update_odometry() {

--- a/main/modules/dunker_wheels.cpp
+++ b/main/modules/dunker_wheels.cpp
@@ -23,8 +23,7 @@ DunkerWheels::DunkerWheels(const std::string name, const DunkerMotor_ptr left_mo
 void DunkerWheels::update_odometry() {
     const double left_speed = this->left_motor->get_speed();
     const double right_speed = this->right_motor->get_speed();
-    this->properties.at("linear_speed")->number_value = (left_speed + right_speed) / 2;
-    this->properties.at("angular_speed")->number_value = (right_speed - left_speed) / this->properties.at("width")->number_value;
+    this->update_speeds(left_speed, right_speed);
 }
 
 void DunkerWheels::do_wheel_speeds(double left, double right) {

--- a/main/modules/dunker_wheels.h
+++ b/main/modules/dunker_wheels.h
@@ -1,21 +1,22 @@
 #pragma once
 
 #include "dunker_motor.h"
-#include "module.h"
+#include "wheels.h"
 
-class DunkerWheels : public Module {
+class DunkerWheels : public Wheels {
 private:
     const DunkerMotor_ptr left_motor;
     const DunkerMotor_ptr right_motor;
-    bool enabled = true;
+
+protected:
+    void do_wheel_speeds(double left, double right) override;
+    void do_enable() override;
+    void do_disable() override;
+    void update_odometry() override;
 
 public:
     static inline constexpr const char *TYPE = "DunkerWheels";
 
     DunkerWheels(const std::string name, const DunkerMotor_ptr left_motor, const DunkerMotor_ptr right_motor);
-    void step() override;
-    void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
-    void enable();
-    void disable();
 };

--- a/main/modules/dunker_wheels.h
+++ b/main/modules/dunker_wheels.h
@@ -18,5 +18,4 @@ public:
     static inline constexpr const char *TYPE = "DunkerWheels";
 
     DunkerWheels(const std::string name, const DunkerMotor_ptr left_motor, const DunkerMotor_ptr right_motor);
-    static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/odrive_wheels.cpp
+++ b/main/modules/odrive_wheels.cpp
@@ -12,13 +12,8 @@ static Module_ptr create_odrive_wheels(const std::string &name, const std::vecto
 }
 REGISTER_MODULE(ODriveWheels, &create_odrive_wheels)
 
-const std::map<std::string, Variable_ptr> ODriveWheels::get_defaults() {
-    return Wheels::get_wheels_defaults();
-}
-
 ODriveWheels::ODriveWheels(const std::string name, const ODriveMotor_ptr left_motor, const ODriveMotor_ptr right_motor)
     : Wheels(name), left_motor(left_motor), right_motor(right_motor) {
-    this->properties = ODriveWheels::get_defaults();
 }
 
 void ODriveWheels::update_odometry() {

--- a/main/modules/odrive_wheels.cpp
+++ b/main/modules/odrive_wheels.cpp
@@ -13,20 +13,15 @@ static Module_ptr create_odrive_wheels(const std::string &name, const std::vecto
 REGISTER_MODULE(ODriveWheels, &create_odrive_wheels)
 
 const std::map<std::string, Variable_ptr> ODriveWheels::get_defaults() {
-    return {
-        {"width", std::make_shared<NumberVariable>(1.0)},
-        {"linear_speed", std::make_shared<NumberVariable>()},
-        {"angular_speed", std::make_shared<NumberVariable>()},
-        {"enabled", std::make_shared<BooleanVariable>(true)},
-    };
+    return Wheels::get_wheels_defaults();
 }
 
 ODriveWheels::ODriveWheels(const std::string name, const ODriveMotor_ptr left_motor, const ODriveMotor_ptr right_motor)
-    : Module(name), left_motor(left_motor), right_motor(right_motor) {
+    : Wheels(name), left_motor(left_motor), right_motor(right_motor) {
     this->properties = ODriveWheels::get_defaults();
 }
 
-void ODriveWheels::step() {
+void ODriveWheels::update_odometry() {
     double left_position = this->left_motor->get_position();
     double right_position = this->right_motor->get_position();
 
@@ -42,16 +37,21 @@ void ODriveWheels::step() {
     this->last_left_position = left_position;
     this->last_right_position = right_position;
     this->initialized = true;
+}
 
-    if (this->properties.at("enabled")->boolean_value != this->enabled) {
-        if (this->properties.at("enabled")->boolean_value) {
-            this->enable();
-        } else {
-            this->disable();
-        }
-    }
+void ODriveWheels::do_wheel_speeds(double left, double right) {
+    this->left_motor->speed(left);
+    this->right_motor->speed(right);
+}
 
-    Module::step();
+void ODriveWheels::do_enable() {
+    this->left_motor->enable();
+    this->right_motor->enable();
+}
+
+void ODriveWheels::do_disable() {
+    this->left_motor->disable();
+    this->right_motor->disable();
 }
 
 void ODriveWheels::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
@@ -61,40 +61,11 @@ void ODriveWheels::call(const std::string method_name, const std::vector<ConstEx
             this->left_motor->power(arguments[0]->evaluate_number());
             this->right_motor->power(arguments[1]->evaluate_number());
         }
-    } else if (method_name == "speed") {
-        Module::expect(arguments, 2, numbery, numbery);
-        if (this->properties.at("enabled")->boolean_value) {
-            double linear = arguments[0]->evaluate_number();
-            double angular = arguments[1]->evaluate_number();
-            double width = this->properties.at("width")->number_value;
-            this->left_motor->speed(linear - angular * width / 2.0);
-            this->right_motor->speed(linear + angular * width / 2.0);
-        }
     } else if (method_name == "off") {
         Module::expect(arguments, 0);
         this->left_motor->off();
         this->right_motor->off();
-    } else if (method_name == "enable") {
-        Module::expect(arguments, 0);
-        this->enable();
-    } else if (method_name == "disable") {
-        Module::expect(arguments, 0);
-        this->disable();
     } else {
-        Module::call(method_name, arguments);
+        Wheels::call(method_name, arguments);
     }
-}
-
-void ODriveWheels::enable() {
-    this->enabled = true;
-    this->properties.at("enabled")->boolean_value = true;
-    this->left_motor->enable();
-    this->right_motor->enable();
-}
-
-void ODriveWheels::disable() {
-    this->left_motor->disable();
-    this->right_motor->disable();
-    this->enabled = false;
-    this->properties.at("enabled")->boolean_value = false;
 }

--- a/main/modules/odrive_wheels.cpp
+++ b/main/modules/odrive_wheels.cpp
@@ -29,8 +29,7 @@ void ODriveWheels::update_odometry() {
         unsigned long int d_micros = micros_since(this->last_micros);
         double left_speed = (left_position - this->last_left_position) / d_micros * 1000000;
         double right_speed = (right_position - this->last_right_position) / d_micros * 1000000;
-        this->properties.at("linear_speed")->number_value = (left_speed + right_speed) / 2;
-        this->properties.at("angular_speed")->number_value = (right_speed - left_speed) / this->properties.at("width")->number_value;
+        this->update_speeds(left_speed, right_speed);
     }
 
     this->last_micros = micros();

--- a/main/modules/odrive_wheels.h
+++ b/main/modules/odrive_wheels.h
@@ -24,5 +24,4 @@ public:
 
     ODriveWheels(const std::string name, const ODriveMotor_ptr left_motor, const ODriveMotor_ptr right_motor);
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
-    static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/odrive_wheels.h
+++ b/main/modules/odrive_wheels.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "module.h"
 #include "odrive_motor.h"
+#include "wheels.h"
 
-class ODriveWheels : public Module {
+class ODriveWheels : public Wheels {
 private:
     const ODriveMotor_ptr left_motor;
     const ODriveMotor_ptr right_motor;
@@ -12,15 +12,17 @@ private:
     unsigned long int last_micros;
     double last_left_position;
     double last_right_position;
-    bool enabled = true;
+
+protected:
+    void do_wheel_speeds(double left, double right) override;
+    void do_enable() override;
+    void do_disable() override;
+    void update_odometry() override;
 
 public:
     static inline constexpr const char *TYPE = "ODriveWheels";
 
     ODriveWheels(const std::string name, const ODriveMotor_ptr left_motor, const ODriveMotor_ptr right_motor);
-    void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
-    void enable();
-    void disable();
 };

--- a/main/modules/roboclaw_wheels.cpp
+++ b/main/modules/roboclaw_wheels.cpp
@@ -13,7 +13,7 @@ static Module_ptr create_roboclaw_wheels(const std::string &name, const std::vec
 REGISTER_MODULE(RoboClawWheels, &create_roboclaw_wheels)
 
 const std::map<std::string, Variable_ptr> RoboClawWheels::get_defaults() {
-    auto defaults = Wheels::get_wheels_defaults();
+    auto defaults = Wheels::get_defaults();
     defaults["m_per_tick"] = std::make_shared<NumberVariable>(1);
     return defaults;
 }

--- a/main/modules/roboclaw_wheels.cpp
+++ b/main/modules/roboclaw_wheels.cpp
@@ -45,8 +45,7 @@ void RoboClawWheels::update_odometry() {
         const double m_per_tick = this->properties.at("m_per_tick")->number_value;
         double left_speed = (d_left_position * m_per_tick) / d_micros * 1000000;
         double right_speed = (d_right_position * m_per_tick) / d_micros * 1000000;
-        this->properties.at("linear_speed")->number_value = (left_speed + right_speed) / 2;
-        this->properties.at("angular_speed")->number_value = (right_speed - left_speed) / this->properties.at("width")->number_value;
+        this->update_speeds(left_speed, right_speed);
     }
 
     this->last_micros = micros();

--- a/main/modules/roboclaw_wheels.cpp
+++ b/main/modules/roboclaw_wheels.cpp
@@ -13,17 +13,13 @@ static Module_ptr create_roboclaw_wheels(const std::string &name, const std::vec
 REGISTER_MODULE(RoboClawWheels, &create_roboclaw_wheels)
 
 const std::map<std::string, Variable_ptr> RoboClawWheels::get_defaults() {
-    return {
-        {"width", std::make_shared<NumberVariable>(1)},
-        {"linear_speed", std::make_shared<NumberVariable>()},
-        {"angular_speed", std::make_shared<NumberVariable>()},
-        {"enabled", std::make_shared<BooleanVariable>(true)},
-        {"m_per_tick", std::make_shared<NumberVariable>(1)},
-    };
+    auto defaults = Wheels::get_wheels_defaults();
+    defaults["m_per_tick"] = std::make_shared<NumberVariable>(1);
+    return defaults;
 }
 
 RoboClawWheels::RoboClawWheels(const std::string name, const RoboClawMotor_ptr left_motor, const RoboClawMotor_ptr right_motor)
-    : Module(name), left_motor(left_motor), right_motor(right_motor) {
+    : Wheels(name), left_motor(left_motor), right_motor(right_motor) {
     this->properties = RoboClawWheels::get_defaults();
 }
 
@@ -37,15 +33,15 @@ static double difference_wrapped_u32(double current_value, double last_value) {
     return diff;
 }
 
-void RoboClawWheels::step() {
+void RoboClawWheels::update_odometry() {
     double left_position = this->left_motor->get_position();
     double right_position = this->right_motor->get_position();
 
-    if (initialized) {
-        double d_left_position = difference_wrapped_u32(left_position, last_left_position);
-        double d_right_position = difference_wrapped_u32(right_position, last_right_position);
+    if (this->initialized) {
+        double d_left_position = difference_wrapped_u32(left_position, this->last_left_position);
+        double d_right_position = difference_wrapped_u32(right_position, this->last_right_position);
 
-        unsigned long int d_micros = micros_since(last_micros);
+        unsigned long int d_micros = micros_since(this->last_micros);
         const double m_per_tick = this->properties.at("m_per_tick")->number_value;
         double left_speed = (d_left_position * m_per_tick) / d_micros * 1000000;
         double right_speed = (d_right_position * m_per_tick) / d_micros * 1000000;
@@ -53,20 +49,26 @@ void RoboClawWheels::step() {
         this->properties.at("angular_speed")->number_value = (right_speed - left_speed) / this->properties.at("width")->number_value;
     }
 
-    last_micros = micros();
-    last_left_position = left_position;
-    last_right_position = right_position;
-    initialized = true;
+    this->last_micros = micros();
+    this->last_left_position = left_position;
+    this->last_right_position = right_position;
+    this->initialized = true;
+}
 
-    if (this->properties.at("enabled")->boolean_value != this->enabled) {
-        if (this->properties.at("enabled")->boolean_value) {
-            this->enable();
-        } else {
-            this->disable();
-        }
-    }
+void RoboClawWheels::do_wheel_speeds(double left, double right) {
+    const double m_per_tick = this->properties.at("m_per_tick")->number_value;
+    this->left_motor->speed(left / m_per_tick);
+    this->right_motor->speed(right / m_per_tick);
+}
 
-    Module::step();
+void RoboClawWheels::do_enable() {
+    this->left_motor->enable();
+    this->right_motor->enable();
+}
+
+void RoboClawWheels::do_disable() {
+    this->left_motor->disable();
+    this->right_motor->disable();
 }
 
 void RoboClawWheels::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
@@ -76,41 +78,11 @@ void RoboClawWheels::call(const std::string method_name, const std::vector<Const
             this->left_motor->power(arguments[0]->evaluate_number());
             this->right_motor->power(arguments[1]->evaluate_number());
         }
-    } else if (method_name == "speed") {
-        Module::expect(arguments, 2, numbery, numbery);
-        if (this->properties.at("enabled")->boolean_value) {
-            double linear = arguments[0]->evaluate_number();
-            double angular = arguments[1]->evaluate_number();
-            const double half_width = this->properties.at("width")->number_value / 2.0;
-            const double m_per_tick = this->properties.at("m_per_tick")->number_value;
-            this->left_motor->speed((linear - angular * half_width) / m_per_tick);
-            this->right_motor->speed((linear + angular * half_width) / m_per_tick);
-        }
     } else if (method_name == "off") {
         Module::expect(arguments, 0);
         this->left_motor->power(0);
         this->right_motor->power(0);
-    } else if (method_name == "enable") {
-        Module::expect(arguments, 0);
-        this->enable();
-    } else if (method_name == "disable") {
-        Module::expect(arguments, 0);
-        this->disable();
     } else {
-        Module::call(method_name, arguments);
+        Wheels::call(method_name, arguments);
     }
-}
-
-void RoboClawWheels::enable() {
-    this->enabled = true;
-    this->properties.at("enabled")->boolean_value = true;
-    this->left_motor->enable();
-    this->right_motor->enable();
-}
-
-void RoboClawWheels::disable() {
-    this->left_motor->disable();
-    this->right_motor->disable();
-    this->enabled = false;
-    this->properties.at("enabled")->boolean_value = false;
 }

--- a/main/modules/roboclaw_wheels.cpp
+++ b/main/modules/roboclaw_wheels.cpp
@@ -19,8 +19,7 @@ const std::map<std::string, Variable_ptr> RoboClawWheels::get_defaults() {
 }
 
 RoboClawWheels::RoboClawWheels(const std::string name, const RoboClawMotor_ptr left_motor, const RoboClawMotor_ptr right_motor)
-    : Wheels(name), left_motor(left_motor), right_motor(right_motor) {
-    this->properties = RoboClawWheels::get_defaults();
+    : Wheels(name, RoboClawWheels::get_defaults()), left_motor(left_motor), right_motor(right_motor) {
 }
 
 /* Catch unsigned wrap-around by detecting large jumps in encoder deltas */

--- a/main/modules/roboclaw_wheels.h
+++ b/main/modules/roboclaw_wheels.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "roboclaw_motor.h"
+#include "wheels.h"
 
-class RoboClawWheels : public Module {
+class RoboClawWheels : public Wheels {
 private:
     const RoboClawMotor_ptr left_motor;
     const RoboClawMotor_ptr right_motor;
@@ -11,16 +12,17 @@ private:
     int64_t last_left_position;
     int64_t last_right_position;
     bool initialized = false;
-    bool enabled = true;
 
-    void enable();
-    void disable();
+protected:
+    void do_wheel_speeds(double left, double right) override;
+    void do_enable() override;
+    void do_disable() override;
+    void update_odometry() override;
 
 public:
     static inline constexpr const char *TYPE = "RoboClawWheels";
 
     RoboClawWheels(const std::string name, const RoboClawMotor_ptr left_motor, const RoboClawMotor_ptr right_motor);
-    void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/wheels.cpp
+++ b/main/modules/wheels.cpp
@@ -1,6 +1,6 @@
 #include "wheels.h"
 
-std::map<std::string, Variable_ptr> Wheels::get_wheels_defaults() {
+const std::map<std::string, Variable_ptr> Wheels::get_defaults() {
     return {
         {"width", std::make_shared<NumberVariable>(1.0)},
         {"linear_speed", std::make_shared<NumberVariable>()},
@@ -11,10 +11,9 @@ std::map<std::string, Variable_ptr> Wheels::get_wheels_defaults() {
 
 Wheels::Wheels(const std::string name)
     : Module(name) {
-    // Seed the shared properties the base unconditionally reads, so a subclass that forgets to
-    // assign its own defaults still boots (a missing key would throw std::out_of_range, which the
-    // main loop does not catch). Subclasses overwrite this with their own defaults in their ctor.
-    this->properties = Wheels::get_wheels_defaults();
+    // Install the shared defaults. Subclasses with no extra properties (Dunker, ODrive) rely on
+    // this; those that add properties (RoboClaw's m_per_tick) overwrite it in their own ctor.
+    this->properties = Wheels::get_defaults();
 }
 
 void Wheels::update_speeds(double left_speed, double right_speed) {

--- a/main/modules/wheels.cpp
+++ b/main/modules/wheels.cpp
@@ -1,0 +1,61 @@
+#include "wheels.h"
+
+std::map<std::string, Variable_ptr> Wheels::get_wheels_defaults() {
+    return {
+        {"width", std::make_shared<NumberVariable>(1.0)},
+        {"linear_speed", std::make_shared<NumberVariable>()},
+        {"angular_speed", std::make_shared<NumberVariable>()},
+        {"enabled", std::make_shared<BooleanVariable>(true)},
+    };
+}
+
+Wheels::Wheels(const std::string name)
+    : Module(name) {
+}
+
+void Wheels::step() {
+    this->update_odometry();
+
+    if (this->properties.at("enabled")->boolean_value != this->enabled) {
+        if (this->properties.at("enabled")->boolean_value) {
+            this->enable();
+        } else {
+            this->disable();
+        }
+    }
+
+    Module::step();
+}
+
+void Wheels::call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) {
+    if (method_name == "speed") {
+        Module::expect(arguments, 2, numbery, numbery);
+        if (!this->properties.at("enabled")->boolean_value) {
+            return;
+        }
+        const double linear = arguments[0]->evaluate_number();
+        const double angular = arguments[1]->evaluate_number();
+        const double width = this->properties.at("width")->number_value;
+        this->do_wheel_speeds(linear - angular * width / 2.0, linear + angular * width / 2.0);
+    } else if (method_name == "enable") {
+        Module::expect(arguments, 0);
+        this->enable();
+    } else if (method_name == "disable") {
+        Module::expect(arguments, 0);
+        this->disable();
+    } else {
+        Module::call(method_name, arguments);
+    }
+}
+
+void Wheels::enable() {
+    this->enabled = true;
+    this->properties.at("enabled")->boolean_value = true;
+    this->do_enable();
+}
+
+void Wheels::disable() {
+    this->do_disable();
+    this->enabled = false;
+    this->properties.at("enabled")->boolean_value = false;
+}

--- a/main/modules/wheels.cpp
+++ b/main/modules/wheels.cpp
@@ -1,19 +1,8 @@
 #include "wheels.h"
 
-const std::map<std::string, Variable_ptr> Wheels::get_defaults() {
-    return {
-        {"width", std::make_shared<NumberVariable>(1.0)},
-        {"linear_speed", std::make_shared<NumberVariable>()},
-        {"angular_speed", std::make_shared<NumberVariable>()},
-        {"enabled", std::make_shared<BooleanVariable>(true)},
-    };
-}
-
-Wheels::Wheels(const std::string name)
+Wheels::Wheels(const std::string name, const std::map<std::string, Variable_ptr> &defaults)
     : Module(name) {
-    // Install the shared defaults. Subclasses with no extra properties (Dunker, ODrive) rely on
-    // this; those that add properties (RoboClaw's m_per_tick) overwrite it in their own ctor.
-    this->properties = Wheels::get_defaults();
+    this->properties = defaults;
 }
 
 void Wheels::update_speeds(double left_speed, double right_speed) {
@@ -24,7 +13,7 @@ void Wheels::update_speeds(double left_speed, double right_speed) {
 void Wheels::step() {
     this->update_odometry();
 
-    if (this->properties.at("enabled")->boolean_value != this->enabled) {
+    if (this->properties.at("enabled")->boolean_value != this->last_applied_enabled) {
         if (this->properties.at("enabled")->boolean_value) {
             this->enable();
         } else {
@@ -57,13 +46,22 @@ void Wheels::call(const std::string method_name, const std::vector<ConstExpressi
 }
 
 void Wheels::enable() {
-    this->enabled = true;
+    this->last_applied_enabled = true;
     this->properties.at("enabled")->boolean_value = true;
     this->do_enable();
 }
 
 void Wheels::disable() {
     this->do_disable();
-    this->enabled = false;
+    this->last_applied_enabled = false;
     this->properties.at("enabled")->boolean_value = false;
+}
+
+const std::map<std::string, Variable_ptr> Wheels::get_defaults() {
+    return {
+        {"width", std::make_shared<NumberVariable>(1.0)},
+        {"linear_speed", std::make_shared<NumberVariable>()},
+        {"angular_speed", std::make_shared<NumberVariable>()},
+        {"enabled", std::make_shared<BooleanVariable>(true)},
+    };
 }

--- a/main/modules/wheels.cpp
+++ b/main/modules/wheels.cpp
@@ -11,6 +11,15 @@ std::map<std::string, Variable_ptr> Wheels::get_wheels_defaults() {
 
 Wheels::Wheels(const std::string name)
     : Module(name) {
+    // Seed the shared properties the base unconditionally reads, so a subclass that forgets to
+    // assign its own defaults still boots (a missing key would throw std::out_of_range, which the
+    // main loop does not catch). Subclasses overwrite this with their own defaults in their ctor.
+    this->properties = Wheels::get_wheels_defaults();
+}
+
+void Wheels::update_speeds(double left_speed, double right_speed) {
+    this->properties.at("linear_speed")->number_value = (left_speed + right_speed) / 2;
+    this->properties.at("angular_speed")->number_value = (right_speed - left_speed) / this->properties.at("width")->number_value;
 }
 
 void Wheels::step() {

--- a/main/modules/wheels.cpp
+++ b/main/modules/wheels.cpp
@@ -1,5 +1,14 @@
 #include "wheels.h"
 
+const std::map<std::string, Variable_ptr> Wheels::get_defaults() {
+    return {
+        {"width", std::make_shared<NumberVariable>(1.0)},
+        {"linear_speed", std::make_shared<NumberVariable>()},
+        {"angular_speed", std::make_shared<NumberVariable>()},
+        {"enabled", std::make_shared<BooleanVariable>(true)},
+    };
+}
+
 Wheels::Wheels(const std::string name, const std::map<std::string, Variable_ptr> &defaults)
     : Module(name) {
     this->properties = defaults;
@@ -55,13 +64,4 @@ void Wheels::disable() {
     this->do_disable();
     this->last_applied_enabled = false;
     this->properties.at("enabled")->boolean_value = false;
-}
-
-const std::map<std::string, Variable_ptr> Wheels::get_defaults() {
-    return {
-        {"width", std::make_shared<NumberVariable>(1.0)},
-        {"linear_speed", std::make_shared<NumberVariable>()},
-        {"angular_speed", std::make_shared<NumberVariable>()},
-        {"enabled", std::make_shared<BooleanVariable>(true)},
-    };
 }

--- a/main/modules/wheels.h
+++ b/main/modules/wheels.h
@@ -14,9 +14,6 @@ using Wheels_ptr = std::shared_ptr<Wheels>;
  */
 class Wheels : public Module {
 protected:
-    /// Common property defaults; concrete modules extend this in their own `get_defaults()`.
-    static std::map<std::string, Variable_ptr> get_wheels_defaults();
-
     /// Write `linear_speed`/`angular_speed` from measured per-wheel speeds; call from `update_odometry()`.
     void update_speeds(double left_speed, double right_speed);
 
@@ -31,6 +28,8 @@ private:
     bool enabled = true;
 
 public:
+    /// Shared property defaults; subclasses that add properties shadow this in their own `get_defaults()`.
+    static const std::map<std::string, Variable_ptr> get_defaults();
     Wheels(const std::string name);
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;

--- a/main/modules/wheels.h
+++ b/main/modules/wheels.h
@@ -13,6 +13,9 @@ using Wheels_ptr = std::shared_ptr<Wheels>;
  * drivetrains provide the motor-specific parts through the protected hooks.
  */
 class Wheels : public Module {
+private:
+    bool last_applied_enabled = true; // last value synced to the motors; `step()` edge-detects direct property writes against it
+
 protected:
     /// Write `linear_speed`/`angular_speed` from measured per-wheel speeds; call from `update_odometry()`.
     void update_speeds(double left_speed, double right_speed);
@@ -24,15 +27,12 @@ protected:
     /// Update `linear_speed`/`angular_speed` from the motors; called every `step()`.
     virtual void update_odometry() = 0;
 
-private:
-    bool enabled = true;
-
 public:
-    /// Shared property defaults; subclasses that add properties shadow this in their own `get_defaults()`.
-    static const std::map<std::string, Variable_ptr> get_defaults();
-    Wheels(const std::string name);
+    Wheels(const std::string name, const std::map<std::string, Variable_ptr> &defaults = Wheels::get_defaults());
     void step() override;
     void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
     void enable();
     void disable();
+    /// Shared property defaults; subclasses that add properties shadow this and pass the result to the constructor.
+    static const std::map<std::string, Variable_ptr> get_defaults();
 };

--- a/main/modules/wheels.h
+++ b/main/modules/wheels.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "module.h"
+
+class Wheels;
+using Wheels_ptr = std::shared_ptr<Wheels>;
+
+/**
+ * Shared base for differential-drive wheels modules.
+ *
+ * Owns the common properties (`width`, `linear_speed`, `angular_speed`, `enabled`), the
+ * enabled-sync in `step()` and the `speed`/`enable`/`disable` command flow. Concrete
+ * drivetrains provide the motor-specific parts through the protected hooks.
+ */
+class Wheels : public Module {
+protected:
+    bool enabled = true;
+
+    /// Common property defaults; concrete modules extend this in their own `get_defaults()`.
+    static std::map<std::string, Variable_ptr> get_wheels_defaults();
+
+    /// Apply per-wheel target speeds (already split from linear/angular via `width`).
+    virtual void do_wheel_speeds(double left, double right) = 0;
+    virtual void do_enable() = 0;
+    virtual void do_disable() = 0;
+    /// Update `linear_speed`/`angular_speed` from the motors; called every `step()`.
+    virtual void update_odometry() = 0;
+
+public:
+    Wheels(const std::string name);
+    void step() override;
+    void call(const std::string method_name, const std::vector<ConstExpression_ptr> arguments) override;
+    void enable();
+    void disable();
+};

--- a/main/modules/wheels.h
+++ b/main/modules/wheels.h
@@ -14,10 +14,11 @@ using Wheels_ptr = std::shared_ptr<Wheels>;
  */
 class Wheels : public Module {
 protected:
-    bool enabled = true;
-
     /// Common property defaults; concrete modules extend this in their own `get_defaults()`.
     static std::map<std::string, Variable_ptr> get_wheels_defaults();
+
+    /// Write `linear_speed`/`angular_speed` from measured per-wheel speeds; call from `update_odometry()`.
+    void update_speeds(double left_speed, double right_speed);
 
     /// Apply per-wheel target speeds (already split from linear/angular via `width`).
     virtual void do_wheel_speeds(double left, double right) = 0;
@@ -25,6 +26,9 @@ protected:
     virtual void do_disable() = 0;
     /// Update `linear_speed`/`angular_speed` from the motors; called every `step()`.
     virtual void update_odometry() = 0;
+
+private:
+    bool enabled = true;
 
 public:
     Wheels(const std::string name);


### PR DESCRIPTION
### Motivation

`DunkerWheels`, `ODriveWheels` and `RoboClawWheels` each inherited `Module` directly and duplicated the same scaffolding: the `width`/`linear_speed`/`angular_speed`/`enabled` properties, the enabled-sync in `step()` and the `speed`/`enable`/`disable` command flow.

This is the first half of splitting #223 (per @falkoschindler's review): a pure, behavior-preserving refactor that can be reviewed line-for-line against the old modules. The `drivable` feature lands separately in #226, stacked on this branch. #223 stays open until the robots currently depending on it are migrated to this split.

### Implementation

A new abstract `Wheels : public Module` (`wheels.h`/`wheels.cpp`) owns the common properties, the `step()` enabled-sync and the `speed`/`enable`/`disable` flow. The concrete drivetrains only implement the motor-specific hooks — `do_wheel_speeds`, `do_enable`, `do_disable`, `update_odometry`. `ODriveWheels` and `RoboClawWheels` keep their extra `power`/`off` commands; `RoboClawWheels` keeps its `m_per_tick` scaling and wrapped-u32 odometry.

**One deliberate reconciliation:** the shared `speed` gate checks the immediate `enabled` *property* — as `ODriveWheels` and `RoboClawWheels` already did. `DunkerWheels` previously gated on the once-per-`step()` `enabled` *member*, so its gate now reacts in the same cycle too. This is the only intentional behavior change, and for a nonzero `speed` it is the safer direction: a `disable` in the same cycle as a `speed` is now honored immediately for all three, instead of one extra command slipping through to still-enabled motors.

The one edge where it is marginally *less* safe: after a direct `enabled = false` property write, a same-cycle `speed(0, 0)` is now dropped rather than forwarded, so instead of an active zero-velocity command the motors coast until the next `step()` runs `do_disable()` and cuts the power stage. For statements over UART that gap is microseconds (statements are processed before module steps in the same loop iteration); for rule-driven writes it is up to one main-loop cycle (~10ms). This matches the long-standing `ODriveWheels`/`RoboClawWheels` behavior and is fine to keep; reacting to `enabled` writes eagerly would be a separate change, which the consolidation into `Wheels` actually makes easier to do later.

No new user-facing commands or properties; `module.h` and the docs are untouched.

### Progress

- [x] The implementation is complete.
- [x] Tested on hardware (built clean for `esp32` and flashed to an ESP32; the wheels modules construct and take drive commands without regression).
- [x] Documentation has been updated (or is not necessary — no user-facing surface changed).

