### PR TITLE
Queue every BNO08x sensor report instead of keeping the last one per packet

### DIFF
--- a/components/bno08x_driver/bno08x.cpp
+++ b/components/bno08x_driver/bno08x.cpp
@@ -69,7 +69,7 @@ void sensor_handler(void *cookie, sh2_SensorEvent_t *event);
 
 Bno08x::Bno08x(gpio_num_t reset_pin)
     : port(I2C_NUM_0), address(I2C_ADDR_DEFAULT), int_pin(GPIO_NUM_NC),
-      reset_pin(reset_pin), pending_value(nullptr), reset_occurred(false) {
+      reset_pin(reset_pin), reset_occurred(false) {
     std::memset(&prodIds, 0, sizeof(prodIds));
     std::memset(&hal, 0, sizeof(hal));
 }
@@ -172,14 +172,29 @@ bool Bno08x::enableReport(sh2_SensorId_t sensorId, uint32_t interval_us) {
 }
 
 bool Bno08x::getSensorEvent(sh2_SensorValue_t *value) {
-    pending_value = value;
-    value->timestamp = 0;
+    if (queue_count == 0) {
+        sh2_service(); // decodes every report of the next packet into the queue via sensor_handler
+    }
+    return popSensorEvent(value);
+}
 
-    sh2_service();
+void Bno08x::pushSensorEvent(const sh2_SensorValue_t &value) {
+    if (queue_count == EVENT_QUEUE_SIZE) {
+        // consumer too slow: drop the oldest event, the sensor keeps reporting anyway
+        queue_head = (queue_head + 1) % EVENT_QUEUE_SIZE;
+        --queue_count;
+    }
+    event_queue[(queue_head + queue_count) % EVENT_QUEUE_SIZE] = value;
+    ++queue_count;
+}
 
-    if (value->timestamp == 0 && value->sensorId != SH2_GYRO_INTEGRATED_RV) {
+bool Bno08x::popSensorEvent(sh2_SensorValue_t *value) {
+    if (queue_count == 0) {
         return false;
     }
+    *value = event_queue[queue_head];
+    queue_head = (queue_head + 1) % EVENT_QUEUE_SIZE;
+    --queue_count;
     return true;
 }
 
@@ -314,15 +329,17 @@ void hal_callback(void *cookie, sh2_AsyncEvent_t *event) {
 
 void sensor_handler(void *cookie, sh2_SensorEvent_t *event) {
     auto *imu = static_cast<Bno08x *>(cookie);
-    if (!imu || !imu->pending_value) {
+    if (!imu) {
         return;
     }
 
-    int rc = sh2_decodeSensorEvent(imu->pending_value, event);
+    sh2_SensorValue_t value{};
+    int rc = sh2_decodeSensorEvent(&value, event);
     if (rc != SH2_OK) {
         ESP_LOGE(TAG, "sh2_decodeSensorEvent failed: %d", rc);
-        imu->pending_value->timestamp = 0;
+        return;
     }
+    imu->pushSensorEvent(value);
 }
 
 } // namespace

--- a/components/bno08x_driver/bno08x.cpp
+++ b/components/bno08x_driver/bno08x.cpp
@@ -180,12 +180,22 @@ bool Bno08x::getSensorEvent(sh2_SensorValue_t *value) {
 
 void Bno08x::pushSensorEvent(const sh2_SensorValue_t &value) {
     if (queue_count == EVENT_QUEUE_SIZE) {
-        // consumer too slow: drop the oldest event, the sensor keeps reporting anyway
+        // a single cargo pushed more reports than fit (hub batched several ticks after a host stall):
+        // drop the oldest event, the sensor keeps reporting anyway
+        if (!overflow_logged) {
+            ESP_LOGW(TAG, "sensor event queue overflow, dropping oldest event");
+            overflow_logged = true;
+        }
         queue_head = (queue_head + 1) % EVENT_QUEUE_SIZE;
         --queue_count;
     }
     event_queue[(queue_head + queue_count) % EVENT_QUEUE_SIZE] = value;
     ++queue_count;
+}
+
+void Bno08x::clearSensorEvents() {
+    queue_head = 0;
+    queue_count = 0;
 }
 
 bool Bno08x::popSensorEvent(sh2_SensorValue_t *value) {

--- a/components/bno08x_driver/bno08x.h
+++ b/components/bno08x_driver/bno08x.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 
@@ -25,6 +27,10 @@ public:
     bool wasReset();
 
     bool enableReport(sh2_SensorId_t sensor, uint32_t interval_us = 10000);
+
+    /// Pops the next decoded sensor event. Services the SH2 transport when the queue is empty; one SHTP
+    /// packet may carry several reports (all sensors due at the same tick are bundled), and every one of
+    /// them is queued — the Adafruit driver this is derived from kept only the last report per packet.
     bool getSensorEvent(sh2_SensorValue_t *value);
 
     I2cDevice *get_device() const;
@@ -43,6 +49,13 @@ private:
 
 public:
     // accessed by SH2 HAL callbacks
-    sh2_SensorValue_t *pending_value;
+    void pushSensorEvent(const sh2_SensorValue_t &value);
     bool reset_occurred;
+
+private:
+    static constexpr size_t EVENT_QUEUE_SIZE = 32;
+    std::array<sh2_SensorValue_t, EVENT_QUEUE_SIZE> event_queue{};
+    size_t queue_head = 0;  // next event to pop
+    size_t queue_count = 0; // events waiting
+    bool popSensorEvent(sh2_SensorValue_t *value);
 };

--- a/components/bno08x_driver/bno08x.h
+++ b/components/bno08x_driver/bno08x.h
@@ -33,6 +33,10 @@ public:
     /// them is queued — the Adafruit driver this is derived from kept only the last report per packet.
     bool getSensorEvent(sh2_SensorValue_t *value);
 
+    /// Drops every queued event, e.g. after a report configuration change so that reports of the old
+    /// configuration (decoded while sh2_setSensorConfig waited for its response) are not published.
+    void clearSensorEvents();
+
     I2cDevice *get_device() const;
 
 private:
@@ -53,9 +57,13 @@ public:
     bool reset_occurred;
 
 private:
-    static constexpr size_t EVENT_QUEUE_SIZE = 32;
-    std::array<sh2_SensorValue_t, EVENT_QUEUE_SIZE> event_queue{};
+    bool popSensorEvent(sh2_SensorValue_t *value);
+
+    // One SHTP cargo carries at most one report per enabled sensor (7 in ndof mode) when the host keeps up;
+    // after a host stall the hub may batch a few ticks into one cargo, which is pushed in a single burst.
+    static constexpr size_t EVENT_QUEUE_SIZE = 16;
+    std::array<sh2_SensorValue_t, EVENT_QUEUE_SIZE> event_queue;
     size_t queue_head = 0;  // next event to pop
     size_t queue_count = 0; // events waiting
-    bool popSensorEvent(sh2_SensorValue_t *value);
+    bool overflow_logged = false;
 };

--- a/docs/module_reference.md
+++ b/docs/module_reference.md
@@ -364,6 +364,7 @@ The BNO085 offers improved accuracy and better sensor fusion algorithms compared
 Unlike the BNO055 module, euler angles (`yaw`, `roll`, `pitch`) are not computed on-device —
 only quaternion output (`quat_w/x/y/z`) is provided.
 Euler conversion should be done upstream.
+The gyroscope (`gyr_x/y/z`) is reported in **rad/s** (the SH2 calibrated gyroscope report), not degrees/s as on the BNO055.
 
 | Methods              | Description                   | Arguments |
 | -------------------- | ----------------------------- | --------- |

--- a/main/modules/imu_bno085.cpp
+++ b/main/modules/imu_bno085.cpp
@@ -125,6 +125,10 @@ void ImuBno085::apply_mode(const std::string &mode) {
             active_reports[i] = desired[i];
         }
     }
+
+    // sh2_setSensorConfig services the transport while waiting for its response, so reports of the
+    // previous configuration (or from before a hub reset) may have been queued meanwhile
+    bno->clearSensorEvents();
 }
 
 ImuBno085::ImuBno085(const std::string name, i2c_port_t i2c_port, gpio_num_t sda_pin, gpio_num_t scl_pin,


### PR DESCRIPTION
### Motivation

With `ImuBno085` in its default `ndof` mode the quaternion (`quat_w/x/y/z`) reaches the core message at only ~1 Hz although every report is enabled with a 100 ms interval. On the AIR² test platform that meant a heading that lagged every rotation burst by up to a second (the 2026-08-06 rosys-side fusion fix worked around exactly that), and it looked like a slow sensor until the serial logs were counted: ~100 Hz core messages, quaternion changes at 1.1–1.3 Hz even while turning, gyroscope changes at ~10 Hz.

The cause is in the driver, not the sensor: `sh2.c` calls the sensor callback once per report of an SHTP packet, but `Bno08x::getSensorEvent` (derived from the Adafruit driver) decodes every callback into the same single `pending_value`, so only the last report of a packet survives. The hub bundles the reports due at the same tick into one packet with a fixed order — the gyroscope sits late and survives, the game rotation vector rarely does. Enabling fewer reports (`imu.set_mode("imu")`: accelerometer, gyroscope, rotation vector) lifts the quaternion to ~9 Hz with the unpatched firmware, which is how the cause was narrowed down.

### Implementation

A fixed ring buffer of decoded `sh2_SensorValue_t` in `Bno08x` (32 entries): `sensor_handler` decodes each report and pushes it (oldest dropped when full), `getSensorEvent` pops one event per call and only calls `sh2_service()` when the queue is empty. `pending_value` goes away; the `SH2_GYRO_INTEGRATED_RV` special case is no longer needed because every decoded event is queued regardless of its timestamp. `ImuBno085::step()` already drains up to 16 events per step at ~100 Hz, which covers 7 × 10 Hz with room to spare. Method names follow the file's existing Adafruit-style camelCase.

Docs: one line in the BNO085 section — the gyroscope is reported in rad/s (SH2 calibrated gyroscope report), not degrees/s as on the BNO055; verified against a commanded 0.2 rad/s turn (gyro integral 92.1° vs. quaternion yaw change 92.7°).

Measured on a Robot Brain (ESP32, Jetson Orin, BNO085, 0.12.0 + this patch, spot turns at 0.2 rad/s, `ndof`): quaternion changes at 10.0 Hz while rotating (1.0 Hz before), gyroscope 10.0 Hz (unchanged). Compiles for esp32 and esp32s3 on main and on v0.12.0 (IDF 5.3.1 Docker image). Only the esp32 build was flashed.

### Progress

- [x] The implementation is complete.
- [x] Tested on hardware.
- [x] Documentation has been updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code) [※](https://zauberzeug.github.io/colophon/#m=claude-fable-5&t=Diagnosis%20from%20the%20serial%20logs%20and%20the%20driver%20code%2C%20patch%20and%20text%20by%20the%20model%3B%20the%20author%20directed%2C%20flashed%20and%20measured%20the%20result%20on%20the%20robot.&d=2026-08-19&a=claude-code "claude-fable-5: Diagnosis from the serial logs and the driver code, patch and text by the model; the author directed, flashed and measured the result on the robot.")
