### PR TITLE
Guard Serial reads and writes against a deleted UART driver

### DIFF
--- a/main/modules/serial.cpp
+++ b/main/modules/serial.cpp
@@ -80,6 +80,9 @@ void Serial::reinitialize_after_flash() const {
 }
 
 size_t Serial::write(const uint8_t byte) const {
+    if (!uart_is_driver_installed(this->uart_num)) {
+        return 0;
+    }
     const char send = byte;
     uart_write_bytes(this->uart_num, &send, 1);
     return 1;
@@ -90,6 +93,9 @@ void Serial::write_checked_line(const char *message) const {
 }
 
 void Serial::write_checked_line(const char *message, const int length) const {
+    if (!uart_is_driver_installed(this->uart_num)) {
+        return;
+    }
     static char checksum_buffer[16];
     uint8_t checksum = 0;
     int start = 0;
@@ -120,16 +126,25 @@ bool Serial::has_buffered_lines() const {
 }
 
 void Serial::flush() const {
+    if (!uart_is_driver_installed(this->uart_num)) {
+        return;
+    }
     uart_flush(this->uart_num);
 }
 
 int Serial::read(uint32_t timeout) const {
+    if (!uart_is_driver_installed(this->uart_num)) {
+        return -1;
+    }
     uint8_t data = 0;
     const int length = uart_read_bytes(this->uart_num, &data, 1, timeout);
     return length > 0 ? data : -1;
 }
 
 int Serial::read_line(char *buffer, size_t buffer_len) const {
+    if (!uart_is_driver_installed(this->uart_num)) {
+        return 0;
+    }
     int pos = uart_pattern_pop_pos(this->uart_num);
     if (pos >= static_cast<int>(buffer_len)) {
         if (this->available() <= pos) {


### PR DESCRIPTION
### Motivation

Closes #259.

#261 guarded `Serial::has_buffered_lines()`, which silenced the ~1 kHz receive-side flood. A coordinator `SerialBus` still writes through `Serial::write_checked_line()` on every poll, so after the driver is gone (`Expander.disconnect()` on the same `Serial`) the log fills with `uart_write_bytes(1455): uart driver error` twice per poll, every 250 ms, until reboot.

### Implementation

`Serial::write()`, `write_checked_line()`, `flush()`, `read()` and `read_line()` get the same `uart_is_driver_installed()` short-circuit that `available()` and `has_buffered_lines()` already have. Nothing changes while the driver is installed. The explicit teardown of the bus communication task mentioned in the issue is left as is: the coordinator keeps polling and reports a poll timeout every 250 ms, but no longer touches the deleted driver.

Reproduced and verified on a bench ESP32-S3: `s = Serial(4, 5, 115200, 1)`, `bus = SerialBus(s, 1)`, `bus.make_coordinator(2)`, `p = Expander(s)`, `p.disconnect()`. Over the following 14 s, main logged 110 `uart driver error` lines, this branch logged none; the poll timeout warnings continue unchanged on both. Binary size on esp32s3 is unchanged.

### Progress

- [x] The implementation is complete.
- [x] Tested on hardware (or is not necessary).
- [x] Documentation has been updated (or is not necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
