### PR TITLE
Guard parsing against low-heap crashes in owl's parser

### DIFF
--- a/docs/machine_safety.md
+++ b/docs/machine_safety.md
@@ -35,6 +35,13 @@ so that no stale commands fire after the host stopped:
 when core.last_message_age > 500 then motor.stop(); core.clear_schedule() end
 ```
 
+## Low memory
+
+Parsing a line requires a certain amount of free heap memory, which scales with the length of the line.
+When there is not enough free or contiguous memory, Lizard drops the line and responds with `error: not enough free memory to parse (<free> free, <required> required)` instead of risking a crash and reboot.
+Like a line with an incorrect checksum, the command was not executed;
+the host system should react accordingly, for example by re-sending the command later or stopping the machine.
+
 ## Expander watchdog
 
 The `expander` module provides a watchdog feature that restarts the port expander when it gets stuck and does not send messages anymore.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -9,6 +9,8 @@
 #include "compilation/rule.h"
 #include "compilation/variable.h"
 #include "compilation/variable_assignment.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include "global.h"
 #include "modules/bluetooth.h"
 #include "modules/core.h"
@@ -305,10 +307,21 @@ void process_tree(owl_tree *const tree, bool from_expander) {
     }
 }
 
+// owl's peak transient allocation scales with the token count of the line, so the
+// required-heap floor scales with its length (base covers a short line's fixed cost).
+static constexpr size_t PARSE_HEAP_BASE = 4096;
+static constexpr size_t PARSE_HEAP_PER_CHAR = 64;
+
 void process_lizard(const char *line, bool trigger_keep_alive, bool from_expander) {
     InterpreterLock lock;
     if (trigger_keep_alive) {
         core_module->keep_alive();
+    }
+
+    // owl's generated parser can abort()/deref under low heap instead of returning an error; drop the line rather than reboot.
+    if (xPortGetFreeHeapSize() < PARSE_HEAP_BASE + PARSE_HEAP_PER_CHAR * strlen(line)) {
+        echo("error: not enough free memory to parse");
+        return;
     }
 
     const bool debug = core_module->get_property("debug")->boolean_value;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -9,8 +9,8 @@
 #include "compilation/rule.h"
 #include "compilation/variable.h"
 #include "compilation/variable_assignment.h"
+#include "esp_heap_caps.h"
 #include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
 #include "global.h"
 #include "modules/bluetooth.h"
 #include "modules/core.h"
@@ -318,9 +318,13 @@ void process_lizard(const char *line, bool trigger_keep_alive, bool from_expande
         core_module->keep_alive();
     }
 
-    // owl's generated parser can abort()/deref under low heap instead of returning an error; drop the line rather than reboot.
-    if (xPortGetFreeHeapSize() < PARSE_HEAP_BASE + PARSE_HEAP_PER_CHAR * strlen(line)) {
-        echo("error: not enough free memory to parse");
+    // owl's generated parser can abort()/deref on a failed allocation instead of returning an error, so require both
+    // enough total heap (scaled by the line's length) and a large enough contiguous block before parsing. Other tasks
+    // may allocate between the check and the parse; the padded constants absorb that. Drop the line rather than reboot.
+    const size_t required_heap = PARSE_HEAP_BASE + PARSE_HEAP_PER_CHAR * strlen(line);
+    const size_t free_heap = xPortGetFreeHeapSize();
+    if (free_heap < required_heap || heap_caps_get_largest_free_block(MALLOC_CAP_8BIT) < PARSE_HEAP_BASE) {
+        echo("error: not enough free memory to parse (%u free, %u required)", (unsigned)free_heap, (unsigned)required_heap);
         return;
     }
 


### PR DESCRIPTION
### Motivation

Under low heap, owl's generated parser can `abort()` or dereference a failed allocation **during** `owl_tree_create_from_string()` — before `process_lizard()` checks `owl_tree_get_error()` — so the brain reboots. #239 fixed the one path where owl *returns* `ERROR_ALLOCATION_FAILURE`; the construction-phase sites still crash (details + host MRE in #240). `parser.h` is generated, so they can't be fixed in-tree; the complete fix is graceful allocation failure upstream in `ianh/owl`.

### Implementation

Skip parsing and drop the line with an error when free heap is below what the parse needs, so owl's allocator is never entered too low. owl's peak transient allocation tracks the line's token count, so the floor scales with length:

```cpp
if (xPortGetFreeHeapSize() < PARSE_HEAP_BASE + PARSE_HEAP_PER_CHAR * strlen(line)) {
    echo("error: not enough free memory to parse");
    return;
}
```

`xPortGetFreeHeapSize()` is the same API already reported as `core.heap`. The constants are conservative starting points measured against `OWL_TOKEN_RUN_LENGTH=256`; since `strlen` is only a proxy for token count, a pathological ultra-dense line can still exceed the estimate (fully solved only by the owl change in #240).

### Progress

- [x] The implementation is complete.
- [ ] Tested on hardware — builds for `esp32s3` (idf v5.3.1); on-device threshold tuning still to confirm.
- [x] Documentation has been updated (or is not necessary).
