### PR TITLE
Guard integer division/modulo by zero in expressions

### DIFF
--- a/main/compilation/expressions.cpp
+++ b/main/compilation/expressions.cpp
@@ -194,7 +194,11 @@ DivideExpression::DivideExpression(const ConstExpression_ptr left, const ConstEx
 }
 
 int64_t DivideExpression::evaluate_integer() const {
-    return this->left->evaluate_integer() / this->right->evaluate_integer();
+    const int64_t divisor = this->right->evaluate_integer();
+    if (divisor == 0) {
+        throw std::runtime_error("division by zero");
+    }
+    return this->left->evaluate_integer() / divisor;
 }
 
 double DivideExpression::evaluate_number() const {
@@ -206,7 +210,11 @@ ModuloExpression::ModuloExpression(const ConstExpression_ptr left, const ConstEx
 }
 
 int64_t ModuloExpression::evaluate_integer() const {
-    return this->left->evaluate_integer() % this->right->evaluate_integer();
+    const int64_t divisor = this->right->evaluate_integer();
+    if (divisor == 0) {
+        throw std::runtime_error("modulo by zero");
+    }
+    return this->left->evaluate_integer() % divisor;
 }
 
 double ModuloExpression::evaluate_number() const {
@@ -218,7 +226,11 @@ FloorDivideExpression::FloorDivideExpression(const ConstExpression_ptr left, con
 }
 
 int64_t FloorDivideExpression::evaluate_integer() const {
-    return this->left->evaluate_integer() / this->right->evaluate_integer();
+    const int64_t divisor = this->right->evaluate_integer();
+    if (divisor == 0) {
+        throw std::runtime_error("division by zero");
+    }
+    return this->left->evaluate_integer() / divisor;
 }
 
 double FloorDivideExpression::evaluate_number() const {


### PR DESCRIPTION
Fixes #234.

Sending a single line like `1 / 0` over serial panicked the ESP32 with an unhandled `IntegerDivideByZero` hardware trap and rebooted the whole controller. `DivideExpression::evaluate_integer`, `ModuloExpression::evaluate_integer`, and `FloorDivideExpression::evaluate_integer` performed a raw integer division with no divisor check, so the trap fired below the C++ level and bypassed the `try/catch (std::runtime_error)` in `process_uart()` that normally turns expression errors into a graceful `error: ...` echo.

This PR guards the divisor in all three integer operators and throws `std::runtime_error` instead, matching how the file already reports arithmetic errors (e.g. "invalid type for arithmetic operation"). With this change, `1 / 0` echoes `error processing uart0: division by zero` and the controller keeps running. The float path is unaffected (it already yields `inf`/`nan` without trapping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
