### PR TITLE
Handle owl allocation failure instead of aborting

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -339,6 +339,10 @@ void process_lizard(const char *line, bool trigger_keep_alive, bool from_expande
     case ERROR_MORE_INPUT_NEEDED:
         echo("error: more input needed at range %zu %zu", range.start, range.end);
         break;
+    case ERROR_ALLOCATION_FAILURE:
+        // Must not reach process_tree: owl's accessors exit() on a failed tree, which aborts on ESP-IDF.
+        echo("error: allocation failure while parsing");
+        break;
     default:
         if (debug) {
             owl_tree_print(tree.get());

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -320,6 +320,10 @@ void process_lizard(const char *line, bool trigger_keep_alive, bool from_expande
     if (debug) {
         toc("Tree creation");
     }
+    if (!tree) {
+        echo("error: allocation failure while parsing");
+        return;
+    }
     struct source_range range;
     switch (owl_tree_get_error(tree.get(), &range)) {
     case ERROR_INVALID_FILE:
@@ -340,10 +344,9 @@ void process_lizard(const char *line, bool trigger_keep_alive, bool from_expande
         echo("error: more input needed at range %zu %zu", range.start, range.end);
         break;
     case ERROR_ALLOCATION_FAILURE:
-        // Must not reach process_tree: owl's accessors exit() on a failed tree, which aborts on ESP-IDF.
         echo("error: allocation failure while parsing");
         break;
-    default:
+    case ERROR_NONE:
         if (debug) {
             owl_tree_print(tree.get());
             tic();
@@ -352,6 +355,11 @@ void process_lizard(const char *line, bool trigger_keep_alive, bool from_expande
         if (debug) {
             toc("Tree traversal");
         }
+        break;
+    default:
+        // owl's accessors exit() on a failed tree (aborting on ESP-IDF), so never let an error reach process_tree.
+        echo("error: unknown parse error");
+        break;
     }
 }
 


### PR DESCRIPTION
### Motivation

`process_lizard()` handles every `owl_tree_get_error` code except `ERROR_ALLOCATION_FAILURE`, which falls through to the `default` branch and calls `process_tree()`. owl's accessors call `exit(-1)` on a failed tree — `exit` is not implemented on ESP-IDF, so the firmware aborts and the whole brain reboots.

This showed up as a hard boot loop (8 reboots in 25 s) on a robot with an I/O expander: garbled expander lines arriving while the heap was tight produced trees with `ERROR_ALLOCATION_FAILURE`, and every such line took the brain down. Backtrace: `Expander::handle_messages → process_lizard → process_tree → owl_tree_get_parsed_statements → check_for_error → exit → abort`.

### Implementation

Handle the error code explicitly like all other parse errors: echo `error: allocation failure while parsing` and drop the line, so a failed allocation can never reach owl's aborting accessors.

### Progress

- [x] The implementation is complete.
- [x] Tested on hardware (or is not necessary).
- [x] Documentation has been updated (or is not necessary).