### PR TITLE
Replace ESP32-only pin and strapping constants with target-aware ones

### DIFF
--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -354,8 +354,8 @@ The constructor expects up to seven arguments:
 - `port`: I²C port number (default: 0)
 - `sda`: SDA pin (default matches target, e.g. 21 on ESP32)
 - `scl`: SCL pin (default matches target, e.g. 22 on ESP32)
-- `int`: Interrupt pin (default: 26)
-- `rst`: Reset pin (default: 32)
+- `int`: Interrupt pin (default: 26 on ESP32, none on ESP32-S3)
+- `rst`: Reset pin (default: 32 on ESP32, none on ESP32-S3)
 - `address`: I²C address (default: 0x4A)
 - `clk`: I²C clock in Hz (default: 400000)
 

--- a/main/modules/core.cpp
+++ b/main/modules/core.cpp
@@ -156,8 +156,30 @@ void Core::call(const std::string method_name, const std::vector<ConstExpression
             echo("Not a strapping pin");
             break;
         }
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+        // The S3's soc/gpio_reg.h does not document the strapping layout. GPIO0 = bit 3 and GPIO46 = bit 2 follow
+        // from soc/boot_mode.h (download boot requires both bits to be low); GPIO45 = bit 4 matches esptool's
+        // GPIO_STRAP_VDDSPI_MASK. GPIO3 (JTAG source selection) is also a strapping pin, but no ESP-IDF or esptool
+        // source documents its bit position, so we only report the raw register for it.
+        switch (gpio_num) {
+        case GPIO_NUM_0:
+            echo("Strapping GPIO0: %d", (strapping_reg & BIT(3)) ? 1 : 0);
+            break;
+        case GPIO_NUM_45:
+            echo("Strapping GPIO45: %d", (strapping_reg & BIT(4)) ? 1 : 0);
+            break;
+        case GPIO_NUM_46:
+            echo("Strapping GPIO46: %d", (strapping_reg & BIT(2)) ? 1 : 0);
+            break;
+        case GPIO_NUM_3:
+            echo("Strapping GPIO3: unknown bit position, register: 0x%04x", strapping_reg);
+            break;
+        default:
+            echo("Not a strapping pin");
+            break;
+        }
 #else
-        // Other targets strap different pins into different bits; soc/gpio_reg.h does not document the layout.
+        // Other targets strap different pins into different bits; decode them here when a new target is added.
         echo("Strapping register: 0x%04x", strapping_reg);
 #endif
     } else if (method_name == "forget_serial_bus") {

--- a/main/modules/core.cpp
+++ b/main/modules/core.cpp
@@ -131,31 +131,35 @@ void Core::call(const std::string method_name, const std::vector<ConstExpression
             throw std::runtime_error("invalid pin");
         }
         const uint32_t strapping_reg = REG_READ(GPIO_STRAP_REG);
-        // Register 4.13. GPIO_STRAP_REG (0x0038)
-        // https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf
+#ifdef CONFIG_IDF_TARGET_ESP32
+        // GPIO_STRAPPING is {10'b0, MTDI, GPIO0, GPIO2, GPIO4, MTDO, GPIO5}, see soc/gpio_reg.h
         switch (gpio_num) {
         case GPIO_NUM_0:
-            echo("Strapping GPIO0: %d", (strapping_reg & BIT(0)) ? 1 : 0);
+            echo("Strapping GPIO0: %d", (strapping_reg & BIT(4)) ? 1 : 0);
             break;
         case GPIO_NUM_2:
-            echo("Strapping GPIO2: %d", (strapping_reg & BIT(1)) ? 1 : 0);
+            echo("Strapping GPIO2: %d", (strapping_reg & BIT(3)) ? 1 : 0);
             break;
         case GPIO_NUM_4:
-            echo("Strapping GPIO4: %d", (strapping_reg & BIT(5)) ? 1 : 0);
+            echo("Strapping GPIO4: %d", (strapping_reg & BIT(2)) ? 1 : 0);
             break;
         case GPIO_NUM_5:
-            echo("Strapping GPIO5: %d", (strapping_reg & BIT(4)) ? 1 : 0);
+            echo("Strapping GPIO5: %d", (strapping_reg & BIT(0)) ? 1 : 0);
             break;
         case GPIO_NUM_12:
-            echo("Strapping GPIO12 (MTDI): %d", (strapping_reg & BIT(3)) ? 1 : 0);
+            echo("Strapping GPIO12 (MTDI): %d", (strapping_reg & BIT(5)) ? 1 : 0);
             break;
         case GPIO_NUM_15:
-            echo("Strapping GPIO15 (MTDO): %d", (strapping_reg & BIT(2)) ? 1 : 0);
+            echo("Strapping GPIO15 (MTDO): %d", (strapping_reg & BIT(1)) ? 1 : 0);
             break;
         default:
             echo("Not a strapping pin");
             break;
         }
+#else
+        // Other targets strap different pins into different bits; soc/gpio_reg.h does not document the layout.
+        echo("Strapping register: 0x%04x", strapping_reg);
+#endif
     } else if (method_name == "forget_serial_bus") {
         Module::expect(arguments, 0);
         bus_backup::remove();

--- a/main/modules/expander.cpp
+++ b/main/modules/expander.cpp
@@ -11,6 +11,15 @@
 #include <cstring>
 #include <stdexcept>
 
+// The expander is flashed with our own running partition, so it is always the same target as we are.
+#ifdef CONFIG_IDF_TARGET_ESP32S3
+#define BOOT_MODE_PIN 46
+#define FLASH_VOLTAGE_PIN 45
+#else
+#define BOOT_MODE_PIN 2
+#define FLASH_VOLTAGE_PIN 12
+#endif
+
 static Module_ptr create_expander(const std::string &name, const std::vector<ConstExpression_ptr> &arguments, MessageHandler message_handler) {
     if (arguments.size() != 1 && arguments.size() != 3) {
         throw std::runtime_error("unexpected number of arguments");
@@ -178,9 +187,10 @@ void Expander::call(const std::string method_name, const std::vector<ConstExpres
         Storage::clear_nvs();
         gpio_set_level(this->boot_pin, 0);
         if (!force) {
+            char command[32];
             this->serial->write_checked_line("core.get_pin_status(0)");
-            this->serial->write_checked_line("core.get_pin_status(2)");
-            this->serial->write_checked_line("core.get_pin_status(12)");
+            this->serial->write_checked_line(command, csprintf(command, sizeof(command), "core.get_pin_status(%d)", BOOT_MODE_PIN));
+            this->serial->write_checked_line(command, csprintf(command, sizeof(command), "core.get_pin_status(%d)", FLASH_VOLTAGE_PIN));
             delay(100);
             this->handle_messages(true);
         }
@@ -209,22 +219,18 @@ void Expander::call(const std::string method_name, const std::vector<ConstExpres
 }
 
 void Expander::check_strapping_pins(const char *buffer) {
-    // We only need to check GPIO 0, 2 and 12 because they directly influence boot mode and flash voltage selection,
-    // ensuring correct operation during boot and flashing. These are not directly controllable by the expander.
-    if (strstr(buffer, "GPIO_Status[12]|") != nullptr) {
-        if (strstr(buffer, "GPIO_Status[12]| Level: 1") != nullptr) {
-            echo("warning: GPIO12 state is HIGH, this can cause issues with flash voltage selection");
-        }
+    // These strapping pins are sampled at reset and are not directly controllable by the expander.
+    char pattern[32];
+    csprintf(pattern, sizeof(pattern), "GPIO_Status[%d]| Level: 1", FLASH_VOLTAGE_PIN);
+    if (strstr(buffer, pattern) != nullptr) {
+        echo("warning: GPIO%d state is HIGH, this can cause issues with flash voltage selection", FLASH_VOLTAGE_PIN);
     }
-    if (strstr(buffer, "GPIO_Status[0]|") != nullptr) {
-        if (strstr(buffer, "GPIO_Status[0]| Level: 1") != nullptr) {
-            throw std::runtime_error("GPIO0 current state is HIGH - must be LOW for boot mode");
-        }
+    if (strstr(buffer, "GPIO_Status[0]| Level: 1") != nullptr) {
+        throw std::runtime_error("GPIO0 current state is HIGH - must be LOW for boot mode");
     }
-    if (strstr(buffer, "GPIO_Status[2]|") != nullptr) {
-        if (strstr(buffer, "GPIO_Status[2]| Level: 1") != nullptr) {
-            throw std::runtime_error("GPIO2 current state is HIGH - must be LOW or floating for flash mode");
-        }
+    csprintf(pattern, sizeof(pattern), "GPIO_Status[%d]| Level: 1", BOOT_MODE_PIN);
+    if (strstr(buffer, pattern) != nullptr) {
+        throw std::runtime_error("GPIO" + std::to_string(BOOT_MODE_PIN) + " current state is HIGH - must be LOW or floating for flash mode");
     }
 }
 

--- a/main/modules/expander.cpp
+++ b/main/modules/expander.cpp
@@ -11,15 +11,6 @@
 #include <cstring>
 #include <stdexcept>
 
-// The expander is flashed with our own running partition, so it is always the same target as we are.
-#ifdef CONFIG_IDF_TARGET_ESP32S3
-#define BOOT_MODE_PIN 46
-#define FLASH_VOLTAGE_PIN 45
-#else
-#define BOOT_MODE_PIN 2
-#define FLASH_VOLTAGE_PIN 12
-#endif
-
 static Module_ptr create_expander(const std::string &name, const std::vector<ConstExpression_ptr> &arguments, MessageHandler message_handler) {
     if (arguments.size() != 1 && arguments.size() != 3) {
         throw std::runtime_error("unexpected number of arguments");
@@ -188,9 +179,10 @@ void Expander::call(const std::string method_name, const std::vector<ConstExpres
         gpio_set_level(this->boot_pin, 0);
         if (!force) {
             char command[32];
-            this->serial->write_checked_line("core.get_pin_status(0)");
-            this->serial->write_checked_line(command, csprintf(command, sizeof(command), "core.get_pin_status(%d)", BOOT_MODE_PIN));
-            this->serial->write_checked_line(command, csprintf(command, sizeof(command), "core.get_pin_status(%d)", FLASH_VOLTAGE_PIN));
+            for (const int pin : {0, BOOT_MODE_PIN, FLASH_VOLTAGE_PIN}) {
+                const int length = csprintf(command, sizeof(command), "core.get_pin_status(%d)", pin);
+                this->serial->write_checked_line(command, length);
+            }
             delay(100);
             this->handle_messages(true);
         }
@@ -218,19 +210,25 @@ void Expander::call(const std::string method_name, const std::vector<ConstExpres
     }
 }
 
+static bool strapping_pin_is_high(const char *buffer, const int pin) {
+    char pattern[32];
+    csprintf(pattern, sizeof(pattern), "GPIO_Status[%d]| Level: 1", pin);
+    return strstr(buffer, pattern) != nullptr;
+}
+
 void Expander::check_strapping_pins(const char *buffer) {
     // These strapping pins are sampled at reset and are not directly controllable by the expander.
-    char pattern[32];
-    csprintf(pattern, sizeof(pattern), "GPIO_Status[%d]| Level: 1", FLASH_VOLTAGE_PIN);
-    if (strstr(buffer, pattern) != nullptr) {
+    if (strapping_pin_is_high(buffer, FLASH_VOLTAGE_PIN)) {
         echo("warning: GPIO%d state is HIGH, this can cause issues with flash voltage selection", FLASH_VOLTAGE_PIN);
     }
-    if (strstr(buffer, "GPIO_Status[0]| Level: 1") != nullptr) {
+    if (strapping_pin_is_high(buffer, 0)) {
         throw std::runtime_error("GPIO0 current state is HIGH - must be LOW for boot mode");
     }
-    csprintf(pattern, sizeof(pattern), "GPIO_Status[%d]| Level: 1", BOOT_MODE_PIN);
-    if (strstr(buffer, pattern) != nullptr) {
-        throw std::runtime_error("GPIO" + std::to_string(BOOT_MODE_PIN) + " current state is HIGH - must be LOW or floating for flash mode");
+    if (strapping_pin_is_high(buffer, BOOT_MODE_PIN)) {
+        char message[96];
+        csprintf(message, sizeof(message),
+                 "GPIO%d current state is HIGH - must be LOW or floating for flash mode", BOOT_MODE_PIN);
+        throw std::runtime_error(message);
     }
 }
 

--- a/main/modules/imu_bno085.cpp
+++ b/main/modules/imu_bno085.cpp
@@ -6,6 +6,15 @@
 
 #include "esp_log.h"
 
+#ifdef CONFIG_IDF_TARGET_ESP32S3
+// GPIO26 and GPIO32 carry SPI flash and PSRAM on the ESP32-S3, so there is no safe default here.
+#define DEFAULT_INT_PIN GPIO_NUM_NC
+#define DEFAULT_RST_PIN GPIO_NUM_NC
+#else
+#define DEFAULT_INT_PIN GPIO_NUM_26
+#define DEFAULT_RST_PIN GPIO_NUM_32
+#endif
+
 static Module_ptr create_imu_bno085(const std::string &name, const std::vector<ConstExpression_ptr> &arguments, MessageHandler) {
     if (arguments.size() > 7) {
         throw std::runtime_error("unexpected number of arguments");
@@ -14,8 +23,8 @@ static Module_ptr create_imu_bno085(const std::string &name, const std::vector<C
     const i2c_port_t port = arguments.size() > 0 ? (i2c_port_t)arguments[0]->evaluate_integer() : I2C_NUM_0;
     const gpio_num_t sda_pin = arguments.size() > 1 ? (gpio_num_t)arguments[1]->evaluate_integer() : DEFAULT_I2C_SDA_PIN;
     const gpio_num_t scl_pin = arguments.size() > 2 ? (gpio_num_t)arguments[2]->evaluate_integer() : DEFAULT_I2C_SCL_PIN;
-    const gpio_num_t int_pin = arguments.size() > 3 ? (gpio_num_t)arguments[3]->evaluate_integer() : GPIO_NUM_26;
-    const gpio_num_t rst_pin = arguments.size() > 4 ? (gpio_num_t)arguments[4]->evaluate_integer() : GPIO_NUM_32;
+    const gpio_num_t int_pin = arguments.size() > 3 ? (gpio_num_t)arguments[3]->evaluate_integer() : DEFAULT_INT_PIN;
+    const gpio_num_t rst_pin = arguments.size() > 4 ? (gpio_num_t)arguments[4]->evaluate_integer() : DEFAULT_RST_PIN;
     const uint8_t address = arguments.size() > 5 ? arguments[5]->evaluate_integer() : 0x4A;
     const int clk_speed = arguments.size() > 6 ? arguments[6]->evaluate_integer() : 400000;
     return std::make_shared<ImuBno085>(name, port, sda_pin, scl_pin, int_pin, rst_pin, address, clk_speed);

--- a/main/modules/imu_bno085.cpp
+++ b/main/modules/imu_bno085.cpp
@@ -6,13 +6,14 @@
 
 #include "esp_log.h"
 
+// These pins are specific to the BNO085 module, so they live here rather than in module_helpers.h.
 #ifdef CONFIG_IDF_TARGET_ESP32S3
 // GPIO26 and GPIO32 carry SPI flash and PSRAM on the ESP32-S3, so there is no safe default here.
-#define DEFAULT_INT_PIN GPIO_NUM_NC
-#define DEFAULT_RST_PIN GPIO_NUM_NC
+#define DEFAULT_BNO085_INT_PIN GPIO_NUM_NC
+#define DEFAULT_BNO085_RST_PIN GPIO_NUM_NC
 #else
-#define DEFAULT_INT_PIN GPIO_NUM_26
-#define DEFAULT_RST_PIN GPIO_NUM_32
+#define DEFAULT_BNO085_INT_PIN GPIO_NUM_26
+#define DEFAULT_BNO085_RST_PIN GPIO_NUM_32
 #endif
 
 static Module_ptr create_imu_bno085(const std::string &name, const std::vector<ConstExpression_ptr> &arguments, MessageHandler) {
@@ -23,8 +24,8 @@ static Module_ptr create_imu_bno085(const std::string &name, const std::vector<C
     const i2c_port_t port = arguments.size() > 0 ? (i2c_port_t)arguments[0]->evaluate_integer() : I2C_NUM_0;
     const gpio_num_t sda_pin = arguments.size() > 1 ? (gpio_num_t)arguments[1]->evaluate_integer() : DEFAULT_I2C_SDA_PIN;
     const gpio_num_t scl_pin = arguments.size() > 2 ? (gpio_num_t)arguments[2]->evaluate_integer() : DEFAULT_I2C_SCL_PIN;
-    const gpio_num_t int_pin = arguments.size() > 3 ? (gpio_num_t)arguments[3]->evaluate_integer() : DEFAULT_INT_PIN;
-    const gpio_num_t rst_pin = arguments.size() > 4 ? (gpio_num_t)arguments[4]->evaluate_integer() : DEFAULT_RST_PIN;
+    const gpio_num_t int_pin = arguments.size() > 3 ? (gpio_num_t)arguments[3]->evaluate_integer() : DEFAULT_BNO085_INT_PIN;
+    const gpio_num_t rst_pin = arguments.size() > 4 ? (gpio_num_t)arguments[4]->evaluate_integer() : DEFAULT_BNO085_RST_PIN;
     const uint8_t address = arguments.size() > 5 ? arguments[5]->evaluate_integer() : 0x4A;
     const int clk_speed = arguments.size() > 6 ? arguments[6]->evaluate_integer() : 400000;
     return std::make_shared<ImuBno085>(name, port, sda_pin, scl_pin, int_pin, rst_pin, address, clk_speed);

--- a/main/modules/module_helpers.h
+++ b/main/modules/module_helpers.h
@@ -8,12 +8,20 @@
 #include <stdexcept>
 #include <string>
 
-#ifdef CONFIG_IDF_TARGET_ESP32S3
+// The strapping pins are used by the expander's pre-flash check; since an expander is flashed with our own
+// running partition, it is always the same target as we are and compile-time constants are sufficient.
+#if defined(CONFIG_IDF_TARGET_ESP32S3)
 #define DEFAULT_I2C_SDA_PIN GPIO_NUM_8
 #define DEFAULT_I2C_SCL_PIN GPIO_NUM_9
-#else
+#define BOOT_MODE_PIN 46
+#define FLASH_VOLTAGE_PIN 45
+#elif defined(CONFIG_IDF_TARGET_ESP32)
 #define DEFAULT_I2C_SDA_PIN GPIO_NUM_21
 #define DEFAULT_I2C_SCL_PIN GPIO_NUM_22
+#define BOOT_MODE_PIN 2
+#define FLASH_VOLTAGE_PIN 12
+#else
+#error "Unsupported IDF target: define its default and strapping pins here."
 #endif
 
 template <typename M>


### PR DESCRIPTION
Reviewing #248 prompted a repo-wide sweep for the same bug class: **magic literals that are only correct on the original ESP32.** Since the repo ships `sdkconfig.defaults.esp32s3` and the release workflow builds an `[esp32, esp32s3]` matrix, the S3 is a shipped target, so these are live bugs rather than hypotheticals.

Three sites survived the sweep. Most of the codebase came back clean — the negative result is folded below, because "what was checked and found fine" is the part that is expensive to re-derive.

| # | Site | Was | Breaks on | Now |
| --- | --- | --- | --- | --- |
| 1 | `imu_bno085.cpp` | `GPIO_NUM_26`, `GPIO_NUM_32` | **S3** — SPI flash / PSRAM pins, so the default constructor resets the chip | `GPIO_NUM_NC` on S3 |
| 2 | `expander.cpp` | pins `0`, `2`, `12` | **S3** — false abort, and no real guard | `0`, `46`, `45` on S3 |
| 3 | `core.cpp` | `BIT(0..5)` table | **S3** — wrong bits, **and ESP32 — the table was simply wrong** | table matching `soc/gpio_reg.h` |

Finding 3 is the awkward one: `core.get_pin_strapping()` has been reporting the wrong pin's bit on the **original ESP32** all along. That is a pre-existing bug rather than a portability fix, so say the word and I will split it into its own PR — I kept it here because it is the same "hardcoded target constants are wrong" theme and the same reviewer context.

**Verified on hardware** (ESP32-D0WD-V3): a controlled A/B on `GPIO_STRAP_REG`, plus a before/after of `core.get_pin_strapping()` itself on the same board. Finding 1's failure mode was reproduced on an S3 while reviewing #248. **Finding 2 is the one gap — static grounding only**, since I had no S3 expander pair to run `expander.flash()` against.

<details>
<summary><b>Finding 1</b> — <code>ImuBno085()</code> with default arguments resets an ESP32-S3</summary>

```cpp
const gpio_num_t int_pin = ... : GPIO_NUM_26;
const gpio_num_t rst_pin = ... : GPIO_NUM_32;
```

On the S3 both are flash/PSRAM pins:

- `soc/esp32s3/include/soc/io_mux_reg.h:116` — `#define IO_MUX_GPIO26_REG PERIPHS_IO_MUX_SPICS1_U`
- `soc/esp32s3/include/soc/io_mux_reg.h:122` — `#define IO_MUX_GPIO32_REG PERIPHS_IO_MUX_SPID_U`
- IDF docs, in an `.. only:: esp32s3` block: "GPIO26 - GPIO32 (commonly used for SPI Flash and PSRAM)" (`sd_pullup_requirements.rst:54`)

Driving the reset line takes the flash down with it. On an S3, `bno = ImuBno085()` resets the chip after ~1.4 s, 3/3 attempts:

```
rst:0x8 (TG1WDT_SYS_RST),boot:0x8 (SPI_FAST_FLASH_BOOT)
W (46) boot.esp32s3: PRO CPU has been reset by WDT.
```

Passing explicit pins (`ImuBno085(0, 8, 9, 4, 5)`) fails cleanly with `BNO085 initialization failed` and no reset — so only the defaults are wrong. Before #248 the module threw at bus setup, well before touching any GPIO, which is why this never surfaced.

**Fix:** `GPIO_NUM_NC` on S3, in a file-local target block (matching the `pwm_output.cpp` / `stepper_motor.cpp` precedent — `module_helpers.h` is left for genuinely shared constants like `DEFAULT_I2C_SDA_PIN`, which has three consumers). I deliberately did **not** invent S3 pin numbers, since I don't know the intended S3 wiring; `NC` is the only default that cannot take the flash down. `bno08x.cpp:95-101` guards both pins against `GPIO_NUM_NC` and never touches `int_pin` outside that block, so it degrades to polled INT plus I²C soft reset.

</details>

<details>
<summary><b>Finding 2</b> — the pre-flash strapping guard checks ESP32 pins on the S3 <b>(static evidence only)</b></summary>

`expander.flash()` asked the remote chip for `core.get_pin_status(0/2/12)` and aborted on GPIO2 high / warned on GPIO12 high. Those are the **ESP32's** straps. On the S3 the boot-mode and flash-voltage straps are GPIO0, GPIO46 and GPIO45:

- `sd_pullup_requirements.rst:52-53`, in an `.. only:: esp32s3` block — "GPIO0 (strapping pin)", "GPIO45, GPIO46 (strapping pins, internal weak pulldown)"
- `esp_hw_support/port/esp32s3/rtc_init.c:231-232` reads `strap_reg & BIT(5)` as the VDD_SPI voltage strap
- Espressif's [S3 schematic checklist](https://docs.espressif.com/projects/esp-hardware-design-guidelines/en/latest/esp32s3/schematic-checklist.html) puts boot mode on GPIO0 + GPIO46

So on an S3 the guard **falsely aborts** when an ordinary GPIO2 happens to be high, and **silently protects nothing**, because GPIO45/46 are never looked at.

Compile-time selection is sound here because `flashReplica` flashes `esp_ota_get_running_partition()` (`serial-replicator.cpp:208-222`) — our own binary — so the expander is always the same target. GPIO3 (JTAG select) is deliberately skipped; it doesn't affect boot or flashing.

The two-stage `strstr` collapsed to one because `"GPIO_Status[n]| Level: 1"` strictly implies `"GPIO_Status[n]|"`, and `[2]` cannot substring-match `[12]`.

> **This is the finding with no hardware behind it.** I have no pair of S3s wired as host/expander. If you have one, a before/after of `expander.flash()` is the check I could not run.

</details>

<details>
<summary><b>Finding 3</b> — <code>get_pin_strapping()</code> is target-blind <i>and</i> was wrong on the ESP32</summary>

**(a) Portability.** The pin→bit table is ESP32-only. `soc/esp32/include/soc/gpio_reg.h:132` documents the ESP32 field; `soc/esp32s3/include/soc/gpio_reg.h:167` leaves the description empty. The targets also decode different-width boot-mode fields — `IS_1XXXX(v) = (v & 0x10)` (5 bits) vs `IS_1XXX(v) = (v & 0x08)` (4 bits), `soc/*/boot_mode.h`. On the S3 the old code answered `get_pin_strapping(0)` from an unrelated bit and said "Not a strapping pin" for the pins that are ones. Since the S3 layout isn't documented in the headers, the new code prints the raw register there rather than guessing.

**(b) The ESP32 table was wrong.** Old: `GPIO0→BIT(0)`, `GPIO2→BIT(1)`, `GPIO15→BIT(2)`, `GPIO12→BIT(3)`, `GPIO5→BIT(4)`, `GPIO4→BIT(5)`. Three IDF sources contradict it and agree with each other:

| Source | Says |
| --- | --- |
| `soc/esp32/include/soc/gpio_reg.h:131-133` | `GPIO_STRAPPING` `[15:0]` = `{10'b0, MTDI, GPIO0, GPIO2, GPIO4, MTDO, GPIO5}` — MSB-first, so bit5=MTDI(12), bit4=GPIO0, bit3=GPIO2, bit2=GPIO4, bit1=MTDO(15), bit0=GPIO5 |
| `esp_hw_support/port/esp32/rtc_init.c:150-152` | reads `strap_reg & BIT(5)` as the VDD_SDIO strap = MTDI/GPIO12 → **bit5 is GPIO12, not GPIO4** |
| `soc/esp32/include/soc/boot_mode.h` | `IS_1XXXX(v) = ((v)&0x10)==0x10` is "SPI Boot", which ESP32 selects with GPIO0 high → **bit4 is GPIO0, not GPIO5** |

The old comment cited TRM "Register 4.13", which describes `GPIO_STRAPPING [15:0]` without naming per-bit pins — so the mapping looks inferred rather than read. Only the `BIT()` values change; the case order is untouched.

</details>

<details>
<summary><b>Hardware verification</b> — controlled A/B, plus a real before/after of the command itself</summary>

`GPIO_STRAP_REG` = `DR_REG_GPIO_BASE + 0x38` = **`0x3ff44038`** (`soc/reg_base.h:16` + `soc/gpio_reg.h:130`).

**Step 1 — isolate GPIO0's bit.** esptool enters download mode by holding **GPIO0 low**; a plain reset lets it float **high**. That makes GPIO0's latched level the only controlled variable:

| Reset condition | `GPIO_STRAP_REG` | `[5:0]` | Source |
| --- | --- | --- | --- |
| Download mode — GPIO0 **low** | `0x00000003` | `00 0011` | `esptool read_mem`, 3/3 identical |
| Normal boot — GPIO0 **high** | `0x13` | `01 0011` | ROM log `boot:0x13 (SPI_FAST_FLASH_BOOT)` |
| **XOR** | **`0x10`** | **bit 4** | |

Exactly one bit moved → **bit 4 is GPIO0**. The old table put GPIO0 at bit 0 and GPIO5 at bit 4.

**Step 2 — run the actual command, before and after.** Same board, same boot conditions, Lizard built from `main` vs from this branch:

| `core.get_pin_strapping(n)` | `main` | this PR | Physical truth |
| --- | --- | --- | --- |
| GPIO0 | 1 | 1 | 1 — booted from flash |
| GPIO2 | **1** | **0** | 0 |
| GPIO4 | 0 | 0 | 0 |
| GPIO5 | 1 | 1 | 1 — internal pull-up |
| GPIO12 (MTDI) | 0 | 0 | 0 — 3.3 V flash, board runs |
| GPIO15 (MTDO) | **0** | **1** | **1 — the ROM boot log is printing** |

Two pins disagree, and **GPIO15 settles it**: `main` reports MTDO low, i.e. ROM boot log disabled — while that very boot log is being read on the same UART in the same session. This PR's six answers reconstruct to `0b010011` = `0x13`, matching the ROM's own `boot:` value.

Being precise about what is *independently* pinned: bit 4 (GPIO0) by the controlled A/B, and bit 1 (MTDO) by the boot log. The remaining bits follow from the header layout and are consistent with both readings — this confirms the mapping, it is not a full reverse-engineering of every strap bit.

<sub>Board claimed via a shared-hardware lock and released after. Its 4 MB flash was backed up first, and <b>restored byte-for-byte afterwards</b> — post-restore <code>md5 58e6a820b7e0e9f2f04f3273a9d47333</code>, identical to the pre-experiment image. The bench build used a 4 MB partition table (this board is 4 MB; the shipped table needs 8 MB); that affects flash layout only, not strap-register decoding.</sub>

</details>

<details>
<summary><b>What else was swept, and found clean</b> — the negative result</summary>

Deliberately few findings rather than a padded list. These were checked and are **not** findings:

| Area | Why it's fine |
| --- | --- |
| ADC channels / units | `adc_oneshot_io_to_channel()` resolves pin→unit/channel at runtime |
| ADC calibration scheme | already target-guarded (curve vs line fitting) |
| LEDC speed mode / duty resolution | already target-guarded in `pwm_output.cpp`, `stepper_motor.cpp` |
| CAN / TWAI bit timing | `TWAI_TIMING_CONFIG_*` are per-target macros |
| Timing | `esp_timer_get_time()`; no APB/XTAL or 80 MHz assumption anywhere |
| UART0 | `UART_SCLK_DEFAULT`; `UART_NUM_0` exists on every target |
| PCNT | new `pulse_cnt` driver API, no channel-count literals |
| GPIO range checks | already `GPIO_NUM_MAX`, not `39` |
| DAC / touch / RMT / MCPWM / PSRAM | not used |

Two things looked at and left alone as out of scope:

- The `#ifdef CONFIG_IDF_TARGET_ESP32S3 / #else` idiom treats "not S3" as "ESP32" in five pre-existing places. That breaks the build *loudly* on C3/C6 (`LEDC_HIGH_SPEED_MODE` and line-fitting calibration don't exist there). Neither is a supported target and the failure is a compile error, not silent misbehaviour, so widening those felt like scope creep.
- `core.cpp` validates pins with `gpio_num < GPIO_NUM_MAX`, which admits the gaps (24, 28-31 on ESP32; 22-25 on S3) that `SOC_GPIO_VALID_GPIO_MASK` excludes. Pre-existing on both targets, so not variant-specific.

</details>

<details>
<summary><b>Build, lint, and second-lineage review</b></summary>

Built with the project's own entrypoint, IDF v5.3.1 in `espressif/idf:v5.3.1` (the version `compile.sh` and the release workflow pin), before and after:

```
python3 build.py esp32     --clean  →  Build completed successfully for esp32
python3 build.py esp32s3   --clean  →  Build completed successfully for esp32s3
```

`pre-commit` (clang-format, mdformat, whitespace) clean.

Reviewed by **Codex (GPT-5.2)** as an adversarial second lineage — different model family, read-only, handed the header paths and told to verify every citation itself rather than trust mine. Two rounds; its first-round wording fix is applied. Final: **9/10, no blocking findings**, and it independently confirmed the six pin→bit pairs, that `GPIO_NUM_NC` degrades cleanly, and that collapsing the `strstr` pair is equivalent. On the riskiest claim:

> The ESP32 strap bit-order correction is supported by `gpio_reg.h`, `rtc_init.c`, and `boot_mode.h`; I do not see a defensible reading where the original mapping was right.

A four-angle cleanup pass (reuse / simplification / efficiency / altitude) also ran; it moved the BNO085 defaults to file scope and trimmed a comment. It explicitly declined a switch→table rewrite in `core.cpp`, a compile-time-stringify micro-optimisation in `expander.cpp` (that path already does `clear_nvs()` and multiple `delay(100)`s), and normalising the `#ifdef` polarity — `core.cpp`'s positive `CONFIG_IDF_TARGET_ESP32` form falls through to "layout unknown" for a future target instead of silently applying ESP32 values.

</details>
