### PR TITLE
Stop the idle timer while BLE pairing waits for the user's PIN

### DIFF
--- a/main/utils/ble_command.cpp
+++ b/main/utils/ble_command.cpp
@@ -265,6 +265,10 @@ static int on_gap_event(struct ble_gap_event *event, void * /* arg */) {
         return 0;
 
     case BLE_GAP_EVENT_PASSKEY_ACTION: {
+        if (idle_timer) {
+            xTimerStop(idle_timer, 0);
+        }
+
         if (deactivated) {
             struct ble_sm_io pk = {};
             pk.action = event->passkey.params.action;


### PR DESCRIPTION
### Motivation

LE Secure Connections pairing with an active PIN can fail when PIN entry takes longer than the app-idle timeout (#282): the central reaches the PIN prompt, the link drops, and the pending security procedure reports `enc_change` status 7 (`BLE_HS_ENOTCONN`).

The cause is the app-idle timer, not the security manager. `idle_timer` starts on `BLE_GAP_EVENT_CONNECT` and `on_idle_timeout` terminates the connection whenever `app_active` is false — and `app_active` is set only *after* the authentication check in `on_chr_access`, so the rejected first write leaves it false for the whole pairing phase. Passkey Entry needs a person to read the PIN off UART and type it into the central, which routinely takes longer than `IDLE_TIMEOUT_MS`. The timer fires mid-pairing, the local terminate breaks the link, and the SM procedure then completes with `BLE_HS_ENOTCONN` — the status in the report. That also explains why `bt.deactivate_pin()` works: there the first write is accepted, `app_active` becomes true, and the timer is stopped before it can fire.

### Implementation

Stop the idle timer when the passkey action fires. The `ENC_CHANGE` success branch already re-arms it with `xTimerReset`, which starts a dormant FreeRTOS timer, so a client that finishes pairing still gets a fresh 15 s to send its first command. A central that connects and stalls *before* pairing is still kicked at 15 s, and if pairing never completes NimBLE's own 30 s `BLE_SM_TIMEOUT_MS` raises an `ENC_CHANGE` failure that the existing error branch terminates. So this change does not remove the idle guard for pre-pairing or post-authentication clients; it only exempts the pairing window.

Bench-verified on an ESP32-S3 against a BlueZ 5.72 central driving `bluetoothctl`'s agent, passkey entered 20 s after pairing starts, bonds cleared on both peers and the image digest-pinned before every run. Before the change the link dies at connect + 15.1 s — disconnect reason 534, local host termination — with the PIN prompt still open, and the central reports `Failed to pair`. After it, `BLE: authenticated` arrives at connect + 24.2 s and the central reports `Pairing successful` (again at a 22 s delay, authenticated at + 26.4 s). Writing a Lizard command over BLE after pairing keeps the connection up across a 140 s capture, while an idle client is still dropped 15.0 s after authenticating. Instrumented, `ble_sm_inject_io` returns 0 with action `BLE_SM_IOACT_DISP`, so the injection race raised in the issue is not implicated here.

One part of the report is not explained by this change: `bluetoothctl` prompted for the PIN normally, so the missing dialog seen on Android and macOS may be a separate central-side or stale-bond problem. Leaving #282 open for that.
