### PR TITLE
Guard checksum parsing against unparseable suffixes

### DIFF
--- a/main/utils/uart.cpp
+++ b/main/utils/uart.cpp
@@ -61,10 +61,14 @@ int check(char *buffer, int len, bool *checksum_ok) {
             checksum ^= buffer[i];
         }
         const std::string hex_number(&buffer[len - 2], 2);
-        if (std::stoi(hex_number, 0, 16) != checksum) {
+        try {
+            if (std::stoi(hex_number, 0, 16) != checksum) {
+                ok = false;
+            } else {
+                len -= 3;
+            }
+        } catch (...) {
             ok = false;
-        } else {
-            len -= 3;
         }
     }
     buffer[len] = 0;


### PR DESCRIPTION
Fixes #242.

`check()` calls `std::stoi` on the two-character checksum suffix with no guard. A suffix it can't parse — e.g. the line `foo@zz` — throws `std::invalid_argument`, which is a `std::logic_error`, so it slips past the `runtime_error`-only handlers → `std::terminate()` → **reboot**. Four bytes of line noise reboot the controller.

This treats a parse failure as what it already looks like — a checksum mismatch — matching the guard `SerialBus::parse_message` already uses on its own `std::stoi`.

**With whitespace hidden ([`?w=1`](https://github.com/zauberzeug/lizard/pull/243/files?w=1)) the change is 4 added lines and nothing removed:**

```diff
         const std::string hex_number(&buffer[len - 2], 2);
+        try {
             if (std::stoi(hex_number, 0, 16) != checksum) {
                 ok = false;
             } else {
                 len -= 3;
             }
+        } catch (...) {
+            ok = false;
+        }
```

No new locals, no comments in the code, no behaviour change for any input that didn't already throw.

<details>
<summary><b>Before / after on hardware — full matrix</b></summary>

Same ESP32-S3, same build path (`python3 build.py esp32s3` in `espressif/idf:v5.3.1`, flashed via `espresso.py`), pristine `main` vs this branch.

**Before** (`ba866e6`): `foo@zz` → `abort()` at PC `0x4208c6ff`, coredump saved, REBOOT.

**After:**

| input | result | note |
|---|---|---|
| `foo@zz` | `warning: Checksum mismatch while processing UART0@0f` | **was: abort → reboot** |
| `foo@1z` | `warning: Checksum mismatch …` | unchanged (partial-parses to `0x1`) |
| `foo@ f` | `warning: Checksum mismatch …` | unchanged |
| `foo@+f` | `warning: Checksum mismatch …` | unchanged |
| `foo@00` | `warning: Checksum mismatch …` | unchanged |
| `1 + 1@2b` | `2@32` | **valid checksum still executes — `len -= 3` path intact** |
| `1 + 1` | `2@32` | unchecksummed control |
| `bogus_prop@2e` | `error processing uart0: unknown variable "bogus_prop"@0b` | valid checksum, suffix stripped correctly |

Observed failing without the patch and passing with it on the same board.

</details>

<details>
<summary><b>Why <code>catch (...)</code> rather than validating hex</b></summary>

Strict two-hex-digit validation would *also* reject `1z` / ` f` / `+f`, which `std::stoi` currently accepts via partial parse. That's a grammar change rather than a crash fix, so it's deliberately left out — happy to add it separately if you want that behaviour.

`catch (...)` is scoped to the `stoi` call and its branch body only. `std::string hex_number(...)` stays **outside** the `try`, so a `bad_alloc` from constructing it still escapes instead of being silently reported as a checksum mismatch.

`len -= 3` can't leave inconsistent state: the only throwing expression in the `try` is `stoi` itself, which runs before any mutation.

</details>

<details>
<summary><b>Checks</b></summary>

- `clang-format` 22.1.5 (the pinned `mirrors-clang-format` rev): clean, zero diff.
- Builds green for `esp32s3`; run locally, since CI here is pre-commit-only.
- No test added — there's no host test harness for `uart.cpp` in the repo. The hardware matrix above is the evidence.

</details>
