### PR TITLE
Derive the RoboClaw read timeout from the baud rate

### DIFF
--- a/main/modules/roboclaw.cpp
+++ b/main/modules/roboclaw.cpp
@@ -22,8 +22,20 @@ const std::map<std::string, Variable_ptr> RoboClaw::get_defaults() {
 }
 
 RoboClaw::RoboClaw(const std::string name, const ConstSerial_ptr serial, const uint8_t address)
-    : Module(name), address(address), serial(serial) {
+    : Module(name), timeout(RoboClaw::read_timeout(serial->baud_rate)), address(address), serial(serial) {
     this->properties = RoboClaw::get_defaults();
+}
+
+uint32_t RoboClaw::read_timeout(const long baud_rate) {
+    // The timeout for the first reply byte has to cover a whole exchange: the UART driver only releases a short
+    // reply after its RX idle timeout of 10 character times, and every retry flushes the FIFO, so a reply that is
+    // still waiting for that idle time is lost instead of being picked up by the next attempt. The longest exchange
+    // is 19 characters (8-byte command + ACK, or 2-byte request + 7-byte encoder reply, plus the idle time);
+    // on top of that the RoboClaw needs a few milliseconds to answer.
+    const uint32_t exchange_characters = 19;
+    const uint32_t processing_ms = 10;
+    const uint32_t exchange_ms = (exchange_characters * 10 * 1000 + baud_rate - 1) / baud_rate;
+    return pdMS_TO_TICKS(exchange_ms + processing_ms);
 }
 
 void RoboClaw::step() {

--- a/main/modules/roboclaw.h
+++ b/main/modules/roboclaw.h
@@ -14,10 +14,13 @@ using RoboClaw_ptr = std::shared_ptr<RoboClaw>;
 
 class RoboClaw : public Module {
     uint16_t crc;
-    const uint32_t timeout = 5; // [ticks]
+    // Per-byte read timeout [ticks], derived from the baud rate (see read_timeout()).
+    const uint32_t timeout;
     const uint8_t address;
     const ConstSerial_ptr serial;
     unsigned long int last_temp_reading = 0;
+
+    static uint32_t read_timeout(const long baud_rate);
 
     enum {
         M1FORWARD = 0,


### PR DESCRIPTION
### Motivation

On the Walze W2 (Plexus ESP32-S3, `USB Roboclaw 2x60a v4.2.8`, 38400 baud, Lizard v0.14.1) every encoder read failed with `could not read motor position`, the main loop stretched to ~77 ms, and `wheels.speed()` failed after all retries most of the time. Raw `serial.send`/`serial.read` against the same controller returned every reply with a valid CRC, which ruled out wiring, level shifter, baud rate and address: the RoboClaw answers, the module just does not wait long enough.

The module waited 5 ticks (5 ms at `CONFIG_FREERTOS_HZ=1000`) for each reply byte. That is less than one request/response exchange takes at 38400 baud: the ESP-IDF UART driver only moves a short reply from the FIFO into the ring buffer after its RX idle timeout of 10 character times (~2.6 ms), so an encoder read needs request (0.5 ms) + reply (1.8 ms) + idle time (2.6 ms) ≈ 5 ms before `uart_read_bytes` sees the first byte, plus whatever the RoboClaw itself takes. The retries do not rescue this: `read_n` starts every attempt with `uart_flush()`, which also resets the RX FIFO and thereby discards the reply that is just arriving. A RoboClaw whose response latency falls into a narrow band therefore fails deterministically, while writes (no flush) only succeed when the late `0xFF` of a previous attempt lands in the next window. W1 runs the same script with the old timeout and drives, so its controller apparently sits on the other side of that band.

### Implementation

The timeout is no longer a fixed 5 ticks but computed once in the constructor from the `Serial` module's baud rate: 19 character times for the longest exchange the module performs (an 8-byte command plus its ACK, or a 2-byte request plus the 7-byte encoder reply, plus the driver's 10 character idle time), plus 10 ms for the RoboClaw's own processing. That gives 15 ms at 38400 baud, 12 ms at 115200, 30 ms at 9600 and 90 ms at 2400. The retry logic and the flush stay as they are.

Trade-off: when no RoboClaw answers at all (e-stop cutting its supply, cable off), a failing read at 38400 baud now blocks 45 ms per motor instead of 15 ms.

Not changed here, worth a follow-up: the flush at the start of each retry is what turns a late reply into a lost one. Either flush only before the first attempt or drop stale bytes by CRC instead of by timing.

### Progress

- [x] The implementation is complete.
- [ ] Tested on hardware: a fixed 25-tick timeout was verified on the W2 Plexus with the same startup script (no read errors, loop back at ~15 ms, `speed`, `zero` and the temperature read all work). The baud-rate-derived value (15 ms at 38400 baud) is built but not flashed yet, the robot went offline before I could. Will be done as soon as it is back.
- [x] Documentation has been updated (or is not necessary).

[※](https://zauberzeug.github.io/colophon/#m=claude-fable-5-1&t=Diagnosis%2C%20measurements%20on%20the%20W2%20Plexus%20and%20wording%20by%20the%20model%3B%20the%20direction%20and%20the%20approval%20from%20Falko.&d=2026-09-11&a=claude-code "claude-fable-5-1: Diagnosis, measurements on the W2 Plexus and wording by the model; the direction and the approval from Falko.")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
