### PR TITLE
Read the ODrive's motor current over CAN

### DIFF
--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -512,8 +512,8 @@ The `motor_temperature` will only update if the firmware generated from the
 Otherwise, the `motor_temperature` property will remain at 0.
 
 The ODrive sends its current only when asked to, so `current` and `current_setpoint` stay at 0
-until the periodic message is switched on for the axis — `<axis>.config.can.iq_rate_ms` defaults
-to 0 and is the interval in milliseconds.
+until the periodic message is switched on for the axis — `<axis>.config.can.iq_rate_ms` (requires version 0.5.6)
+defaults to 0 and is the interval in milliseconds.
 
 | Methods                        | Description                            | Arguments        |
 | ------------------------------ | -------------------------------------- | ---------------- |

--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -504,10 +504,16 @@ Version 0.5.6 allows to read the motor error flag.
 | `motor.motor_error`       | Motor error flat (requires version 0.5.6) | `int`     |
 | `motor.enabled`           | Whether the motor is enabled              | `bool`    |
 | `motor.motor_temperature` | Motor temperature (°C)                    | `float`   |
+| `motor.current`           | Measured motor current Iq (A)             | `float`   |
+| `motor.current_setpoint`  | Commanded motor current Iq (A)            | `float`   |
 
 The `motor_temperature` will only update if the firmware generated from the
 [zauberzeug/ODrive](https://github.com/zauberzeug/ODrive) fork is installed on the ODrive.
 Otherwise, the `motor_temperature` property will remain at 0.
+
+The ODrive sends its current only when asked to, so `current` and `current_setpoint` stay at 0
+until the periodic message is switched on for the axis — `<axis>.config.can.iq_rate_ms` defaults
+to 0 and is the interval in milliseconds.
 
 | Methods                        | Description                            | Arguments        |
 | ------------------------------ | -------------------------------------- | ---------------- |

--- a/main/modules/odrive_motor.cpp
+++ b/main/modules/odrive_motor.cpp
@@ -28,6 +28,8 @@ const std::map<std::string, Variable_ptr> ODriveMotor::get_defaults() {
         {"axis_error", std::make_shared<IntegerVariable>()},
         {"motor_error_flag", std::make_shared<IntegerVariable>()},
         {"motor_temperature", std::make_shared<NumberVariable>()},
+        {"current", std::make_shared<NumberVariable>()},
+        {"current_setpoint", std::make_shared<NumberVariable>()},
         {"enabled", std::make_shared<BooleanVariable>(true)},
     };
 }
@@ -40,6 +42,7 @@ ODriveMotor::ODriveMotor(const std::string name, const Can_ptr can, const uint32
 void ODriveMotor::subscribe_to_can() {
     this->can->subscribe(this->can_id + 0x001, std::static_pointer_cast<Module>(this->shared_from_this()));
     this->can->subscribe(this->can_id + 0x009, std::static_pointer_cast<Module>(this->shared_from_this()));
+    this->can->subscribe(this->can_id + 0x014, std::static_pointer_cast<Module>(this->shared_from_this()));
     this->can->subscribe(this->can_id + 0x01e, std::static_pointer_cast<Module>(this->shared_from_this()));
 }
 
@@ -130,6 +133,15 @@ void ODriveMotor::handle_can_msg(const uint32_t id, const int count, const uint8
             ticks_per_second *
             (this->properties.at("reversed")->boolean_value ? -1 : 1) *
             this->properties.at("m_per_tick")->number_value;
+        break;
+    }
+    case 0x014: {
+        float iq_setpoint;
+        std::memcpy(&iq_setpoint, data, 4);
+        this->properties.at("current_setpoint")->number_value = iq_setpoint;
+        float iq_measured;
+        std::memcpy(&iq_measured, data + 4, 4);
+        this->properties.at("current")->number_value = iq_measured;
         break;
     }
     case 0x01e: {

--- a/main/modules/odrive_motor.cpp
+++ b/main/modules/odrive_motor.cpp
@@ -136,12 +136,13 @@ void ODriveMotor::handle_can_msg(const uint32_t id, const int count, const uint8
         break;
     }
     case 0x014: {
+        const int sign = this->properties.at("reversed")->boolean_value ? -1 : 1;
         float iq_setpoint;
         std::memcpy(&iq_setpoint, data, 4);
-        this->properties.at("current_setpoint")->number_value = iq_setpoint;
+        this->properties.at("current_setpoint")->number_value = iq_setpoint * sign;
         float iq_measured;
         std::memcpy(&iq_measured, data + 4, 4);
-        this->properties.at("current")->number_value = iq_measured;
+        this->properties.at("current")->number_value = iq_measured * sign;
         break;
     }
     case 0x01e: {


### PR DESCRIPTION
**Adds `0x014` (Get_Iq) to `ODriveMotor`, so the motor current the board already measures reaches Lizard.** Two properties, one subscription, one `case` — mirroring the existing encoder-estimate decode.

Untested on hardware — the flash needs someone at the bench. Reviewed first on the fork as evnchn/lizard PR 16.

<details>
<summary><b>Byte layout — verified against the firmware, not assumed</b></summary>

From `zauberzeug/ODrive`, branch `zz-0.5.6`, `CANSimple::get_iq_callback`:

```cpp
can_setSignal<float>(txmsg, Idq_setpoint->second, 0, 32, true);
can_setSignal<float>(txmsg, axis.motor_.current_control_.Iq_measured_, 32, 32, true);
```

Bytes 0–3 are the **setpoint**, bytes 4–7 the **measurement**, `isIntel = true` so little-endian — the same assumption the existing `0x009` decode already makes.

`MSG_GET_IQ` is 0x014, cross-checked rather than counted from a table: it is the 19th entry after `MSG_ODRIVE_ESTOP`, and the same arithmetic puts `MSG_GET_ENCODER_ESTIMATES` on 0x009 — which is exactly what this module already subscribes to.
</details>

<details>
<summary><b>Why both properties stay at 0 by default</b></summary>

The ODrive sends this message only when asked: `<axis>.config.can.iq_rate_ms` defaults to `0`. On the ts2 stand both axes read `0`, which is why the bench has always shown `0.00 A` — the board measures fine (`Iq_measured` over USB reads −0.02 A at rest and peaks of 1.9 A / 3.3 A during a move), it simply never broadcasts.

That is the same shape as the existing `motor_temperature`, which depends on the zauberzeug ODrive fork and is documented as remaining 0 otherwise, so the new properties are documented next to it.
</details>

<details>
<summary><b>Build</b></summary>

Green on ESP-IDF v5.3.1 (the version `release.yml` pins): `lizard.bin` generated, 36% of the app partition free.

Three things blocked a fresh-checkout build, none of them this change — recording them because they will bite the next person:

1. submodules not initialised → `Failed to resolve component 'esp32-serial-flasher'`
2. `compile.sh` runs a bare `idf.py build`, which does **not** apply `sdkconfig.defaults.esp32`. Without it `CONFIG_COMPILER_CXX_EXCEPTIONS` is off and every `throw` in the tree becomes `error: exception handling disabled`. A control build of **unmodified** upstream failed identically, which is how I know it was environmental.
3. `CONFIG_ZZ_BLE_DEV_PIN` needs `sdkconfig.defaults.secret`, copied from the template.

What worked: `idf.py -DSDKCONFIG_DEFAULTS="sdkconfig.defaults.esp32;sdkconfig.defaults.secret" set-target esp32 build`. Teaching `compile.sh` to do that would be a separate small PR.
</details>

Downstream, this is the last missing piece of three: the ODrive side is stock and merely switched off, and the host side already parses two currents behind a config flag (`zauberzeug/feldfreund` PR 584). After this, showing current in the panel is one config line plus persisting `iq_rate_ms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
