### PR TITLE
Catch every exception while loading the startup script

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -467,8 +467,10 @@ void app_main() {
     try {
         Storage::init();
         process_lizard(Storage::startup.c_str());
-    } catch (const std::runtime_error &e) {
+    } catch (const std::exception &e) {
         echo("error while loading startup script: %s", e.what());
+    } catch (...) {
+        echo("error while loading startup script: unknown exception");
     }
 
     bus_backup::save_if_present();


### PR DESCRIPTION
### Motivation

Fixes #288.

`app_main` only caught `std::runtime_error` around `Storage::init()` and `process_lizard(startup)`. A `std::bad_alloc` thrown while the startup statements were executed escaped, terminated the main task and left the core in a boot loop with the console never serviced, so `!-`/`!.` could not recover it (observed on the F30 core with a 154-line startup).

### Implementation

The catch now covers `std::exception` and a catch-all. Loading stops at the failing statement, the modules created so far stay, one error line names the exception, and the core continues to `Ready.` so the startup can be fixed over the console. This matches the existing behaviour for a `std::runtime_error` from a failing module constructor (#246).

Tested on a bench ESP32-S3: normal startup boots to `Ready.` as before; a local build that throws `std::bad_alloc` after loading the startup prints `error while loading startup script: std::bad_alloc` and reaches `Ready.` with a working console.

### Progress

- [x] The implementation is complete.
- [x] Tested on hardware (or is not necessary).
- [x] Documentation has been updated (or is not necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
