### PR TITLE
Fix I2C bus setup on ESP32-S3

### DIFF
--- a/main/utils/i2c_bus.cpp
+++ b/main/utils/i2c_bus.cpp
@@ -1,11 +1,12 @@
 #include "i2c_bus.h"
 
-#include "hal/i2c_ll.h"
 #include <stdexcept>
+#include "hal/i2c_ll.h"
 
 namespace {
 constexpr int I2C_MASTER_TX_BUF_DISABLE = 0;
 constexpr int I2C_MASTER_RX_BUF_DISABLE = 0;
+// I2C_LL_MAX_TIMEOUT is a cycle count on ESP32 (~13 ms) but an exponent on ESP32-S3 (~54 s)
 constexpr uint32_t DEFAULT_TIMEOUT_TICKS = I2C_LL_MAX_TIMEOUT;
 } // namespace
 

--- a/main/utils/i2c_bus.cpp
+++ b/main/utils/i2c_bus.cpp
@@ -1,11 +1,12 @@
 #include "i2c_bus.h"
 
+#include "hal/i2c_ll.h"
 #include <stdexcept>
 
 namespace {
 constexpr int I2C_MASTER_TX_BUF_DISABLE = 0;
 constexpr int I2C_MASTER_RX_BUF_DISABLE = 0;
-constexpr uint32_t DEFAULT_TIMEOUT_TICKS = 1048575;
+constexpr uint32_t DEFAULT_TIMEOUT_TICKS = I2C_LL_MAX_TIMEOUT;
 } // namespace
 
 std::map<i2c_port_t, I2cBusManager::BusConfig> I2cBusManager::configs;
@@ -35,6 +36,7 @@ void I2cBusManager::ensure(i2c_port_t port, gpio_num_t sda_pin, gpio_num_t scl_p
         throw std::runtime_error("could not install i2c driver");
     }
     if (i2c_set_timeout(port, DEFAULT_TIMEOUT_TICKS) != ESP_OK) {
+        i2c_driver_delete(port);
         throw std::runtime_error("could not set i2c timeout");
     }
 


### PR DESCRIPTION
*Opened by Claude Code on evnchn's behalf.*

**TL;DR: 3-line fix — no I²C module can be constructed on ESP32-S3.** Fixes #247.

`DEFAULT_TIMEOUT_TICKS` was the ESP32's `I2C_LL_MAX_TIMEOUT` written out as a literal (`1048575`). The S3's timeout register is five bits wide, so `i2c_set_timeout()` rejected it and `Imu`, `ImuBno085` and `Mcp23017` all threw before touching the bus. Using the constant the driver actually range-checks against makes it correct on both targets.

The second hunk deletes the driver on that failure path. It had been installed successfully by then but was never unwound, so the *first* failing module reported the real cause and every one after it reported a misleading `could not install i2c driver`.

```diff
+#include "hal/i2c_ll.h"
+// I2C_LL_MAX_TIMEOUT is a cycle count on ESP32 (~13 ms) but an exponent on ESP32-S3 (~54 s)
-constexpr uint32_t DEFAULT_TIMEOUT_TICKS = 1048575;
+constexpr uint32_t DEFAULT_TIMEOUT_TICKS = I2C_LL_MAX_TIMEOUT;

     if (i2c_set_timeout(port, DEFAULT_TIMEOUT_TICKS) != ESP_OK) {
+        i2c_driver_delete(port);
         throw std::runtime_error("could not set i2c timeout");
     }
```

<details>
<summary><b>Before / after on hardware, both chips</b></summary>

One line typed at the prompt, nothing attached to the I²C pins:

| `imu = Imu()` | before | after |
|---|---|---|
| **ESP32-S3** | `could not set i2c timeout` | `imu setup failed: I2CError: Check your wiring.` |
| **ESP32** | `imu setup failed: I2CError: Check your wiring.` | *unchanged* |

After the fix the S3 behaves exactly like the ESP32 — the bus initializes and the *device* is correctly reported absent. `Mcp23017()` likewise reaches device I/O (`unable to send i2c command`) rather than failing at bus setup.

The ESP32 column is a pure regression check; behaviour is identical either way.

NOTE: `core.info()`'s `compile time` is not a reliable freshness signal on an incremental build — it comes from a translation unit ninja may not recompile. Since ESP32 behaviour is unchanged by this fix, I confirmed the board was running the patched binary from object/link timestamps rather than from `core.info()`.

</details>

<details>
<summary><b>The unwind hunk, shown failing without it</b></summary>

With the timeout fixed the throw is unreachable, so verifying the second hunk needs the failure forced. Built the S3 with `DEFAULT_TIMEOUT_TICKS = I2C_LL_MAX_TIMEOUT + 1` to guarantee `i2c_set_timeout()` fails, then constructed all three I²C modules in sequence:

**Without `i2c_driver_delete` (current code):**

```
>>> imu = Imu()          → could not set i2c timeout        ← true cause
>>> mcp = Mcp23017()     → could not install i2c driver     ← misleading
>>> b = ImuBno085()      → could not install i2c driver     ← misleading
```

**With `i2c_driver_delete` (this PR):**

```
>>> imu = Imu()          → could not set i2c timeout
>>> mcp = Mcp23017()     → could not set i2c timeout
>>> b = ImuBno085()      → could not set i2c timeout
```

Every module reports the real cause regardless of construction order. The temporary `+ 1` was reverted and the tree re-verified before committing.

</details>

<details>
<summary><b>On the <code>hal/i2c_ll.h</code> include</b></summary>

Two things I checked before proposing it, since it is a private ESP-IDF header:

- **It is required.** Removing the include fails the build: `error: 'I2C_LL_MAX_TIMEOUT' was not declared in this scope`. It is not reachable transitively through `driver/i2c.h`.
- **It matches existing practice here.** `main/modules/core.cpp` already includes `hal/gpio_hal.h`, plus `soc/io_mux_reg.h` and `soc/soc.h`; `main/modules/stepper_motor.cpp` includes `soc/gpio_sig_map.h`.

I chose `I2C_LL_MAX_TIMEOUT` because it is exactly the constant `i2c_set_timeout()` validates against, so the value cannot drift out of agreement with the check when a new target is added. The alternatives, if you would rather not take the dependency:

1. Per-target constants behind `#if CONFIG_IDF_TARGET_ESP32 / _ESP32S3` — public, but duplicates a value that already exists and needs maintaining per new target.
2. Drop the explicit `i2c_set_timeout()` and take the driver default from `i2c_param_config()` — smallest diff, but silently changes ESP32 behaviour. The long timeout looks deliberate — 88687e8 ("fix i2c timeouts", 2022) raised it from `30000` to `1048575`, i.e. ~0.4 ms to ~13 ms for the BNO055 — so I did not.

Happy to switch to either.

</details>

<details>
<summary><b>Against the CONTRIBUTING checklist</b></summary>

- **Compiles without warnings** — clean build for both targets, no warnings from `i2c_bus.cpp`.
- **Follows style guidelines** — `pre-commit run clang-format` passes.
- **Tested on target hardware** — ESP32-S3 (QFN56 rev v0.2, 16 MB) and ESP32 (D0WD-V3, 4 MB), both with an empty I²C bus. ESP-IDF v5.3.1.
- **No debug prints left in code.**
- **Documentation** — no user-facing behaviour change to document; the DSL surface is unchanged.

Not tested: an S3 with an I²C device actually present. Bus setup now succeeds, so device I/O should proceed normally, but I have not confirmed that on hardware. The 4 MB ESP32 test rig needed two local build-config deviations to fit the board (`coredump` dropped from `partitions.csv`, `CONFIG_ESPTOOLPY_FLASHSIZE` 8MB → 4MB); neither touches this code path and neither is part of this branch.

</details>

