### PR TITLE
Pack requirements-macos.txt into the release zip-file

### DIFF
--- a/.github/zip_content.txt
+++ b/.github/zip_content.txt
@@ -8,4 +8,5 @@ monitor.py
 upload_ssh.py
 README.md
 requirements.txt
+requirements-macos.txt
 LICENSE


### PR DESCRIPTION
### Motivation

Since #204 split the Python requirements, `requirements.txt` starts with `-r requirements-macos.txt`. The release packaging list `.github/zip_content.txt` was not updated accordingly, so the `lizard_firmware_and_devtools_*.zip` assets ship a `requirements.txt` whose include target is missing. Installing from the zip fails with `failed to read from file 'requirements-macos.txt': No such file or directory` — this broke the RoSys v0.35.0 Docker build (https://github.com/zauberzeug/rosys/actions/runs/31081873200), which installs the requirements from the latest Lizard release zip. The v0.13.0 assets have been patched in place; this PR fixes the packaging for future releases.

### Implementation

Add `requirements-macos.txt` to `.github/zip_content.txt` so it is packed into the release zip alongside `requirements.txt`.

### Progress

- [x] The implementation is complete.
- [x] Test on hardware is not necessary.
- [x] Documentation is not necessary.
