### PR TITLE
Revert the parse heap guard from #241

### DIFF
--- a/docs/machine_safety.md
+++ b/docs/machine_safety.md
@@ -35,13 +35,6 @@ so that no stale commands fire after the host stopped:
 when core.last_message_age > 500 then motor.stop(); core.clear_schedule() end
 ```
 
-## Low memory
-
-Parsing a line requires a certain amount of free heap memory, which scales with the length of the line.
-When there is not enough free or contiguous memory, Lizard drops the line and responds with `error: not enough free memory to parse (<free> free, <required> required)` instead of risking a crash and reboot.
-Like a line with an incorrect checksum, the command was not executed;
-the host system should react accordingly, for example by re-sending the command later or stopping the machine.
-
 ## Expander watchdog
 
 The `expander` module provides a watchdog feature that restarts the port expander when it gets stuck and does not send messages anymore.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -9,8 +9,6 @@
 #include "compilation/rule.h"
 #include "compilation/variable.h"
 #include "compilation/variable_assignment.h"
-#include "esp_heap_caps.h"
-#include "freertos/FreeRTOS.h"
 #include "global.h"
 #include "modules/bluetooth.h"
 #include "modules/core.h"
@@ -307,25 +305,10 @@ void process_tree(owl_tree *const tree, bool from_expander) {
     }
 }
 
-// owl's peak transient allocation scales with the token count of the line, so the
-// required-heap floor scales with its length (base covers a short line's fixed cost).
-static constexpr size_t PARSE_HEAP_BASE = 4096;
-static constexpr size_t PARSE_HEAP_PER_CHAR = 64;
-
 void process_lizard(const char *line, bool trigger_keep_alive, bool from_expander) {
     InterpreterLock lock;
     if (trigger_keep_alive) {
         core_module->keep_alive();
-    }
-
-    // owl's generated parser can abort()/deref on a failed allocation instead of returning an error, so require both
-    // enough total heap (scaled by the line's length) and a large enough contiguous block before parsing. Other tasks
-    // may allocate between the check and the parse; the padded constants absorb that. Drop the line rather than reboot.
-    const size_t required_heap = PARSE_HEAP_BASE + PARSE_HEAP_PER_CHAR * strlen(line);
-    const size_t free_heap = xPortGetFreeHeapSize();
-    if (free_heap < required_heap || heap_caps_get_largest_free_block(MALLOC_CAP_8BIT) < PARSE_HEAP_BASE) {
-        echo("error: not enough free memory to parse (%u free, %u required)", (unsigned)free_heap, (unsigned)required_heap);
-        return;
     }
 
     const bool debug = core_module->get_property("debug")->boolean_value;


### PR DESCRIPTION
### Motivation

The pre-parse heap guard from #241 rejects ordinary startup scripts: a 3906-character rosys configuration fails with `error: not enough free memory to parse (159072 free, 254080 required)` and the machine never applies its startup script (#272). The review of #272 showed that no length-based estimate can be made correct — constants that admit real configs still let expression-dense lines reach owl's `abort()`, constants that cover those reject real configs again.

The window the guard closed is narrow: when the heap is really exhausted, owl's first allocation (the 2568-byte token run) fails and is reported as `ERROR_ALLOCATION_FAILURE`, which #239 handles. The construction-phase abort sites are only reachable in the few-KB band above that, on a device that is not operable anyway.

### Implementation

- Revert ba866e6 (#241) on main: drop the guard in `process_lizard()` and the paragraph in `docs/machine_safety.md`
- #239 stays; the real fix for the remaining abort sites is tracked in #240 (upstream in owl, fork/patch as fallback)

### Progress

- [x] The implementation is complete.
- [x] Tested on hardware (or is not necessary).
- [x] Documentation has been updated (or is not necessary).

[※](https://zauberzeug.github.io/colophon/#m=claude-fable-5&t=Substance%20from%20the%20conversation%20with%20the%20maintainers%2C%20wording%20from%20the%20model.&a=claude-code "claude-fable-5: Substance from the conversation with the maintainers, wording from the model.")
