### PR TITLE
Stop hammering the UART driver after it is deinstalled

### DIFF
--- a/main/modules/expander.cpp
+++ b/main/modules/expander.cpp
@@ -230,6 +230,7 @@ void Expander::check_strapping_pins(const char *buffer) {
 
 void Expander::deinstall() {
     this->serial->deinstall();
+    this->properties.at("is_ready")->boolean_value = false;
     if (this->boot_pin != GPIO_NUM_NC && this->enable_pin != GPIO_NUM_NC) {
         gpio_reset_pin(this->boot_pin);
         gpio_reset_pin(this->enable_pin);

--- a/main/modules/serial.cpp
+++ b/main/modules/serial.cpp
@@ -116,7 +116,7 @@ int Serial::available() const {
 }
 
 bool Serial::has_buffered_lines() const {
-    return uart_pattern_get_pos(this->uart_num) != -1;
+    return uart_is_driver_installed(this->uart_num) && uart_pattern_get_pos(this->uart_num) != -1;
 }
 
 void Serial::flush() const {


### PR DESCRIPTION
Fixes #257.

Partially addresses #259 and deliberately does **not** close it: the receive-side flood is gone, but a *coordinator* `SerialBus` still writes through an unguarded `write_checked_line()` (`serial_bus.cpp:131` → `:318`) at roughly the poll rate, and the explicit comm-task teardown that #259 itself calls "longer term" is not included.

**TL;DR** — Two lines. `Serial::has_buffered_lines()` gets the `uart_is_driver_installed()` guard that `Serial::available()` already has, and `Expander::deinstall()` marks the expander not-ready. This kills the log flood from both issues. Not verified on hardware — see Progress.

### Motivation

Issues #259 and #257 are the same root cause seen from two angles, and both were diagnosed down to the mechanism by Jens Ogorek. This PR implements his diagnosis.

`Serial::available()` guards its IDF call with `uart_is_driver_installed()` and returns 0 when the driver is gone. `Serial::has_buffered_lines()` did not — it was a bare `uart_pattern_get_pos()`. So after `p0.disconnect()`, `SerialBus::process_uart()` kept spinning that call at roughly 1 kHz against a deleted driver, and every call logged a UART driver error. That is #259.

Separately, `Expander::deinstall()` tore the driver down but left the module in `Global::modules` with `is_ready == true`, so `Expander::step()` kept calling `ping()` and `handle_messages()` at ~100 Hz until the ping timeout eventually flipped the flag. That is the write/read spam in #257.

### Implementation

`Serial::has_buffered_lines()` short-circuits on `uart_is_driver_installed()`, mirroring `Serial::available()` exactly. `Expander::deinstall()` clears `is_ready`, so `Expander::step()` stops touching the link immediately instead of waiting out the 1 s / 2 s ping timeout.

Nothing changes while a driver is installed: the added call is a bounds/null check, which is why the same pattern is already considered acceptable in `available()` on the same hot path.

<details>
<summary><b>Mechanism, with file:line</b></summary>

- `main/modules/serial.cpp:109-113` — `Serial::available()` already returns 0 when `!uart_is_driver_installed(this->uart_num)`.
- `main/modules/serial.cpp:118` — `has_buffered_lines()` was `return uart_pattern_get_pos(this->uart_num) != -1;`, no guard.
- `main/modules/serial_bus.cpp:165` — `SerialBus::process_uart()` loops on `has_buffered_lines()` from the pinned communication task, which has no timeout exit. This is the ~1 kHz spam path in #259.
- `main/modules/expander.cpp:72-74` — `Expander::step()` only pings and handles messages while `is_ready` is true.
- `main/modules/expander.cpp:231` — `Expander::deinstall()` now clears `is_ready` right after `serial->deinstall()`.

Bonus, and part of why the guard is worth having beyond the log noise: in IDF v5.3.1, `uart_pattern_get_pos()` (`uart.c:567`) checks only `p_uart_obj[uart_num]` and has **no** `uart_num < UART_NUM_MAX` bounds check, unlike its siblings. `uart_is_driver_installed()` (`uart.c:1806`) does bounds-check. Since `Serial(rx, tx, baud, uart_num)` never validates `uart_num`, a Lizard one-liner such as `Serial(26, 27, 115200, 99)` previously indexed a 3-element static array out of bounds. The short-circuit closes that path too.
</details>

<details>
<summary><b>Flash path: does clearing <code>is_ready</code> break it?</b> — no, checked every caller</summary>

`Expander::flash()` calls `deinstall()` (`expander.cpp:187`), flashes, saves startup, calls `reinitialize_after_flash()` (`:196`), and on success calls `restart()` (`:200`) — and `restart()` (`:128`) **already** sets `is_ready = false` and re-enters boot detection. So the post-flash state is unchanged by this PR. If flashing fails, the expander stays not-ready, which is the correct state.

Related question a reviewer will ask: **does `is_ready` ever come back after a `disconnect()`?** No. `check_boot_progress()` (`:80`) is the only writer of `is_ready = true` (`:93`), and it runs only from the constructor loop (`:60-66`). This is **not** introduced here — `Expander::restart()` (`:128`) and the ping timeout (`:113`) already reach the same terminal state on main today. Arguably worth its own issue; deliberately out of scope for this PR.
</details>

<details>
<summary><b>Build evidence — both targets</b></summary>

```
Build completed successfully for esp32
lizard.bin binary size 0x13ba40 bytes. Smallest app partition is 0x1f0000 bytes. 0xb45c0 bytes (36%) free.

Build completed successfully for esp32s3
lizard.bin binary size 0x139ca0 bytes. Smallest app partition is 0x1f0000 bytes. 0xb6360 bytes (37%) free.
```
Full clean builds (`rm -rf build sdkconfig sdkconfig.old` between targets — removing only `sdkconfig` is not enough, `build/CMakeCache.txt` retains the target and `idf.py` aborts with *"Target settings are not consistent"*).
</details>

<details>
<summary><b>Adversarial review — verbatim second-lineage verdict (OpenAI Codex, gpt-5.5)</b></summary>

```
Verdict: no blockers for the minimal diff as scoped, but it only partially fixes #259. #257 looks closed.

**BLOCKERS**

None found.

**SUGGESTIONS**

#257 is effectively closed. After `p0.disconnect()`, `Expander::deinstall()` now clears `is_ready` at expander.cpp:231, and `Expander::step()` only calls `ping()` / `handle_messages()` while `is_ready` is true at expander.cpp:71. That stops the 100 Hz write/read spam immediately after disconnect. The new `has_buffered_lines()` guard at serial.cpp:118 also prevents the `uart_pattern_get_pos()` error if a caller still checks after deinstall.

#259 is receive-side fixed, not task-teardown fixed. `SerialBus::process_uart()` now exits cleanly when the driver is already deleted because its loop condition goes through guarded `has_buffered_lines()` at serial_bus.cpp:163. However, the comm task still runs forever. If the bus is a coordinator, it can still call `send_message()` at serial_bus.cpp:131, which reaches unguarded `write_checked_line()` at serial_bus.cpp:318. Concrete residual: after driver deletion with `peer_ids` configured, polling attempts still produce `uart_write_bytes` errors roughly once per poll timeout, not at the former ~1 kHz receive-loop rate. That matches the issue's "longer term teardown" note, so I would not block this minimal fix on it.

The flash path is not broken by setting `is_ready = false`. `flash` calls `deinstall()` at expander.cpp:187, then flashes, saves startup, calls `reinitialize_after_flash()` at expander.cpp:196, and on success calls `restart()` at expander.cpp:200, which already sets `is_ready = false` and starts boot detection state. If flashing fails, the serial driver has still been reinitialized before throwing, but the expander remains not ready, which is consistent with failure.

Concurrency: the new `uart_is_driver_installed() && uart_pattern_get_pos()` has a TOCTOU window if another core deletes the UART driver between the two calls. That window already existed around all UART calls; this change narrows the common dead-driver path and does not make it worse. `read_line()` still has unguarded `uart_pattern_pop_pos()` at serial.cpp:132, but it is only reached after `has_buffered_lines()` returns true, so only the same pre-existing deletion race can hit it. The new `is_ready` write is read by the main loop's `Expander::step()`, not by the SerialBus task.

Exception/re-entrancy: `properties.at("is_ready")` should not throw on reachable `Expander::deinstall()` paths because `properties = Expander::get_defaults()` is populated in the constructor before `restart()` and before any `call()`. `deinstall()` is not a destructor path. Placement after `serial->deinstall()` is acceptable for current single-main-loop calls; moving it before would only reduce the theoretical interval where an already-deinstalled serial has `is_ready == true`.

Normal installed-driver behavior is unchanged. Cost-wise, the added `uart_is_driver_installed()` is just a bounds/null check and matches `available()`'s existing pattern, so ~1 kHz use in the bus task is not a concern.
```
</details>

<details>
<summary><b>Deliberately out of scope — the honest residual on #259</b></summary>

**This does not fully close issue 259, and I would rather say so than have you find it.** The receive-side flood is dead. But the communication task still runs forever, so a **coordinator** `SerialBus` still reaches unguarded `write_checked_line()` via `send_message()` (`serial_bus.cpp:131` → `:318`): after driver deletion with `peer_ids` configured, you should still see `uart_write_bytes` errors at roughly the poll rate (`POLL_TIMEOUT_MS = 250`, `serial_bus.cpp:19`) plus a "poll timed out" warning — instead of the previous ~1 kHz. A non-coordinator bus goes fully silent.

The proper fix is the explicit `SerialBus::disconnect()` / teardown that stops the comm task *before* the driver goes away — which #259 itself files under "longer term". That is a design change and belongs in its own discussion, not in this two-line guard.

Also unchanged, and correctly so: `Proxy::call` and `Proxy::write_property` (`proxy.cpp:24,28`) still write to the expander after `disconnect()`. They are user-command-triggered rather than loop-rate so they cannot flood, but they are the remaining source of the "occasional `uart_write_bytes(1455)` errors" in #257 if someone pokes a proxy post-disconnect.
</details>

### Progress

- [x] The implementation is complete.
- [x] Tested on hardware. **Done — by @JensOgorek, not by me.** I have no Robot Brain + P0 expander here; my own ceiling was green builds for both targets plus static analysis and an adversarial second-lineage review. On F31/rb67, in an 8 s capture after `p0.disconnect()`: `uart_pattern_get_pos(569)` driver errors **223 → 0**, `uart_write_bytes(1455)` errors **2 → 0**, and the `expander p0 connection lost` warning gone — that last one being the direct read-out of the `is_ready` half of the diff rather than of traffic volume. [Full measurement and its one setup caveat](https://github.com/zauberzeug/lizard/pull/261#issuecomment-5203457638). I have deliberately not used a closing keyword so this does not auto-close on merge.
- [x] Documentation has been updated (or is not necessary). No user-visible language change.


