### PR TITLE
Back off polling to unreachable serial bus peers

### DIFF
--- a/main/modules/serial_bus.cpp
+++ b/main/modules/serial_bus.cpp
@@ -136,6 +136,7 @@ void SerialBus::call(const std::string method_name, const std::vector<ConstExpre
         this->poll_index = 0;
         this->peer_ids.swap(new_peer_ids);
         this->peer_poll_states.swap(new_peer_poll_states);
+        this->coordinator = true;
         portEXIT_CRITICAL(&this->config_mux);
     } else {
         Module::call(method_name, arguments);
@@ -156,22 +157,34 @@ void SerialBus::call(const std::string method_name, const std::vector<ConstExpre
                 next_index = bus->next_pollable_peer();
                 have_peer = next_index < bus->peer_ids.size();
                 if (have_peer) {
+                    // commit the poll while still holding the mux so make_coordinator
+                    // cannot cancel it between selection and is_polling = true
                     bus->poll_index = next_index;
                     peer_id = bus->peer_ids[next_index];
+                    bus->poll_start_millis = millis();
+                    bus->is_polling = true;
                 }
                 portEXIT_CRITICAL(&bus->config_mux);
                 if (have_peer) {
                     bus->send_message(peer_id, POLL_CMD, sizeof(POLL_CMD) - 1);
-                    bus->poll_start_millis = millis();
-                    bus->is_polling = true;
                 }
             }
-            // handle poll timeout
+            // handle poll timeout (re-check is_polling under the mux: make_coordinator may
+            // have cancelled the poll after the unguarded pre-check)
             if (bus->is_polling && millis_since(bus->poll_start_millis) > POLL_TIMEOUT_MS) {
+                uint8_t peer_id = 0;
+                unsigned long backoff_ms = 0;
+                bool report = false;
                 portENTER_CRITICAL(&bus->config_mux);
-                bus->handle_poll_timeout();
-                bus->is_polling = false;
+                if (bus->is_polling && millis_since(bus->poll_start_millis) > POLL_TIMEOUT_MS) {
+                    report = bus->handle_poll_timeout(peer_id, backoff_ms);
+                    bus->is_polling = false;
+                }
                 portEXIT_CRITICAL(&bus->config_mux);
+                if (report) {
+                    bus->print_to_incoming_queue(
+                        "warning: serial bus %s: peer %u unreachable, backing off %lu ms", bus->name.c_str(), peer_id, backoff_ms);
+                }
             }
         } else {
             // respond to poll
@@ -229,12 +242,18 @@ void SerialBus::process_uart() {
 
         // handle done command
         if (std::strcmp(message.payload, DONE_CMD) == 0) {
+            uint8_t peer_id = 0;
+            bool report = false;
             portENTER_CRITICAL(&this->config_mux);
-            if (this->is_coordinator() && message.sender == this->peer_ids[this->poll_index]) {
+            // is_polling filters DONEs from polls that make_coordinator cancelled
+            if (this->is_polling && this->is_coordinator() && message.sender == this->peer_ids[this->poll_index]) {
                 this->is_polling = false;
-                this->handle_poll_success();
+                report = this->handle_poll_success(peer_id);
             }
             portEXIT_CRITICAL(&this->config_mux);
+            if (report) {
+                this->print_to_incoming_queue("serial bus %s: peer %u reachable again", this->name.c_str(), peer_id);
+            }
             continue;
         }
 
@@ -263,26 +282,34 @@ size_t SerialBus::next_pollable_peer() const {
     return peer_count;
 }
 
-void SerialBus::handle_poll_success() {
+// must be called under config_mux; returns true if the peer just became reachable again
+// (reporting happens outside the critical section, so the caller prints)
+bool SerialBus::handle_poll_success(uint8_t &peer_id) {
     PeerPollState &state = this->peer_poll_states[this->poll_index];
     state.backoff_duration_ms = 0;
     state.backoff_start_millis = 0;
     if (state.unreachable) {
         state.unreachable = false;
-        this->print_to_incoming_queue("serial bus %s: peer %u reachable again", this->name.c_str(), this->peer_ids[this->poll_index]);
+        peer_id = this->peer_ids[this->poll_index];
+        return true;
     }
+    return false;
 }
 
-void SerialBus::handle_poll_timeout() {
+// must be called under config_mux; returns true if the peer just became unreachable
+// (reporting happens outside the critical section, so the caller prints)
+bool SerialBus::handle_poll_timeout(uint8_t &peer_id, unsigned long &backoff_ms) {
     PeerPollState &state = this->peer_poll_states[this->poll_index];
     state.backoff_duration_ms = state.backoff_duration_ms == 0 ? POLL_BACKOFF_INITIAL_MS
                                                                : std::min(state.backoff_duration_ms * 2, POLL_BACKOFF_MAX_MS);
     state.backoff_start_millis = millis();
     if (!state.unreachable) {
         state.unreachable = true;
-        this->print_to_incoming_queue(
-            "warning: serial bus %s: peer %u unreachable, backing off %lu ms", this->name.c_str(), this->peer_ids[this->poll_index], state.backoff_duration_ms);
+        peer_id = this->peer_ids[this->poll_index];
+        backoff_ms = state.backoff_duration_ms;
+        return true;
     }
+    return false;
 }
 
 bool SerialBus::parse_message(const char *message_line, IncomingMessage &message) const {

--- a/main/modules/serial_bus.cpp
+++ b/main/modules/serial_bus.cpp
@@ -17,6 +17,8 @@ extern void process_line(const char *line, const int len);
 
 static constexpr size_t FRAME_BUFFER_SIZE = 512;
 static constexpr unsigned long POLL_TIMEOUT_MS = 250;
+static constexpr unsigned long POLL_BACKOFF_INITIAL_MS = 1000;
+static constexpr unsigned long POLL_BACKOFF_MAX_MS = 8000;
 static constexpr size_t OUTGOING_QUEUE_LENGTH = 32;
 static constexpr size_t INCOMING_QUEUE_LENGTH = 32;
 static_assert(OUTGOING_QUEUE_LENGTH > otb::BUS_OTB_WINDOW); // a stalled poll must not abort an OTB update
@@ -124,6 +126,10 @@ void SerialBus::call(const std::string method_name, const std::vector<ConstExpre
             peers.push_back(static_cast<uint8_t>(peer_value));
         }
         this->peer_ids = peers;
+        this->peer_poll_states.assign(peers.size(), PeerPollState{});
+        // cancel any poll in flight: poll_index may be stale (out of range) for the new peer list
+        this->is_polling = false;
+        this->poll_index = 0;
     } else {
         Module::call(method_name, arguments);
     }
@@ -134,16 +140,19 @@ void SerialBus::call(const std::string method_name, const std::vector<ConstExpre
     while (true) {
         bus->process_uart();
         if (bus->is_coordinator()) {
-            // poll next peer
+            // poll next peer that is not currently backed off
             if (!bus->is_polling && !bus->send_outgoing_queue()) {
-                bus->poll_index = (bus->poll_index + 1) % bus->peer_ids.size();
-                bus->send_message(bus->peer_ids[bus->poll_index], POLL_CMD, sizeof(POLL_CMD) - 1);
-                bus->poll_start_millis = millis();
-                bus->is_polling = true;
+                const size_t next_index = bus->next_pollable_peer();
+                if (next_index < bus->peer_ids.size()) {
+                    bus->poll_index = next_index;
+                    bus->send_message(bus->peer_ids[bus->poll_index], POLL_CMD, sizeof(POLL_CMD) - 1);
+                    bus->poll_start_millis = millis();
+                    bus->is_polling = true;
+                }
             }
             // handle poll timeout
             if (bus->is_polling && millis_since(bus->poll_start_millis) > POLL_TIMEOUT_MS) {
-                bus->print_to_incoming_queue("warning: serial bus %s poll to %u timed out", bus->name.c_str(), bus->peer_ids[bus->poll_index]);
+                bus->handle_poll_timeout();
                 bus->is_polling = false;
             }
         } else {
@@ -204,6 +213,7 @@ void SerialBus::process_uart() {
         if (std::strcmp(message.payload, DONE_CMD) == 0) {
             if (this->is_coordinator() && message.sender == this->peer_ids[this->poll_index]) {
                 this->is_polling = false;
+                this->handle_poll_success();
             }
             continue;
         }
@@ -216,6 +226,42 @@ void SerialBus::push_incoming(const IncomingMessage &message) {
     // a warning could not pass the full queue either, so count the drop and let step() report it
     if (xQueueSend(this->inbound_queue, &message, 0) != pdTRUE) {
         this->dropped_inbound++;
+    }
+}
+
+// Round-robins peer_ids starting after poll_index, skipping peers still under backoff.
+// Returns peer_ids.size() if every peer is currently backed off.
+size_t SerialBus::next_pollable_peer() const {
+    const size_t peer_count = this->peer_ids.size();
+    for (size_t offset = 1; offset <= peer_count; ++offset) {
+        const size_t index = (this->poll_index + offset) % peer_count;
+        const PeerPollState &state = this->peer_poll_states[index];
+        if (millis_since(state.backoff_start_millis) >= state.backoff_duration_ms) {
+            return index;
+        }
+    }
+    return peer_count;
+}
+
+void SerialBus::handle_poll_success() {
+    PeerPollState &state = this->peer_poll_states[this->poll_index];
+    state.backoff_duration_ms = 0;
+    state.backoff_start_millis = 0;
+    if (state.unreachable) {
+        state.unreachable = false;
+        this->print_to_incoming_queue("serial bus %s: peer %u reachable again", this->name.c_str(), this->peer_ids[this->poll_index]);
+    }
+}
+
+void SerialBus::handle_poll_timeout() {
+    PeerPollState &state = this->peer_poll_states[this->poll_index];
+    state.backoff_duration_ms = state.backoff_duration_ms == 0 ? POLL_BACKOFF_INITIAL_MS
+                                                               : std::min(state.backoff_duration_ms * 2, POLL_BACKOFF_MAX_MS);
+    state.backoff_start_millis = millis();
+    if (!state.unreachable) {
+        state.unreachable = true;
+        this->print_to_incoming_queue(
+            "warning: serial bus %s: peer %u unreachable, backing off %lu ms", this->name.c_str(), this->peer_ids[this->poll_index], state.backoff_duration_ms);
     }
 }
 

--- a/main/modules/serial_bus.cpp
+++ b/main/modules/serial_bus.cpp
@@ -125,11 +125,18 @@ void SerialBus::call(const std::string method_name, const std::vector<ConstExpre
             }
             peers.push_back(static_cast<uint8_t>(peer_value));
         }
-        this->peer_ids = peers;
-        this->peer_poll_states.assign(peers.size(), PeerPollState{});
-        // cancel any poll in flight: poll_index may be stale (out of range) for the new peer list
+        // Build new vectors in locals first (may allocate — must not happen under spinlock).
+        std::vector<uint8_t> new_peer_ids = peers;
+        std::vector<PeerPollState> new_peer_poll_states(peers.size(), PeerPollState{});
+        // Commit under spinlock: cancel in-flight poll FIRST so communication_loop can't
+        // index peer_poll_states at a stale poll_index into a freshly resized (smaller) vector,
+        // then swap (O(1)) so the critical section holds no allocation.
+        portENTER_CRITICAL(&this->config_mux);
         this->is_polling = false;
         this->poll_index = 0;
+        this->peer_ids.swap(new_peer_ids);
+        this->peer_poll_states.swap(new_peer_poll_states);
+        portEXIT_CRITICAL(&this->config_mux);
     } else {
         Module::call(method_name, arguments);
     }
@@ -142,18 +149,29 @@ void SerialBus::call(const std::string method_name, const std::vector<ConstExpre
         if (bus->is_coordinator()) {
             // poll next peer that is not currently backed off
             if (!bus->is_polling && !bus->send_outgoing_queue()) {
-                const size_t next_index = bus->next_pollable_peer();
-                if (next_index < bus->peer_ids.size()) {
+                size_t next_index;
+                uint8_t peer_id;
+                bool have_peer;
+                portENTER_CRITICAL(&bus->config_mux);
+                next_index = bus->next_pollable_peer();
+                have_peer = next_index < bus->peer_ids.size();
+                if (have_peer) {
                     bus->poll_index = next_index;
-                    bus->send_message(bus->peer_ids[bus->poll_index], POLL_CMD, sizeof(POLL_CMD) - 1);
+                    peer_id = bus->peer_ids[next_index];
+                }
+                portEXIT_CRITICAL(&bus->config_mux);
+                if (have_peer) {
+                    bus->send_message(peer_id, POLL_CMD, sizeof(POLL_CMD) - 1);
                     bus->poll_start_millis = millis();
                     bus->is_polling = true;
                 }
             }
             // handle poll timeout
             if (bus->is_polling && millis_since(bus->poll_start_millis) > POLL_TIMEOUT_MS) {
+                portENTER_CRITICAL(&bus->config_mux);
                 bus->handle_poll_timeout();
                 bus->is_polling = false;
+                portEXIT_CRITICAL(&bus->config_mux);
             }
         } else {
             // respond to poll
@@ -211,10 +229,12 @@ void SerialBus::process_uart() {
 
         // handle done command
         if (std::strcmp(message.payload, DONE_CMD) == 0) {
+            portENTER_CRITICAL(&this->config_mux);
             if (this->is_coordinator() && message.sender == this->peer_ids[this->poll_index]) {
                 this->is_polling = false;
                 this->handle_poll_success();
             }
+            portEXIT_CRITICAL(&this->config_mux);
             continue;
         }
 

--- a/main/modules/serial_bus.h
+++ b/main/modules/serial_bus.h
@@ -47,7 +47,10 @@ private:
     };
 
     std::vector<uint8_t> peer_ids;
-    std::vector<PeerPollState> peer_poll_states; // indexed like peer_ids, resized together in make_coordinator
+    std::vector<PeerPollState> peer_poll_states; // indexed like peer_ids, resized together under config_mux
+    // guards all reads/writes of peer_ids + peer_poll_states + poll_index + is_polling
+    // across the communication_loop task boundary (main task writes via make_coordinator)
+    portMUX_TYPE config_mux = portMUX_INITIALIZER_UNLOCKED;
 
     QueueHandle_t outbound_queue = nullptr;
     QueueHandle_t inbound_queue = nullptr;

--- a/main/modules/serial_bus.h
+++ b/main/modules/serial_bus.h
@@ -58,8 +58,10 @@ private:
     std::atomic<unsigned> dropped_inbound{0};
     unsigned long last_drop_report_millis = 0;
     TaskHandle_t communication_task = nullptr;
-    bool is_polling = false;
-    unsigned long poll_start_millis = 0;
+    // atomic so the communication task's unguarded pre-checks are race-free against
+    // make_coordinator on the other core; consistent multi-field decisions still take config_mux
+    std::atomic<bool> is_polling{false};
+    std::atomic<unsigned long> poll_start_millis{0};
     size_t poll_index = 0;
     uint8_t requesting_node = 0;
     bool ready_pending = true;
@@ -70,8 +72,8 @@ private:
     void process_uart();
     void push_incoming(const IncomingMessage &message);
     size_t next_pollable_peer() const;
-    void handle_poll_success();
-    void handle_poll_timeout();
+    bool handle_poll_success(uint8_t &peer_id);
+    bool handle_poll_timeout(uint8_t &peer_id, unsigned long &backoff_ms);
     bool parse_message(const char *message_line, IncomingMessage &message) const;
     void handle_incoming_message(const IncomingMessage &message);
     void enqueue_outgoing_message(const uint8_t receiver, const char *payload, const size_t length);
@@ -80,5 +82,8 @@ private:
 
     void print_to_incoming_queue(const char *format, ...);
     void handle_echo(const char *line);
-    bool is_coordinator() const { return !this->peer_ids.empty(); }
+    // atomic flag instead of peer_ids.empty(): the communication task calls this without
+    // config_mux while make_coordinator swaps the vectors on the other core
+    std::atomic<bool> coordinator{false};
+    bool is_coordinator() const { return this->coordinator; }
 };

--- a/main/modules/serial_bus.h
+++ b/main/modules/serial_bus.h
@@ -40,8 +40,14 @@ private:
         size_t length;
         char payload[PAYLOAD_CAPACITY];
     };
+    struct PeerPollState {
+        unsigned long backoff_start_millis = 0;
+        unsigned long backoff_duration_ms = 0; // 0 == no timeout seen yet since the last successful poll
+        bool unreachable = false;              // for one-shot unreachable/reachable-again reporting
+    };
 
     std::vector<uint8_t> peer_ids;
+    std::vector<PeerPollState> peer_poll_states; // indexed like peer_ids, resized together in make_coordinator
 
     QueueHandle_t outbound_queue = nullptr;
     QueueHandle_t inbound_queue = nullptr;
@@ -60,6 +66,9 @@ private:
     [[noreturn]] static void communication_loop(void *param);
     void process_uart();
     void push_incoming(const IncomingMessage &message);
+    size_t next_pollable_peer() const;
+    void handle_poll_success();
+    void handle_poll_timeout();
     bool parse_message(const char *message_line, IncomingMessage &message) const;
     void handle_incoming_message(const IncomingMessage &message);
     void enqueue_outgoing_message(const uint8_t receiver, const char *payload, const size_t length);


### PR DESCRIPTION
*Posted by Claude Code on evnchn's behalf.*

### Motivation

A poll to an unreachable peer stalls the round-robin for the full 250 ms timeout on every cycle, so a single unplugged peer throttles all healthy peers. Implements the polling-backoff proposal from the issue.

Closes #279.

### Implementation

After a timeout, that peer is skipped for a backoff window (1 s, doubling to a cap of 8 s) before being polled again, and reachability transitions are reported once instead of on every retry. Healthy peers keep being served at the normal round-trip rate regardless of how many peers are down.

<details>
<summary><b>Design notes / answers to the issue's open questions</b></summary>

- **First poll after boot is exempt from backoff automatically** — a peer only enters backoff after its first observed timeout (`backoff_duration_ms` starts at 0, which reads as "not backed off"), so the boot-time "Ready." handshake isn't delayed by this change.
- **How fast a returning peer is picked up**: purely time-based — once its backoff window (which grows 1s → 2s → 4s → capped at 8s while it keeps failing, and resets to 0 the moment it responds) elapses, the coordinator polls it again on the next round-robin pass. There's no out-of-band "peer came back" signal since broadcasts aren't implemented yet, so this seemed like the simplest fit; happy to tune the constants or add jitter if 1s/8s isn't the right range for real deployments.
- If **every** peer is currently backed off, the coordinator simply skips polling that tick rather than busy-spinning a poll that would only time out again.
- Shared coordinator state (`peer_ids`, `peer_poll_states`, `poll_index`, `is_polling`) is guarded by a `portMUX` spinlock against `make_coordinator` running on the other core; c411d34 closes a remaining cancellation race that was reproduced on hardware (details in [this comment](https://github.com/zauberzeug/lizard/pull/280#issuecomment-5369404818)) and keeps all reporting outside the critical sections.

</details>

### Progress

- [x] The implementation is complete.
- [x] Tested on hardware (or is not necessary).
- [x] Documentation has been updated (or is not necessary — internal scheduling behavior; the module reference already describes polling at its current level of detail).

<details>
<summary><b>Verification</b></summary>

- `source ~/esp/esp-idf/export.sh && python3 build.py esp32` → `Build completed successfully for esp32`
- `source ~/esp/esp-idf/export.sh && python3 build.py esp32s3` → `Build completed successfully for esp32s3`
- `pre-commit run --files main/modules/serial_bus.cpp main/modules/serial_bus.h` → all hooks pass
- **Hardware-tested on an ESP32-S3**: two `SerialBus` nodes on one board (UART1/UART2 cross-wired through the GPIO matrix), coordinator polling a healthy peer plus a nonexistent one — backoff, boot exemption, one-shot unreachable/reachable-again reporting and the all-backed-off skip all observed on real UART traffic. The `make_coordinator` cancellation race was reproduced (437 spurious "unreachable" reports for a healthy peer in 731 bursts) and is gone after c411d34 (0 in 731, same protocol); full numbers in [this comment](https://github.com/zauberzeug/lizard/pull/280#issuecomment-5369404818).
- Got a second-lineage (Codex/GPT-5.2) adversarial review on the diff before opening this PR. It confirmed the core throughput claim holds, and caught one real gap I fixed before pushing: `make_coordinator()` replaced `peer_ids`/`peer_poll_states` without resetting `poll_index`/`is_polling`, so a second call while a poll was in flight could index past the freshly resized (possibly shorter) backoff-state vector. Fixed by clearing `is_polling` and resetting `poll_index` in the same place the peer list is replaced. A second Codex pass on c411d34 found no remaining blockers.

</details>
