### PR TITLE
Report serial bus inbound drops and guard the echo relay

### DIFF
--- a/main/modules/serial_bus.cpp
+++ b/main/modules/serial_bus.cpp
@@ -17,10 +17,16 @@ extern void process_line(const char *line, const int len);
 
 static constexpr size_t FRAME_BUFFER_SIZE = 512;
 static constexpr unsigned long POLL_TIMEOUT_MS = 250;
-// ~264 bytes per slot; outbound must stay above WINDOW = 8 in otb_update.py, or a stalled
-// poll (outbound drains on the comm task, gated by !is_polling) aborts an OTB update.
-static constexpr size_t OUTGOING_QUEUE_LENGTH = 16;
-static constexpr size_t INCOMING_QUEUE_LENGTH = 8;
+// NOTE: each slot costs sizeof(OutgoingMessage) / sizeof(IncomingMessage) bytes of heap.
+// Both queues must stay above otb::BUS_OTB_WINDOW: the peer's inbound queue legitimately holds the whole
+// window while step() is stalled by a flash write, and the coordinator's outbound queue only drains
+// between polls, so a single stalled poll (POLL_TIMEOUT_MS) would otherwise abort an OTB update.
+// The outbound queue is shared by all receivers and stops draining for POLL_TIMEOUT_MS whenever a peer
+// is unreachable, so it stays at 32 to keep serving the healthy peers at full rate in that case.
+static constexpr size_t OUTGOING_QUEUE_LENGTH = 32;
+static constexpr size_t INCOMING_QUEUE_LENGTH = 16;
+static_assert(OUTGOING_QUEUE_LENGTH > otb::BUS_OTB_WINDOW);
+static_assert(INCOMING_QUEUE_LENGTH > otb::BUS_OTB_WINDOW);
 static constexpr const char ECHO_CMD[] = "__ECHO__";
 static constexpr const char POLL_CMD[] = "__POLL__";
 static constexpr const char DONE_CMD[] = "__DONE__";
@@ -74,10 +80,12 @@ void SerialBus::step() {
         this->handle_incoming_message(message);
     }
 
-    // the communication task cannot echo() itself, and a full inbound queue would swallow its warnings
-    const uint32_t dropped = this->dropped_inbound.exchange(0);
-    if (dropped > 0) {
-        echo("warning: serial bus %s dropped %u inbound messages (queue full)", this->name.c_str(), (unsigned)dropped);
+    // the communication task must not echo() itself, and a full inbound queue would swallow its warnings,
+    // so drops are counted there and reported here, at most once per second
+    if (this->dropped_inbound > 0 && millis_since(this->last_drop_report_millis) > 1000) {
+        const unsigned dropped = this->dropped_inbound.exchange(0);
+        this->last_drop_report_millis = millis();
+        echo("warning: serial bus %s dropped %u inbound messages (queue full)", this->name.c_str(), dropped);
     }
 
     if (this->otb_session.handle != 0) {
@@ -201,16 +209,20 @@ void SerialBus::process_uart() {
 
         // handle done command
         if (std::strcmp(message.payload, DONE_CMD) == 0) {
-            if (message.sender == this->peer_ids[this->poll_index]) {
+            if (this->is_coordinator() && message.sender == this->peer_ids[this->poll_index]) {
                 this->is_polling = false;
             }
             continue;
         }
 
-        // enqueue message in inbound queue; a warning could not pass the full queue either, so count the drop
-        if (xQueueSend(this->inbound_queue, &message, 0) != pdTRUE) {
-            this->dropped_inbound++;
-        }
+        this->push_incoming(message);
+    }
+}
+
+void SerialBus::push_incoming(const IncomingMessage &message) {
+    // a warning could not pass the full queue either, so count the drop and let step() report it
+    if (xQueueSend(this->inbound_queue, &message, 0) != pdTRUE) {
+        this->dropped_inbound++;
     }
 }
 
@@ -330,15 +342,13 @@ void SerialBus::send_message(const uint8_t receiver, const char *payload, const 
     this->serial->write_checked_line(buffer, header_len + length);
 }
 
-void SerialBus::print_to_incoming_queue(const char *format, ...) const {
+void SerialBus::print_to_incoming_queue(const char *format, ...) {
     IncomingMessage message{this->node_id, this->node_id, 0, {}};
     va_list args;
     va_start(args, format);
     message.length = std::vsnprintf(message.payload, PAYLOAD_CAPACITY, format, args);
     va_end(args);
-    if (xQueueSend(this->inbound_queue, &message, 0) != pdTRUE) {
-        this->dropped_inbound++;
-    }
+    this->push_incoming(message);
 }
 
 void SerialBus::handle_echo(const char *line) {
@@ -354,6 +364,8 @@ void SerialBus::handle_echo(const char *line) {
     try {
         this->enqueue_outgoing_message(this->echo_target_id, payload, len);
     } catch (const std::runtime_error &e) {
+        // echo() calls back into handle_echo(); stop relaying so the warning is not relayed (and fails) recursively
+        this->echo_target_id = 0;
         echo("warning: serial bus %s failed to relay output: %s", this->name.c_str(), e.what());
     }
 }

--- a/main/modules/serial_bus.cpp
+++ b/main/modules/serial_bus.cpp
@@ -17,9 +17,10 @@ extern void process_line(const char *line, const int len);
 
 static constexpr size_t FRAME_BUFFER_SIZE = 512;
 static constexpr unsigned long POLL_TIMEOUT_MS = 250;
-// 8 slots x ~264 bytes per direction; the queues are drained every main-loop step and
-// senders pace themselves (enqueue blocks up to 50 ms), so deeper queues only cost heap.
-static constexpr size_t OUTGOING_QUEUE_LENGTH = 8;
+// 8 inbound slots x ~264 bytes; the inbound queue is drained every main-loop step, so deeper
+// only costs heap. The outbound queue is drained by the communication task (gated by
+// !is_polling) and must stay above WINDOW = 8 in otb_update.py, or a stalled poll aborts OTB.
+static constexpr size_t OUTGOING_QUEUE_LENGTH = 16;
 static constexpr size_t INCOMING_QUEUE_LENGTH = 8;
 static constexpr const char ECHO_CMD[] = "__ECHO__";
 static constexpr const char POLL_CMD[] = "__POLL__";

--- a/main/modules/serial_bus.cpp
+++ b/main/modules/serial_bus.cpp
@@ -17,8 +17,10 @@ extern void process_line(const char *line, const int len);
 
 static constexpr size_t FRAME_BUFFER_SIZE = 512;
 static constexpr unsigned long POLL_TIMEOUT_MS = 250;
-static constexpr size_t OUTGOING_QUEUE_LENGTH = 32;
-static constexpr size_t INCOMING_QUEUE_LENGTH = 32;
+// 8 slots x ~264 bytes per direction; the queues are drained every main-loop step and
+// senders pace themselves (enqueue blocks up to 50 ms), so deeper queues only cost heap.
+static constexpr size_t OUTGOING_QUEUE_LENGTH = 8;
+static constexpr size_t INCOMING_QUEUE_LENGTH = 8;
 static constexpr const char ECHO_CMD[] = "__ECHO__";
 static constexpr const char POLL_CMD[] = "__POLL__";
 static constexpr const char DONE_CMD[] = "__DONE__";
@@ -70,6 +72,12 @@ void SerialBus::step() {
     IncomingMessage message;
     while (xQueueReceive(this->inbound_queue, &message, 0) == pdTRUE) {
         this->handle_incoming_message(message);
+    }
+
+    // the communication task cannot echo() itself, and a full inbound queue would swallow its warnings
+    const uint32_t dropped = this->dropped_inbound.exchange(0);
+    if (dropped > 0) {
+        echo("warning: serial bus %s dropped %u inbound messages (queue full)", this->name.c_str(), (unsigned)dropped);
     }
 
     if (this->otb_session.handle != 0) {
@@ -199,9 +207,9 @@ void SerialBus::process_uart() {
             continue;
         }
 
-        // enqueue message in inbound queue
+        // enqueue message in inbound queue; a warning could not pass the full queue either, so count the drop
         if (xQueueSend(this->inbound_queue, &message, 0) != pdTRUE) {
-            this->print_to_incoming_queue("warning: serial bus %s could not enqueue message: %s", this->name.c_str(), buffer);
+            this->dropped_inbound++;
         }
     }
 }
@@ -328,7 +336,9 @@ void SerialBus::print_to_incoming_queue(const char *format, ...) const {
     va_start(args, format);
     message.length = std::vsnprintf(message.payload, PAYLOAD_CAPACITY, format, args);
     va_end(args);
-    xQueueSend(this->inbound_queue, &message, 0);
+    if (xQueueSend(this->inbound_queue, &message, 0) != pdTRUE) {
+        this->dropped_inbound++;
+    }
 }
 
 void SerialBus::handle_echo(const char *line) {

--- a/main/modules/serial_bus.cpp
+++ b/main/modules/serial_bus.cpp
@@ -17,10 +17,8 @@ extern void process_line(const char *line, const int len);
 
 static constexpr size_t FRAME_BUFFER_SIZE = 512;
 static constexpr unsigned long POLL_TIMEOUT_MS = 250;
-// NOTE: the outbound queue is shared by all receivers and stops draining for POLL_TIMEOUT_MS
-// whenever a peer is unreachable; 32 keeps the healthy peers served at full rate in that case.
 static constexpr size_t OUTGOING_QUEUE_LENGTH = 32;
-static constexpr size_t INCOMING_QUEUE_LENGTH = 16;
+static constexpr size_t INCOMING_QUEUE_LENGTH = 32;
 static_assert(OUTGOING_QUEUE_LENGTH > otb::BUS_OTB_WINDOW); // a stalled poll must not abort an OTB update
 static_assert(INCOMING_QUEUE_LENGTH > otb::BUS_OTB_WINDOW); // a stalled step() must not drop an OTB chunk
 static constexpr const char ECHO_CMD[] = "__ECHO__";

--- a/main/modules/serial_bus.cpp
+++ b/main/modules/serial_bus.cpp
@@ -17,9 +17,8 @@ extern void process_line(const char *line, const int len);
 
 static constexpr size_t FRAME_BUFFER_SIZE = 512;
 static constexpr unsigned long POLL_TIMEOUT_MS = 250;
-// 8 inbound slots x ~264 bytes; the inbound queue is drained every main-loop step, so deeper
-// only costs heap. The outbound queue is drained by the communication task (gated by
-// !is_polling) and must stay above WINDOW = 8 in otb_update.py, or a stalled poll aborts OTB.
+// ~264 bytes per slot; outbound must stay above WINDOW = 8 in otb_update.py, or a stalled
+// poll (outbound drains on the comm task, gated by !is_polling) aborts an OTB update.
 static constexpr size_t OUTGOING_QUEUE_LENGTH = 16;
 static constexpr size_t INCOMING_QUEUE_LENGTH = 8;
 static constexpr const char ECHO_CMD[] = "__ECHO__";

--- a/main/modules/serial_bus.cpp
+++ b/main/modules/serial_bus.cpp
@@ -17,16 +17,12 @@ extern void process_line(const char *line, const int len);
 
 static constexpr size_t FRAME_BUFFER_SIZE = 512;
 static constexpr unsigned long POLL_TIMEOUT_MS = 250;
-// NOTE: each slot costs sizeof(OutgoingMessage) / sizeof(IncomingMessage) bytes of heap.
-// Both queues must stay above otb::BUS_OTB_WINDOW: the peer's inbound queue legitimately holds the whole
-// window while step() is stalled by a flash write, and the coordinator's outbound queue only drains
-// between polls, so a single stalled poll (POLL_TIMEOUT_MS) would otherwise abort an OTB update.
-// The outbound queue is shared by all receivers and stops draining for POLL_TIMEOUT_MS whenever a peer
-// is unreachable, so it stays at 32 to keep serving the healthy peers at full rate in that case.
+// NOTE: the outbound queue is shared by all receivers and stops draining for POLL_TIMEOUT_MS
+// whenever a peer is unreachable; 32 keeps the healthy peers served at full rate in that case.
 static constexpr size_t OUTGOING_QUEUE_LENGTH = 32;
 static constexpr size_t INCOMING_QUEUE_LENGTH = 16;
-static_assert(OUTGOING_QUEUE_LENGTH > otb::BUS_OTB_WINDOW);
-static_assert(INCOMING_QUEUE_LENGTH > otb::BUS_OTB_WINDOW);
+static_assert(OUTGOING_QUEUE_LENGTH > otb::BUS_OTB_WINDOW); // a stalled poll must not abort an OTB update
+static_assert(INCOMING_QUEUE_LENGTH > otb::BUS_OTB_WINDOW); // a stalled step() must not drop an OTB chunk
 static constexpr const char ECHO_CMD[] = "__ECHO__";
 static constexpr const char POLL_CMD[] = "__POLL__";
 static constexpr const char DONE_CMD[] = "__DONE__";
@@ -80,8 +76,7 @@ void SerialBus::step() {
         this->handle_incoming_message(message);
     }
 
-    // the communication task must not echo() itself, and a full inbound queue would swallow its warnings,
-    // so drops are counted there and reported here, at most once per second
+    // the communication task must not echo() itself, so drops are counted there and reported here, at most once per second
     if (this->dropped_inbound > 0 && millis_since(this->last_drop_report_millis) > 1000) {
         const unsigned dropped = this->dropped_inbound.exchange(0);
         this->last_drop_report_millis = millis();

--- a/main/modules/serial_bus.h
+++ b/main/modules/serial_bus.h
@@ -46,7 +46,8 @@ private:
     QueueHandle_t outbound_queue = nullptr;
     QueueHandle_t inbound_queue = nullptr;
     // written by the communication task, drained and reported by step() on the main task
-    mutable std::atomic<uint32_t> dropped_inbound{0};
+    std::atomic<unsigned> dropped_inbound{0};
+    unsigned long last_drop_report_millis = 0;
     TaskHandle_t communication_task = nullptr;
     bool is_polling = false;
     unsigned long poll_start_millis = 0;
@@ -58,13 +59,14 @@ private:
 
     [[noreturn]] static void communication_loop(void *param);
     void process_uart();
+    void push_incoming(const IncomingMessage &message);
     bool parse_message(const char *message_line, IncomingMessage &message) const;
     void handle_incoming_message(const IncomingMessage &message);
     void enqueue_outgoing_message(const uint8_t receiver, const char *payload, const size_t length);
     bool send_outgoing_queue();
     void send_message(const uint8_t receiver, const char *payload, const size_t length) const;
 
-    void print_to_incoming_queue(const char *format, ...) const;
+    void print_to_incoming_queue(const char *format, ...);
     void handle_echo(const char *line);
     bool is_coordinator() const { return !this->peer_ids.empty(); }
 };

--- a/main/modules/serial_bus.h
+++ b/main/modules/serial_bus.h
@@ -6,6 +6,7 @@
 #include "freertos/task.h"
 #include "module.h"
 #include "serial.h"
+#include <atomic>
 #include <cstdint>
 #include <vector>
 
@@ -44,6 +45,8 @@ private:
 
     QueueHandle_t outbound_queue = nullptr;
     QueueHandle_t inbound_queue = nullptr;
+    // written by the communication task, drained and reported by step() on the main task
+    mutable std::atomic<uint32_t> dropped_inbound{0};
     TaskHandle_t communication_task = nullptr;
     bool is_polling = false;
     unsigned long poll_start_millis = 0;

--- a/main/utils/otb.h
+++ b/main/utils/otb.h
@@ -21,6 +21,7 @@ constexpr const char OTB_ACK_COMMIT[] = "__OTB_ACK_COMMIT__";
 constexpr const char OTB_ERROR_PREFIX[] = "__OTB_ERROR__";
 
 constexpr size_t BUS_OTB_CHUNK_SIZE = 174;
+constexpr size_t BUS_OTB_WINDOW = 8; // unacked chunks in flight, must match WINDOW in otb_update.py
 constexpr size_t BUS_OTB_BUFFER_SIZE = 256;
 constexpr unsigned long BUS_OTB_SESSION_TIMEOUT_MS = 10000;
 

--- a/otb_update.py
+++ b/otb_update.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import serial
 
 CHUNK_SIZE = 174  # must match BUS_OTB_CHUNK_SIZE in main/utils/otb.h
-WINDOW = 8
+WINDOW = 8  # must match BUS_OTB_WINDOW in main/utils/otb.h
 
 parser = argparse.ArgumentParser(description='Push firmware via SerialBus OTB')
 parser.add_argument('firmware', help='Path to firmware binary')


### PR DESCRIPTION
### Motivation

Three robustness issues in the serial bus, found while investigating the F27 heap exhaustion (fixed by #274):

- Inbound overflow was invisible: the warning about a full inbound queue was printed into that same full queue and silently discarded.
- When relaying echo output to the coordinator failed (`enqueue_outgoing_message` throws after blocking 50 ms on a full outbound queue), `handle_echo` echoed a warning — which re-entered `handle_echo` through the echo callback, tried to relay the warning too, failed again, and recursed on the main task for as long as the outbound queue stayed full.
- `__DONE__` handling indexed `peer_ids[poll_index]` without checking `is_coordinator()`, i.e. `operator[]` on an empty vector if a stray `__DONE__` reaches a peer.

### Implementation

Inbound drops are counted in the communication task (which must not `echo()` itself) and reported by `step()` on the main task, at most once per second ("serial bus ... dropped N inbound messages"), covering both real messages and the communication task's own warnings. `handle_echo` stops relaying before echoing its own failure, and `__DONE__` is only matched against `peer_ids` on a coordinator.

The queue lengths are unchanged at 32. An earlier revision of this PR trimmed them to save heap; that turned out to be unnecessary once #274 landed, and the unreachable-peer scenario that sizes the outbound queue has no upper bound anyway (each poll to a dead peer blocks the drain for the 250 ms poll timeout, and the queue is shared by all receivers) — that is a polling problem, tracked separately. What stays from that detour is `BUS_OTB_WINDOW` in `otb.h`, mirrored by `otb_update.py` like `CHUNK_SIZE`, with `static_assert`s that both queues exceed the OTB window: the peer's inbound queue legitimately holds all in-flight chunks while `step()` is stalled by a flash write, and the coordinator's outbound queue holds them across a stalled poll (spotted by @evnchn). The next heap squeeze will hit the assert instead of aborting uploads in the field.

Bench-verified on a classic ESP32 running the full F27 startup: polling, `bus.send` and the overflow error path keep working.

### Progress

- [x] The implementation is complete.
- [x] Tested on hardware.
- [x] Documentation is not necessary.