### PR TITLE
Do not let serial-bus messages reset core.last_message_age

### DIFF
--- a/docs/machine_safety.md
+++ b/docs/machine_safety.md
@@ -25,7 +25,8 @@ The following example stops a motor when there is no serial communication for 50
 when core.last_message_age > 500 then motor.stop(); end
 ```
 
-Any successfully interpreted input message resets `last_message_age`.
+Any successfully interpreted message from UART0 or Bluetooth resets `last_message_age`.
+Messages received over the [serial bus](module_reference.md#serial-bus) do _not_ reset it, so a peer pushing its state to the core cannot mask a lost host connection.
 If the host controller has no command to send but wants to signal that it is still alive, it can call `core.keep_alive()`, which resets the timer silently without producing any output.
 
 If the host streams [scheduled blocks](language.md), they should be discarded as well when the connection is lost,

--- a/docs/machine_safety.md
+++ b/docs/machine_safety.md
@@ -16,7 +16,7 @@ The 8-bit checksum is computed as the bitwise XOR of all bytes of the UTF-8 enco
 
 ## Keep-alive signal
 
-The `core` module provides a property `last_message_age`, which holds the time in milliseconds since the last input message was received from UART0, parsed and successfully interpreted.
+The `core` module provides a property `last_message_age`, which holds the time in milliseconds since the last input message was received from the host via UART0 or Bluetooth.
 It allows formulating rules that stop critical hardware modules when the connection to the host system is lost.
 
 The following example stops a motor when there is no serial communication for 500 ms:
@@ -25,9 +25,10 @@ The following example stops a motor when there is no serial communication for 50
 when core.last_message_age > 500 then motor.stop(); end
 ```
 
-Any successfully interpreted message from UART0 or Bluetooth resets `last_message_age`.
-Messages received over the [serial bus](module_reference.md#serial-bus) do _not_ reset it, so a peer pushing its state to the core cannot mask a lost host connection.
+Any message from UART0 or Bluetooth that is not discarded due to an invalid [checksum](#checksums) resets `last_message_age`, even if it cannot be parsed.
+Messages received over the [serial bus](module_reference.md#serial-bus) do _not_ reset it, so a peer pushing its state to the core cannot implicitly mask a lost host connection.
 If the host controller has no command to send but wants to signal that it is still alive, it can call `core.keep_alive()`, which resets the timer silently without producing any output.
+This also works over the serial bus: a coordinator can keep a peer's timer alive by explicitly sending it `core.keep_alive()`.
 
 If the host streams [scheduled blocks](language.md), they should be discarded as well when the connection is lost,
 so that no stale commands fire after the host stopped:

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -372,7 +372,7 @@ void process_lizard(const char *line, bool trigger_keep_alive, bool from_expande
     }
 }
 
-void process_line(const char *line, const int len) {
+void process_line(const char *line, const int len, const bool trigger_keep_alive = true) {
     InterpreterLock lock;
     if (len >= 2 && line[0] == '!') {
         switch (line[1]) {
@@ -389,7 +389,7 @@ void process_line(const char *line, const int len) {
             Storage::save_startup();
             break;
         case '!':
-            process_lizard(line + 2);
+            process_lizard(line + 2, trigger_keep_alive);
             break;
         case '"':
             echo("%s", line + 2);
@@ -398,7 +398,7 @@ void process_line(const char *line, const int len) {
             throw std::runtime_error("unrecognized control command");
         }
     } else {
-        process_lizard(line);
+        process_lizard(line, trigger_keep_alive);
     }
 }
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -10,6 +10,7 @@
 #include "compilation/variable.h"
 #include "compilation/variable_assignment.h"
 #include "global.h"
+#include "main.h"
 #include "modules/bluetooth.h"
 #include "modules/core.h"
 #include "modules/expander.h"
@@ -372,7 +373,7 @@ void process_lizard(const char *line, bool trigger_keep_alive, bool from_expande
     }
 }
 
-void process_line(const char *line, const int len, const bool trigger_keep_alive = true) {
+void process_line(const char *line, const int len, const bool trigger_keep_alive) {
     InterpreterLock lock;
     if (len >= 2 && line[0] == '!') {
         switch (line[1]) {

--- a/main/main.h
+++ b/main/main.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void process_line(const char *line, const int len, const bool trigger_keep_alive = true);

--- a/main/modules/serial_bus.cpp
+++ b/main/modules/serial_bus.cpp
@@ -13,7 +13,7 @@
 #include <cstring>
 #include <stdexcept>
 
-extern void process_line(const char *line, const int len);
+extern void process_line(const char *line, const int len, const bool trigger_keep_alive);
 
 static constexpr size_t FRAME_BUFFER_SIZE = 512;
 static constexpr unsigned long POLL_TIMEOUT_MS = 250;
@@ -284,14 +284,14 @@ void SerialBus::handle_incoming_message(const IncomingMessage &message) {
 
     // process control commands starting with "!" silently
     if (message.payload[0] == '!') {
-        process_line(message.payload, message.length);
+        process_line(message.payload, message.length, false);
         return;
     }
 
     // process regular commands and relay any echo() output back to sender
     this->echo_target_id = message.sender;
     try {
-        process_line(message.payload, message.length);
+        process_line(message.payload, message.length, false);
     } catch (const std::exception &e) {
         echo("error processing command: %s", e.what());
     }

--- a/main/modules/serial_bus.cpp
+++ b/main/modules/serial_bus.cpp
@@ -1,5 +1,6 @@
 #include "serial_bus.h"
 
+#include "../main.h"
 #include "../utils/format.h"
 #include "../utils/otb.h"
 #include "../utils/string_utils.h"
@@ -12,8 +13,6 @@
 #include <cstdio>
 #include <cstring>
 #include <stdexcept>
-
-extern void process_line(const char *line, const int len, const bool trigger_keep_alive);
 
 static constexpr size_t FRAME_BUFFER_SIZE = 512;
 static constexpr unsigned long POLL_TIMEOUT_MS = 250;


### PR DESCRIPTION
Fixes #283.

## TL;DR

Lines received from a serial-bus peer no longer reset `core.last_message_age`, so a peer pushing its state cannot mask the host watchdog. UART0, Bluetooth and expander input are unchanged, and `bus.send(<peer>, "core.keep_alive()")` still works as an explicit link watchdog.

**Verdict:** reproduced on hardware, fixed, and confirmed against the pre-fix build. 6 code lines in 2 files, plus 1 docs line.

| Firmware | Host UART0 silent for 10 s, peer frames arriving | `core.last_message_age` |
| --- | --- | --- |
| pre-fix `e29f1f3` | 31 frames interpreted | pinned, **max 310 ms** — watchdog masked |
| this PR | 997 frames interpreted | climbs freely, **max 10 973 ms** — watchdog fires |
| this PR, peer sends `core.keep_alive()` | frames interpreted | resets, max 308 ms — escape hatch intact |

## The change

`process_line()` gains a `trigger_keep_alive` flag (default `true`) and forwards it to both `process_lizard()` calls. `SerialBus::handle_incoming_message` passes `false` for both the `!`-control path and the regular-command path.

<details>
<summary>Diff</summary>

```diff
--- a/main/main.cpp
+++ b/main/main.cpp
-void process_line(const char *line, const int len) {
+void process_line(const char *line, const int len, const bool trigger_keep_alive = true) {
     InterpreterLock lock;
     if (len >= 2 && line[0] == '!') {
         switch (line[1]) {
@@
         case '!':
-            process_lizard(line + 2);
+            process_lizard(line + 2, trigger_keep_alive);
             break;
@@
     } else {
-        process_lizard(line);
+        process_lizard(line, trigger_keep_alive);
     }
 }

--- a/main/modules/serial_bus.cpp
+++ b/main/modules/serial_bus.cpp
-extern void process_line(const char *line, const int len);
+extern void process_line(const char *line, const int len, const bool trigger_keep_alive);
@@
     // process control commands starting with "!" silently
     if (message.payload[0] == '!') {
-        process_line(message.payload, message.length);
+        process_line(message.payload, message.length, false);
         return;
     }
@@
     try {
-        process_line(message.payload, message.length);
+        process_line(message.payload, message.length, false);
     } catch (const std::exception &e) {
```

Plus one line in `docs/machine_safety.md`, which claimed any interpreted message resets the timer.

</details>

<details>
<summary>Paths audited — every other route to <code>keep_alive()</code></summary>

| Source | Path | Resets `last_message_age`? | Changed? |
| --- | --- | --- | --- |
| Host UART0 | `process_uart()` -> `process_line(input, len)` (default `true`) | yes | no |
| Bluetooth | `Bluetooth::step()` -> `message_handler(line, true, false)` | yes | no |
| Expander | `message_handler(line, false, true)` | no (already) | no |
| Serial bus, regular command | `handle_incoming_message` -> `process_line(..., false)` | **no (was yes)** | **yes** |
| Serial bus, `!`-control | `handle_incoming_message` -> `process_line(..., false)` | **no (was yes)** | **yes** |
| Serial bus, `core.keep_alive()` | `process_lizard(..., false)` then `Core::call("keep_alive")` -> `Core::keep_alive()` | yes, explicitly | no |
| OTB transfers, echo relay | never reach `process_lizard`/`process_line` | no | no |
| Scheduled blocks | compiled routines, no keep-alive touch | no | no |
| Startup script | `process_lizard(Storage::startup)` | yes (boot-time only) | no |

UART `!+`, `!-`, `!?`, `!.` and `!"` never called `process_lizard`, so they never reset the timer — before or after this change.

</details>

## Hardware verification

Run on a bare ESP32 dev board. No second board and no jumper wire were needed: **GPIO25 carries UART1 TX and UART2 RX simultaneously** (ESP32 GPIO matrix), so the board feeds its own `SerialBus` port frames whose `sender != node_id` — the same shape a real peer sends, through the real `process_uart` -> `parse_message` -> `handle_incoming_message` path.

<details>
<summary>Harness — setup typed over UART0, then the board drives itself</summary>

```
bus_port = Serial(25, -1, 115200, 2)      # bus RX on GPIO25
bus = SerialBus(bus_port, 1)              # this node is id 1
tx = Serial(-1, 25, 115200, 1)            # writes to the same pad
int probe = 0
when core.last_message_age > 300 then tx.send(<frame bytes>); end
core.output("core.millis core.last_message_age probe")
```

The `when` rule does the sending, so **no host input is needed** once the test starts — that is what makes the silent-host condition real rather than simulated. The frame is a literal `$$2:1$$<payload>\n` written byte-wise; the checksum suffix is optional, so no `@xx` is needed.

`probe` is the liveness witness: it only increments if a bus frame was actually parsed and interpreted. A run where `last_message_age` climbs *and* `probe` stays flat would prove nothing (it would just mean the bus went quiet), so both columns are reported together.

Loopback sanity check before every run: `tx.send(<$$2:1$$probe = 42>)` then `core.print(probe)` must print `42`.

</details>

<details>
<summary>Run 1 — pre-fix <code>e29f1f3</code>: bug reproduced, timer pinned</summary>

```
loopback  : probe = 42@06 (42 means bus frames reach the interpreter)
--- host UART0 silent from here, bus payload = "probe = probe + 1" ---
998 samples over 10.0 s of host silence
  millis=   13254  last_message_age=    50  probe=    6
  millis=   15234  last_message_age=   110  probe=   12
  millis=   17214  last_message_age=   170  probe=   18
  millis=   19194  last_message_age=   230  probe=   24
  millis=   21174  last_message_age=   290  probe=   30
  millis=   22167  last_message_age=     3  probe=   34
  millis=   23224  last_message_age=   100  probe=   37

last_message_age over the silent window: min=3 max=310
probe (bus frames interpreted): 6 -> 37
```

The host has been silent for 10 s, yet the timer never passes 310 ms — it is reset by the peer's frames and drops back to 3 ms. `when core.last_message_age > 1000 then wheels.speed(0, 0); end` would never fire. This is the Feldfreund failure in the issue.

</details>

<details>
<summary>Run 2 — this PR: timer climbs while peer frames keep arriving</summary>

```
loopback  : probe = 42@06 (42 means bus frames reach the interpreter)
--- host UART0 silent from here, bus payload = "probe = probe + 1" ---
998 samples over 10.0 s of host silence
  millis=   13247  last_message_age=  1003  probe=  158
  millis=   15227  last_message_age=  2983  probe=  356
  millis=   17207  last_message_age=  4963  probe=  554
  millis=   19187  last_message_age=  6943  probe=  752
  millis=   21167  last_message_age=  8923  probe=  950
  millis=   23147  last_message_age= 10903  probe= 1148
  millis=   23217  last_message_age= 10973  probe= 1155

last_message_age over the silent window: min=1003 max=10973
probe (bus frames interpreted): 158 -> 1155
```

997 frames interpreted from the bus during the window, and the timer still reached 10 973 ms. Both the 1000 ms `wheels.speed(0, 0)` and the 20 000 ms `disable()` rule would now fire on a dead host. (`probe` climbs faster than in run 1 because the rule fires on every cycle once the timer is past 300 ms instead of being throttled by its own resets.)

</details>

<details>
<summary>Run 3 — this PR, peer sends <code>core.keep_alive()</code>: explicit watchdog still works</summary>

```
--- host UART0 silent from here, bus payload = "core.keep_alive()" ---
998 samples over 10.0 s of host silence
  millis=   13254  last_message_age=    38  probe=    0
  millis=   17214  last_message_age=   158  probe=    0
  millis=   21174  last_message_age=   278  probe=    0
  millis=   22164  last_message_age=   308  probe=    0
  millis=   23154  last_message_age=    18  probe=    0

last_message_age over the silent window: min=0 max=308
probe (bus frames interpreted): 0 -> 0
```

The timer is held under 308 ms by `core.keep_alive()` arriving over the bus, so the escape hatch proposed in the issue works after the change. `probe` stays 0 here, which is the point — this payload deliberately does not touch it.

Run order was fixed -> pre-fix -> fixed (A/B/A). The second fixed run reproduced run 2 to the sample, so the difference is the code, not drift.

</details>

<details>
<summary>Build — both targets, ESP-IDF v5.3.1</summary>

```
$ python3 build.py esp32 --clean
Build completed successfully for esp32

$ python3 build.py esp32s3 --clean
Build completed successfully for esp32s3
```

Test-only local changes, reverted before this commit and **not** part of the diff: the dev board has 4 MB flash while `partitions.csv` assumes 8 MB, so the flashed image used a shrunk partition table and `CONFIG_ESPTOOLPY_FLASHSIZE_4MB`. Both targets build green with the stock 8 MB table.

</details>

## Second-lineage review

<details>
<summary>Codex (gpt-5.2-codex), adversarial framing — verbatim verdict</summary>

> **Verdict:** Most is sound. I don't see a firmware blocker in `2779b4f`, and lack of a bus hardware pair is not a blocker for merging given both targets build green, though it remains the main residual runtime risk.
>
> **BLOCKER** — None found.
>
> **SUGGESTION** — `docs/machine_safety.md:19` still says `last_message_age` resets after a message is "parsed and successfully interpreted", but implementation resets before parsing at `main.cpp:317`. Malformed UART0/Bluetooth lines with valid checksum still reset it. This pre-existed, but the edited doc keeps the inaccurate wording.
>
> **NIT** — `docs/machine_safety.md:31` says "The core can use the same method…" for `bus.send(<peer>, "core.keep_alive()")`; technically the coordinator/host-side Lizard script sends it to the peer, not the `core` module itself.
>
> 1. I found no missed non-host path that still implicitly resets `core.last_message_age`. [...] Expander input already calls the message handler with `false, true`. OTB and echo relay do not call `process_lizard`/`process_line`. Scheduled blocks execute compiled routines and do not touch keep-alive.
> 2. `core.keep_alive()` over the bus still works: payload `core.keep_alive()` enters serial bus regular command handling, calls `process_line(..., false)`, then `process_lizard(..., false)` avoids the implicit heartbeat, then the method call reaches `Core::call("keep_alive")`, which explicitly calls `Core::keep_alive()`.
> 3. The default-argument split is legal. The default on `process_line` is visible only in `main.cpp`; the `extern` in `serial_bus.cpp` has the same function type and forces that TU to pass the third argument. Top-level `const` on value parameters is not a linkage/ODR hazard.
> 4. UART0 behavior is unchanged [...] Bluetooth behavior is unchanged [...] UART `!!` still resets through `process_lizard(..., true)`.
> 5. `module_reference.md#serial-bus` is a valid MkDocs/Python-Markdown-style anchor for `## Serial Bus`.

Its point 2 was the one worth checking on hardware rather than by tracing — run 3 above confirms it. The NIT sentence was dropped rather than reworded, to keep the docs change to one line. The SUGGESTION was **not** applied: "parsed and successfully interpreted" is wrong for a different reason — `keep_alive()` fires at the top of `process_lizard()`, before parsing — which predates this change and is out of scope for a watchdog bugfix. Worth a separate docs pass.

</details>

## One behaviour note

- Behaviour change for anyone relying on the old behaviour: a setup whose only heartbeat was peer traffic will now trip its own safety rules until the host, or an explicit `core.keep_alive()`, starts arriving. That is the fix working, but it is a visible change on such a setup.
