### PR TITLE
Restore expander boot pin on a failed strapping-pin check

### DIFF
--- a/main/modules/expander.cpp
+++ b/main/modules/expander.cpp
@@ -182,7 +182,12 @@ void Expander::call(const std::string method_name, const std::vector<ConstExpres
             this->serial->write_checked_line("core.get_pin_status(2)");
             this->serial->write_checked_line("core.get_pin_status(12)");
             delay(100);
-            this->handle_messages(true);
+            try {
+                this->handle_messages(true);
+            } catch (...) {
+                gpio_set_level(this->boot_pin, 1);
+                throw;
+            }
         }
         deinstall();
         bool success = ZZ::Replicator::flashReplica(this->serial->uart_num,


### PR DESCRIPTION
**TL;DR** — Six lines, one file. If the pre-flash strapping check throws, `boot_pin` stayed LOW and the next natural P0 reset dropped into the ROM bootloader. Restore it and rethrow. This is the issue's **side finding only** — the headline first-attempt TIMEOUT is untouched.

### Motivation

Issue #255 — expander flashing reliably fails on the first attempt with `Error while connecting: TIMEOUT`, and succeeds on the second. Jens Ogorek recorded a side finding while diagnosing it, and that side finding is a real, self-contained bug that this PR fixes.

In `Expander::flash()`, the code drives `boot_pin` LOW, then runs the remote strapping-pin check via `handle_messages(true)`. If that check throws, the function aborts **before** reaching `deinstall()` with `boot_pin` still LOW — so the next natural P0 reset enters the ROM bootloader unintentionally. Which is exactly the kind of state that makes a subsequent flash attempt behave differently from the first.

### Implementation

Wrap the `handle_messages(true)` call in `try`/`catch(...)`, restore `boot_pin` HIGH, and rethrow unchanged. `gpio_set_level(..., 1)` matches the boot-pin idle level the constructor establishes at `main/modules/expander.cpp:55`.

No new exception is introduced and nothing is swallowed — the original error text reaching `main.cpp` is byte-identical to before, e.g. `error processing uart0: GPIO0 current state is HIGH - must be LOW for boot mode`. Relevant because CONTRIBUTING.md:91 asks that exceptions be used sparingly.

<details>
<summary><b>Which throws this actually covers — more than the commit subject says</b></summary>

Between `gpio_set_level(this->boot_pin, 0)` (`main/modules/expander.cpp:179`) and `deinstall()` (`:192`), the guard wraps the whole `handle_messages(true)` call, so it covers:

- ~~`Serial::read_line` throws — `main/modules/serial.cpp:139` *"buffer too small, but cannot discard line. flushed serial."* and `:144` *"buffer too small. discarded line."*~~ **Struck: true only on `main` as it stands today.** #262 wraps that `read_line()` call inside `Expander::handle_messages()` in its own catch that echoes and `continue`s, so once #262 lands the throw never propagates out of `handle_messages(true)` and can no longer reach this guard. Caught by @JensOgorek — the merge order of the two PRs decides which paths this guard is protecting.
- `check_strapping_pins()` — `main/modules/expander.cpp:226` and `:231`
- any throw from the `message_handler` callback (`:149`) during normal Lizard processing
- theoretically, an `echo()` callback (`main/utils/uart.cpp:33`) or the `std::string` allocation inside `check()` (`:63`) — surfaced by a second-lineage re-enumeration of this list, not realistic in practice

The three `write_checked_line()` calls do not throw, `delay()` does not throw, and `Storage::clear_nvs()` runs *before* the pin is pulled low, so an NVS failure there leaves the pin in its pre-existing high state. The `catch(...)` breadth is deliberate, not accidental over-reach.
</details>

<details>
<summary><b>Where the bootloader-entry retry lives — investigated, and it is not ours</b></summary>

Jens's second suggestion was to include the bootloader-entry reset sequence in the retry loop. That code is in **`components/esp32-serial-flasher`**, a vendored submodule (upstream `espressif/esp-serial-flasher`), not in Lizard's own sources. `ZZ::Replicator::connect()` and `loader_port_enter_bootloader()` are not Lizard code, so a retry there is a submodule bump plus an upstream change — unverifiable without the hardware and out of scope for this PR.

The NAND-polarity question in the issue is left open deliberately: the Robot Brain schematic is not available here, and guessing at a polarity change in code would be exactly the wrong move.
</details>

<details>
<summary><b>Build evidence — both targets</b></summary>

```
Build completed successfully for esp32
lizard.bin binary size 0x13ba20 bytes. Smallest app partition is 0x1f0000 bytes. 0xb45e0 bytes (36%) free.

Build completed successfully for esp32s3
lizard.bin binary size 0x139c80 bytes. Smallest app partition is 0x1f0000 bytes. 0xb6380 bytes (37%) free.
```
The built artifact was independently checked to actually contain the new code rather than trusting the log text.
</details>

<details>
<summary><b>Adversarial review — verbatim second-lineage verdict (OpenAI Codex, gpt-5.5)</b></summary>

```
BLOCKERS: none.

SUGGESTIONS:
- none

VERDICT: ship. I could not refute this narrow fix. Between main/modules/expander.cpp:179 and `deinstall()` at main/modules/expander.cpp:192, the only realistic throwing path is inside `handle_messages(true)`: `Serial::read_line()` can throw at main/modules/serial.cpp:139, `check_strapping_pins()` throws at main/modules/expander.cpp:226, and the `message_handler` callback can throw via normal Lizard processing. The three `write_checked_line()` calls do not throw, `delay()` does not throw, and `Storage::clear_nvs()` is before the pin is pulled low, so an NVS failure there leaves the pin in its pre-existing high state. Later failures after `deinstall()` are unchanged by this diff and do not match the side-finding mechanism; `flashReplica()` reinitializes/drives GPIO0 high during bootloader entry, and the explicit `could not flash expander` throw is not made worse. `gpio_set_level(..., 1)` is consistent with the constructor's boot-pin idle level at main/modules/expander.cpp:55. Exceptions are enabled in both default configs, and the bare rethrow preserves the original runtime error message for the existing `main.cpp` catches. Confidence: high for this minimal side-finding fix.
```
</details>

<details>
<summary><b>Deliberately out of scope</b></summary>

- **The headline complaint of #255 is not fixed.** First-attempt `esp_loader_connect()` TIMEOUT is untouched.
- The abort paths **after** `deinstall()` — `Storage::save_startup()` at `expander.cpp:197` can throw on NVS failure, and there is the explicit *"could not flash expander"* throw at `:202` — leave `boot_pin` in whatever state esp-serial-flasher's deiniter left it. That is squarely the issue's main complaint territory (undefined pin state across the loader) and is unchanged here. Considered, not missed.
- NAND polarity: no schematic available, so no guess.
</details>

### Progress

- [x] The implementation is complete.
- [ ] Tested on hardware (or is not necessary). **Not done — and @JensOgorek has since argued it may not be safely triggerable at all.** He reviewed the change on real hardware and found nothing blocking, but could not provoke the guard: the only remaining throw is a genuine strapping-pin failure, which on a live Feldfreund means deliberately driving the P0's GPIO2. He also established that the obvious verification route is closed — `core.get_pin_status(25)` reports `Level: 0 | InputEn: 0 | OutputEn: 1`, i.e. with the input buffer disabled the `Level` field does not reflect the driven output level, so the boot pin's state cannot be read back this way. Ceiling therefore stands at green builds for both targets, static analysis, adversarial review, and his review. No closing keyword: #255's main problem is still live and this must not auto-close it.
- [x] Documentation has been updated (or is not necessary). No user-visible language change.
