### PR TITLE
Fix ODriveMotor axis_state property showing garbage from uninitialized int

### DIFF
--- a/main/modules/odrive_motor.cpp
+++ b/main/modules/odrive_motor.cpp
@@ -108,13 +108,11 @@ void ODriveMotor::handle_can_msg(const uint32_t id, const int count, const uint8
         int axis_error;
         std::memcpy(&axis_error, data, 4);
         this->properties.at("axis_error")->integer_value = axis_error;
-        int axis_state;
-        std::memcpy(&axis_state, data + 4, 1);
+        const uint8_t axis_state = data[4];
         this->axis_state = axis_state;
         this->properties.at("axis_state")->integer_value = axis_state;
         if (version == 6) {
-            int message_byte;
-            std::memcpy(&message_byte, data + 5, 1);
+            const uint8_t message_byte = data[5];
             this->properties.at("motor_error_flag")->integer_value = message_byte & 0x01;
         }
         break;


### PR DESCRIPTION
Fixes #230.

**TL;DR** — `axis_state` (and the neighboring `message_byte`) were read as `int x; std::memcpy(&x, data + N, 1);` — one byte copied into an **uninitialized 4-byte int**, leaving 3 indeterminate upper bytes. The `uint8_t` member truncates fine, so mode-switching worked, but the `axis_state` **property** (`int64_t`) got the garbage int, printing values like `-1121283064` and making rules such as `when l.axis_state == 8 ...` silently never match. Fix: read the byte directly as `const uint8_t`.

```diff
-        int axis_state;
-        std::memcpy(&axis_state, data + 4, 1);
+        const uint8_t axis_state = data[4];
         this->axis_state = axis_state;
         this->properties.at("axis_state")->integer_value = axis_state;
         if (version == 6) {
-            int message_byte;
-            std::memcpy(&message_byte, data + 5, 1);
+            const uint8_t message_byte = data[5];
             this->properties.at("motor_error_flag")->integer_value = message_byte & 0x01;
         }
```

`data` is already `const uint8_t *const`, so `data[4]`/`data[5]` read the exact same bytes the `memcpy`s did — no bounds change — while eliminating the uninitialized read entirely.

<details>
<summary><b>Why the reporter's own numbers are the smoking gun</b></summary>

Both observed `integer_value`s decode to the same fingerprint — correct state in the low byte, garbage in the upper three:

| observed value | hex | low byte |
|---|---|---|
| `-1121283064` | `0xBD2A94`**`08`** | **8** (CLOSED_LOOP_CONTROL) |
| `1058449672`  | `0x3F16A9`**`08`** | **8** |

Two unrelated signed ints both ending in byte `0x08` is exactly what "1-byte write into a little-endian 4-byte int, upper 3 bytes indeterminate" produces. It can't be coincidence.
</details>

<details>
<summary><b>Empirical: it's undefined behavior, so it's optimization-dependent (why a naive host test can miss it)</b></summary>

The `&x` forces a stack round-trip: **store 1 byte, then load 4**. Whether the 3 undefined bytes survive depends on the compiler:

| target | opt | codegen for the read | garbage? |
|---|---|---|---|
| x86-64 | `-O0` | `movb 4(%rax),%al` → `movb %al,-12(%rbp)` → `movslq -12(%rbp),%rax` | **yes** (store 1, load 4) |
| x86-64 | `-O2` | `movzbl 4(%rdi),%eax` | no — UB folded to clean byte load |
| ARM64  | `-O0` | `ldrb w8,[x8,#4]` → `strb w8,[sp,#4]` → `ldrsw x0,[sp,#4]` | **yes** |
| ARM64  | `-O2` | `ldrb w0,[x0,#4]` | no — bug optimized away |

At `-O2` the optimizer exploits the UB and returns a clean zero-extended byte, so a host test can print a correct `8` and *look* fine — which is why this only reliably shows on the ESP32 build (Xtensa gcc keeps the full-word load). Forcing deterministic garbage with `clang -ftrivial-auto-var-init=pattern` yields `0xAAAAAA08` = `-1431655928`, and `== 8` fails — matching the report. The fixed code (`const uint8_t x = data[4]`) has no uninitialized variable at all, so it's a single byte load on every target/opt and always yields the correct value.
</details>

<details>
<summary><b>Scope notes</b></summary>

- **`message_byte` (version 6)** — same UB pattern, currently *harmless* because `& 0x01` reads the one byte that was actually written on little-endian. Fixed anyway for consistency (the report explicitly notes "initializing it as well wouldn't hurt").
- **`axis_error` — deliberately left unchanged.** Its `std::memcpy(&axis_error, data, 4)` copies the full 4 bytes into the 32-bit int, so there is no uninitialized-byte bug. (A separate, pre-existing observation unrelated to this fix: if an error bit sets bit 31, the signed `int`→`int64_t` assignment would report a negative value. Out of scope for #230.)
</details>

<details>
<summary><b>Second-lineage review (Codex / GPT) — verdict: SHIP</b></summary>

> **SHIP**
> - No regression for well-defined old behavior: the old reads were not well-defined (read an `int` with 3 indeterminate bytes). The new code defines the intended 8-bit value.
> - No new bounds issue: `data[4]`/`data[5]` require the same bytes as the old `memcpy`. If `count < 5`/`< 6`, both versions are already out-of-bounds (separate issue: `count` is ignored).
> - `uint8_t message_byte & 0x01` is equivalent for all 256 byte values (integer promotions make it an `int` expression before `&`).
> - Leaving `axis_error` is acceptable; it copies the full 4 bytes, so no uninitialized-byte bug.
> - No meaningful type/const/shadowing problem introduced.
</details>
