### PR TITLE
Bound string-escape loop in print_to_buffer to prevent stack overflow

### DIFF
--- a/main/compilation/expression.cpp
+++ b/main/compilation/expression.cpp
@@ -41,6 +41,8 @@ int Expression::print_to_buffer(char *buffer, size_t buffer_len) const {
         char escaped[buffer_len];
         int pos = 0;
         for (char c : this->evaluate_string()) {
+            if (pos + 3 > (int)buffer_len) // room for a 2-byte escape plus the final '\0' (#235)
+                throw std::runtime_error("buffer too small");
             if (c == '"' || c == '\\') {
                 escaped[pos++] = '\\';
             }


### PR DESCRIPTION
Fixes #235.

**TL;DR:** The `string` case of `Expression::print_to_buffer` escapes `"`/`\` into a stack VLA `char escaped[buffer_len]`, writing up to 2 bytes per input char with **no bound check** — so a quote-heavy stored string writes ~2× its length and runs off the end, smashing the stack (reproduced on ESP32-S3 in #235). This adds a **single per-iteration bound check** that throws `"buffer too small"` — the *same* `runtime_error` `csprintf` already throws for an over-long result, already caught by the top-level handlers and echoed. **No heap, no `std::string`, VLA retained** — addresses the memory-unsafety without the allocation cost flagged in the issue thread.

```diff
         for (char c : this->evaluate_string()) {
+            if (pos + 3 > (int)buffer_len) // room for a 2-byte escape plus the final '\0' (#235)
+                throw std::runtime_error("buffer too small");
             if (c == '"' || c == '\\') {
                 escaped[pos++] = '\\';
             }
             escaped[pos++] = c;
         }
```

Observable behaviour for valid strings is **unchanged**; over-long values are echoed as `buffer too small` instead of crashing. `+3` covers the worst case for one iteration: up to 2 bytes for an escaped char, plus the terminating `'\0'` written after the loop. As a bonus it also closes the 1-byte overrun a *plain* string of length `buffer_len` would cause on that terminating null — not just the quote-doubling case.

<details>
<summary><b>Why the guard is placed on every char, not just the escape branch</b></summary>

Tempting to only check inside the `if (c == '"' || c == '\\')` branch (the escape chars are what write 2 bytes). But a **plain** string overflows too: it writes 1 byte per char, then `escaped[pos] = '\0'` lands after them, so a plain string of length `buffer_len` overruns by one. Guarding only the escape branch leaves the plain write unchecked — confirmed with AddressSanitizer below. Checking every char is the only single-line placement that covers both.
</details>

<details>
<summary><b>Why this can't reject a valid string (boundary reasoning)</b></summary>

The guard bounds `escaped` to the VLA — `pos` never exceeds `buffer_len-1`, so `escaped[pos]='\0'` is always in-bounds. It does **not** bound the final output; `csprintf` still owns that (`csprintf` accepts iff `strlen(escaped) <= buffer_len-3`, for the two `"` quotes + null). The guard is deliberately *looser* than `csprintf`, so any string that used to echo successfully (which had `strlen(escaped) <= buffer_len-3`, well below the trip point) still echoes; only the out-of-bounds write is removed.
</details>

<details>
<summary><b>Empirical verification — AddressSanitizer, host build (<code>-O0 -fsanitize=address</code>)</b></summary>

Extracted the exact `csprintf` + escape loop into a host harness and ran under ASan (`-O0` so the UB isn't optimized away):

```
OLD (unpatched):
  ==ERROR: AddressSanitizer: dynamic-stack-buffer-overflow ... WRITE of size 1
  SUMMARY: dynamic-stack-buffer-overflow in print_old(...)      # the escaped[pos++]=c write

NEW (this PR):
  [control] 3 quotes -> "\"\"\"" (len 8) OK                     # round-trips identically
  [overflow] 450 quotes -> threw "buffer too small"             # clean, no OOB
  reached end of main cleanly

guard-in-escape-branch-only (rejected alternative):
  ==ERROR: AddressSanitizer: dynamic-stack-buffer-overflow      # plain 256-char string, on the '\0'
```

On real ESP32-S3 the unpatched path crashed freeing `0x225c225c` — the escaped `"\` byte pattern — matching the smashed-stack signature in #235.
</details>

<details>
<summary><b>Scope / known non-goal</b></summary>

A pre-existing, **unreachable** edge remains untouched: `print_to_buffer(buf, 0)` with an *empty* string would write `escaped[0]` on a zero-length VLA. All call sites pass either a fixed size (256/512) or `sizeof(buffer) - pos`, and `csprintf` guarantees each chained write leaves `pos <= size-1` (or throws), so `buffer_len >= 1` always — the `0` case isn't reachable, and it predates this change. Left out to keep the diff to the one line that fixes the reported bug; happy to fold in a `buffer_len < 3` pre-check if you'd prefer defence-in-depth.

No host-side test harness exists in the repo (CI is pre-commit only), so no unit test is added here — the ASan repro above stands as the evidence. Glad to add a test in whatever shape you'd prefer.
</details>
